### PR TITLE
feat(requirements) - add django rest framework as dependency

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,4 +16,4 @@ django-allauth==0.41.0  # https://github.com/pennersr/django-allauth
 django-crispy-forms==1.9.0  # https://github.com/django-crispy-forms/django-crispy-forms
 django-redis==4.11.0  # https://github.com/niwinz/django-redis
 django-storages==1.9.1 # For Storing Static Files in AWS
-
+djangorestframework==3.11.0  # https://github.com/encode/django-rest-framework


### PR DESCRIPTION
Creating a separate PR for this since there might be other tasks/issues which are dependent on drf being installed. There is also code on master which uses this.
If I am missing something here and drf is already getting installed, please feel free to close this PR.
https://github.com/coronasafe/care/blob/master/care/users/api/views.py