### PR TITLE
refactors serializers and viewsets

### DIFF
--- a/care/facility/api/serializers/__init__.py
+++ b/care/facility/api/serializers/__init__.py
@@ -1,0 +1,1 @@
+TIMESTAMP_FIELDS = ('created_date', 'modified_date', 'deleted',)

--- a/care/facility/api/serializers/ambulance.py
+++ b/care/facility/api/serializers/ambulance.py
@@ -1,40 +1,8 @@
-from django.contrib.auth import get_user_model
 from django.db import transaction
-from drf_extra_fields.geo_fields import PointField
 from rest_framework import serializers
 
-from care.facility.models import FACILITY_TYPES, AmbulanceDriver
-from care.facility.models import Facility, Ambulance
-from config.serializers import ChoiceField
-
-User = get_user_model()
-
-TIMESTAMP_FIELDS = ('created_date', 'modified_date', 'deleted',)
-
-
-class FacilitySerializer(serializers.ModelSerializer):
-    """Serializer for facility.models.Facility."""
-
-    district = ChoiceField(choices=User.DISTRICT_CHOICES)
-    facility_type = ChoiceField(choices=FACILITY_TYPES)
-    # A valid location => {
-    #     "latitude": 49.8782482189424,
-    #     "longitude": 24.452545489
-    # }
-    location = PointField(required=False)
-
-    class Meta:
-        model = Facility
-        fields = [
-            "id",
-            "name",
-            "district",
-            "facility_type",
-            "address",
-            "location",
-            "oxygen_capacity",
-            "phone_number",
-        ]
+from care.facility.api.serializers import TIMESTAMP_FIELDS
+from care.facility.models import Ambulance, AmbulanceDriver
 
 
 class AmbulanceDriverSerializer(serializers.ModelSerializer):

--- a/care/facility/api/serializers/facility.py
+++ b/care/facility/api/serializers/facility.py
@@ -1,0 +1,33 @@
+from django.contrib.auth import get_user_model
+from drf_extra_fields.geo_fields import PointField
+from rest_framework import serializers
+
+from care.facility.models import FACILITY_TYPES, Facility
+from config.serializers import ChoiceField
+
+User = get_user_model()
+
+
+class FacilitySerializer(serializers.ModelSerializer):
+    """Serializer for facility.models.Facility."""
+
+    district = ChoiceField(choices=User.DISTRICT_CHOICES)
+    facility_type = ChoiceField(choices=FACILITY_TYPES)
+    # A valid location => {
+    #     "latitude": 49.8782482189424,
+    #     "longitude": 24.452545489
+    # }
+    location = PointField(required=False)
+
+    class Meta:
+        model = Facility
+        fields = [
+            "id",
+            "name",
+            "district",
+            "facility_type",
+            "address",
+            "location",
+            "oxygen_capacity",
+            "phone_number",
+        ]

--- a/care/facility/api/viewsets/__init__.py
+++ b/care/facility/api/viewsets/__init__.py
@@ -1,0 +1,10 @@
+from rest_framework.mixins import CreateModelMixin, RetrieveModelMixin, UpdateModelMixin, DestroyModelMixin
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.viewsets import GenericViewSet
+
+
+class FacilityBaseViewset(CreateModelMixin, RetrieveModelMixin,
+                          UpdateModelMixin, DestroyModelMixin, GenericViewSet):
+    """Base class for all endpoints related to Faclity model."""
+
+    permission_classes = (IsAuthenticated,)

--- a/care/facility/api/viewsets/ambulance.py
+++ b/care/facility/api/viewsets/ambulance.py
@@ -1,44 +1,12 @@
 from django_filters import rest_framework as filters
 from rest_framework import status, serializers
 from rest_framework.decorators import action
-from rest_framework.mixins import (
-    ListModelMixin,
-    RetrieveModelMixin,
-    CreateModelMixin,
-    UpdateModelMixin,
-    DestroyModelMixin)
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.mixins import ListModelMixin
 from rest_framework.response import Response
-from rest_framework.viewsets import GenericViewSet
 
-from care.facility.api.serializers import FacilitySerializer, AmbulanceSerializer, AmbulanceDriverSerializer
-from care.facility.models import Facility, Ambulance
-
-
-class FacilityBaseViewset(CreateModelMixin, RetrieveModelMixin,
-                          UpdateModelMixin, DestroyModelMixin, GenericViewSet):
-    """Base class for all endpoints related to Faclity model."""
-
-    permission_classes = (IsAuthenticated,)
-
-
-class FacilityViewSet(FacilityBaseViewset, ListModelMixin):
-    """Viewset for facility CRUD operations."""
-
-    serializer_class = FacilitySerializer
-    queryset = Facility.objects.filter(is_active=True)
-
-    def get_queryset(self):
-        user = self.request.user
-        if user.is_superuser:
-            return self.queryset
-        return self.queryset.filter(created_by=user)
-
-    def perform_create(self, serializer):
-        serializer.save(created_by=self.request.user)
-
-    def perform_update(self, serializer):
-        serializer.save(created_by=self.request.user)
+from care.facility.api.serializers.ambulance import AmbulanceSerializer, AmbulanceDriverSerializer
+from care.facility.api.viewsets import FacilityBaseViewset
+from care.facility.models import Ambulance
 
 
 class AmbulanceFilterSet(filters.FilterSet):

--- a/care/facility/api/viewsets/facility.py
+++ b/care/facility/api/viewsets/facility.py
@@ -1,0 +1,24 @@
+from rest_framework.mixins import ListModelMixin
+
+from care.facility.api.serializers.facility import FacilitySerializer
+from care.facility.api.viewsets import FacilityBaseViewset
+from care.facility.models import Facility
+
+
+class FacilityViewSet(FacilityBaseViewset, ListModelMixin):
+    """Viewset for facility CRUD operations."""
+
+    serializer_class = FacilitySerializer
+    queryset = Facility.objects.filter(is_active=True)
+
+    def get_queryset(self):
+        user = self.request.user
+        if user.is_superuser:
+            return self.queryset
+        return self.queryset.filter(created_by=user)
+
+    def perform_create(self, serializer):
+        serializer.save(created_by=self.request.user)
+
+    def perform_update(self, serializer):
+        serializer.save(created_by=self.request.user)

--- a/config/api_router.py
+++ b/config/api_router.py
@@ -1,7 +1,8 @@
 from django.conf import settings
 from rest_framework.routers import DefaultRouter, SimpleRouter
 
-from care.facility.api.views import FacilityViewSet, AmbulanceViewSet
+from care.facility.api.viewsets.ambulance import AmbulanceViewSet
+from care.facility.api.viewsets.facility import FacilityViewSet
 from care.users.api.views import UserViewSet
 
 if settings.DEBUG:


### PR DESCRIPTION
Serializers and viewsets are growing, hence we need to move them to single files rather than having one single large file

Related Issue: https://github.com/coronasafe/care/issues/65