### PR TITLE
Disable browser suggestions in user signup form

### DIFF
--- a/care/templates/users/signup.html
+++ b/care/templates/users/signup.html
@@ -16,7 +16,7 @@ Already have an account? Then please <a href="{% url 'users:signin' %}" class="c
 <div class="max-w-md mt-4">
     <form class="signup" id="signup_form" method="post" action="">
         {% csrf_token %}
-        {{ form|crispy }}
+        {% crispy form %}
         {% if redirect_field_value %}
         <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
         {% endif %}

--- a/care/users/forms.py
+++ b/care/users/forms.py
@@ -67,6 +67,7 @@ class CustomSignupForm(forms.UserCreationForm):
     def __init__(self, *args, **kwargs):
         super(CustomSignupForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
+        self.helper.form_tag = False
         self.helper.layout = Layout(
             Field('username', autocomplete=self.autocomplete_value),
             Field('first_name'),

--- a/care/users/forms.py
+++ b/care/users/forms.py
@@ -1,8 +1,8 @@
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import Field, Layout
 from django.contrib.auth import forms, get_user_model
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
-from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Layout, Field
 
 User = get_user_model()
 
@@ -32,6 +32,11 @@ class UserCreationForm(forms.UserCreationForm):
 
 
 class CustomSignupForm(forms.UserCreationForm):
+
+    # Browsers seem to ignore autocomplete="off" attribute.
+    # Hence, setting value to a random string as suggested in https://stackoverflow.com/a/49053259
+    autocomplete_value = "turnOff"
+
     class Meta:
         model = User
         fields = (
@@ -63,17 +68,17 @@ class CustomSignupForm(forms.UserCreationForm):
         super(CustomSignupForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.layout = Layout(
-            Field('username', placeholder="Desired Username", css_class=""),
-            Field('first_name', placeholder="Your first name", css_class=""),
-            Field('last_name', placeholder="Your last name", css_class=""),
-            Field('email', placeholder="Your Email Address", css_class=""),
-            Field('district', css_class=""),
-            Field('phone_number', placeholder="Your 10 Digit Mobile Number", css_class="'"),
-            Field('gender', css_class=""),
-            Field('age', placeholder="Your age in numbers", css_class=""),
-            Field('skill', css_class=""),
-            Field('password1', placeholder="Password Confirmation", css_class=""),
-            Field('password2', placeholder="Password", css_class=""),
+            Field('username', autocomplete=self.autocomplete_value),
+            Field('first_name'),
+            Field('last_name'),
+            Field('email', autocomplete=self.autocomplete_value),
+            Field('district', autocomplete=self.autocomplete_value),
+            Field('phone_number'),
+            Field('gender', autocomplete=self.autocomplete_value),
+            Field('age', autocomplete=self.autocomplete_value),
+            Field('skill', autocomplete=self.autocomplete_value),
+            Field('password1', autocomplete=self.autocomplete_value),
+            Field('password2', autocomplete=self.autocomplete_value),
         )
 
 


### PR DESCRIPTION

Fixes #48 : 
1. Disable suggestion for input fields (except the first name, last name, and phone number)
2. Use Crispyform helper to render form fields. 
