### PR TITLE
fix created_by field population in facility bulk_upsert

### DIFF
--- a/care/facility/api/serializers/facility.py
+++ b/care/facility/api/serializers/facility.py
@@ -52,7 +52,8 @@ class FacilityUpsertSerializer(serializers.ModelSerializer):
             "location",
             "oxygen_capacity",
             "phone_number",
-            "capacity"
+            "capacity",
+            "created_by"
         ]
 
     def validate_name(self, value):

--- a/care/facility/api/viewsets/facility.py
+++ b/care/facility/api/viewsets/facility.py
@@ -64,6 +64,10 @@ class FacilityViewSet(FacilityBaseViewset, ListModelMixin):
         serializer = FacilityUpsertSerializer(data=data, many=True)
         serializer.is_valid(raise_exception=True)
 
+        validated_data = serializer.validated_data
+        for d in validated_data:
+            d['created_by'] = request.user
+
         with transaction.atomic():
             serializer.create(serializer.validated_data)
         return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
In the previous PR, the create_by field was not populated, hence the person who created it could not see the items. This fixes the issue.