### PR TITLE
Add LocalBody model to Django Admin

### DIFF
--- a/care/users/admin.py
+++ b/care/users/admin.py
@@ -3,7 +3,7 @@ from django.contrib.auth import admin as auth_admin
 from django.contrib.auth import get_user_model
 
 from care.users.forms import UserChangeForm, UserCreationForm
-from care.users.models import Skill
+from care.users.models import LocalBody, Skill
 
 User = get_user_model()
 
@@ -19,3 +19,5 @@ class UserAdmin(auth_admin.UserAdmin):
 
 
 admin.site.register(Skill)
+
+admin.site.register(LocalBody)


### PR DESCRIPTION
If there is no particular reason why this model is not available in Django Admin, this change would be useful for debugging and adding data using Django Admin.