### PR TITLE
Comment out Axes app to suppress warnings

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -82,7 +82,7 @@ THIRD_PARTY_APPS = [
     "drf_extra_fields",
     "location_field.apps.DefaultConfig",
     "django_filters",
-    "axes",
+    # "axes", Commented out to suppress warnings - Add this back when Axes is needed.
 ]
 
 LOCAL_APPS = ["care.users.apps.UsersConfig", "care.facility"]


### PR DESCRIPTION
Since Axes was removed temporarily in 1cf1123 , commenting out this line suppresses the warnings:

```
?: (axes.W002) You do not have 'axes.middleware.AxesMiddleware' in your settings.MIDDLEWARE.
?: (axes.W003) You do not have 'axes.backends.AxesBackend' or a subclass in your settings.AUTHENTICATION_BACKENDS.
	HINT: AxesModelBackend was renamed to AxesBackend in django-axes version 5.0.
```
Once Axes is integrated back in, this line can be uncommented to enable the app.