### PR TITLE
Add tests for the users application

### DIFF
--- a/care/users/tests/test_forms.py
+++ b/care/users/tests/test_forms.py
@@ -1,0 +1,105 @@
+from django.test import TestCase
+
+from care.users.forms import UserCreationForm
+
+
+class UserCreationFormTestCase(TestCase):
+    """Test user creation form"""
+
+    def test_user_type_choices_fails_for_wrong_values(self):
+        """Try putting values apart from the allowed choices"""
+        field = "user_type"
+
+        # Test invalid integer choice
+        form = UserCreationForm(data={field: 1})
+        self.assertEqual(form.is_valid(), False)
+        self.assertEqual(form.has_error(field, code="invalid"), True)
+        # Test invalid type of choice
+        form = UserCreationForm(data={field: "1"})
+        self.assertEqual(form.is_valid(), False)
+        self.assertEqual(form.has_error(field, code="invalid"), True)
+
+    def test_user_type_choices_succeds_for_correct_values(self):
+        """Try putting in the expected values"""
+        field = "user_type"
+
+        # Test invalid integer choice
+        form = UserCreationForm(data={field: 5})
+        self.assertEqual(form.has_error(field, code="invalid"), False)
+
+    def test_district_type_choices_fails_for_wrong_values(self):
+        """Try putting values apart from the allowed choices"""
+        field = "user_type"
+
+        # Test invalid integer choice
+        form = UserCreationForm(data={field: 0})
+        self.assertEqual(form.is_valid(), False)
+        self.assertEqual(form.has_error(field, code="invalid"), True)
+        # Test invalid type of choice
+        form = UserCreationForm(data={field: "0"})
+        self.assertEqual(form.is_valid(), False)
+        self.assertEqual(form.has_error(field, code="invalid"), True)
+
+    def test_district_type_choices_succeds_for_correct_values(self):
+        """Try putting in the expected values"""
+        field = "user_type"
+
+        # Test invalid integer choice
+        form = UserCreationForm(data={field: 5})
+        self.assertEqual(form.has_error(field, code="invalid"), False)
+
+    def test_gender_type_choices_fails_for_wrong_values(self):
+        """Try putting values apart from the allowed choices"""
+        field = "gender"
+
+        # Test invalid integer choice
+        form = UserCreationForm(data={field: 0})
+        self.assertEqual(form.is_valid(), False)
+        self.assertEqual(form.has_error(field, code="invalid"), True)
+        # Test invalid type of choice
+        form = UserCreationForm(data={field: "0"})
+        self.assertEqual(form.is_valid(), False)
+        self.assertEqual(form.has_error(field, code="invalid"), True)
+
+    def test_gendere_type_choices_succeds_for_correct_values(self):
+        """Try putting in the expected values"""
+        field = "gender"
+
+        # Test valid integer choice
+        form = UserCreationForm(data={field: 1})
+        self.assertEqual(form.has_error(field, code="invalid"), False)
+
+    def test_phone_number_validator_fails_wrong_numbers(self):
+        """Try putting values apart from the allowed choices"""
+        field = "phone_number"
+
+        # Test invalid length
+        form = UserCreationForm(data={field: 123456789})
+        self.assertEqual(form.is_valid(), False)
+        self.assertEqual(form.has_error(field, code="invalid"), True)
+        # Test dummy mobile numbers
+        form = UserCreationForm(data={field: 1234567890})
+        self.assertEqual(form.is_valid(), False)
+        self.assertEqual(form.has_error(field, code="invalid"), True)
+        # Test dummy landline numbers
+        form = UserCreationForm(data={field: 1234567890})
+        self.assertEqual(form.is_valid(), False)
+        self.assertEqual(form.has_error(field, code="invalid"), True)
+
+    def test_min_value_age(self):
+        """Test a value for age less than 1"""
+        field = "age"
+        form = UserCreationForm(data={field: 0})
+        self.assertEqual(form.has_error(field, code="invalid"), True)
+
+    def test_max_value_age(self):
+        """Test a value for age greater than 100"""
+        field = "age"
+        form = UserCreationForm(data={field: 101})
+        self.assertEqual(form.has_error(field, code="invalid"), True)
+
+    def test_valid_value_age(self):
+        """Try putting in the expected values"""
+        field = "age"
+        form = UserCreationForm(data={field: 10})
+        self.assertEqual(form.has_error(field, code="invalid"), False)

--- a/care/users/tests/test_models.py
+++ b/care/users/tests/test_models.py
@@ -1,0 +1,119 @@
+from django.test import TestCase
+
+from care.users.models import District, LocalBody, Skill, State, User
+
+
+class SkillModelTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        """
+        Initialise test data for all other methods
+        """
+        cls.skill = Skill.objects.create(name="ghatak", description="corona virus specialist")
+
+    def test_max_length_name(self):
+        """Test max length for name is 255"""
+        skill = self.skill
+        max_length = skill._meta.get_field("name").max_length
+        self.assertEqual(max_length, 255)
+
+    def test_object_name(self):
+        """Test that the name is returned while printing the object"""
+        skill = self.skill
+        self.assertEqual(str(skill), skill.name)
+
+
+class StateModelTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        """
+        Initialise test data for all other methods
+        """
+        cls.state = State.objects.create(name="kerala")
+
+    def test_max_length_name(self):
+        """Test max length for name is 255"""
+        state = self.state
+        max_length = state._meta.get_field("name").max_length
+        self.assertEqual(max_length, 255)
+
+    def test_object_name(self):
+        """Test that the correct format is returned while printing the object"""
+        state = self.state
+        self.assertEqual(str(state), f"State: {self.state.name}")
+
+
+class DistrictModelTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        """
+        Initialise test data for all other methods
+        """
+        state = State.objects.create(name="uttar pradesh")
+        cls.district = District.objects.create(state=state, name="name")
+
+    def test_max_length_name(self):
+        """Test max length for name is 255"""
+        district = self.district
+        max_length = district._meta.get_field("name").max_length
+        self.assertEqual(max_length, 255)
+
+    def test_object_name(self):
+        """Test that the correct format is returned while printing the object"""
+        district = self.district
+        self.assertEqual(
+            str(district), f"District: {self.district.name} - {self.district.state.name}",
+        )
+
+
+class LocalBodyModelTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        """
+        Initialise test data for all other methods
+        """
+        state = State.objects.create(name="bihar")
+        district = District.objects.create(state=state, name="nam")
+        cls.local_body = LocalBody.objects.create(district=district, name="blabla", body_type=1)
+
+    def test_max_length_name(self):
+        """Test max length for name is 255"""
+        local_body = self.local_body
+        max_length = local_body._meta.get_field("name").max_length
+        self.assertEqual(max_length, 255)
+
+    def test_object_name(self):
+        """Test that the correct format is returned while printing the object"""
+        local_body = self.local_body
+        self.assertEqual(
+            str(local_body),
+            f"LocalBody: {self.local_body.name} ({self.local_body.body_type}) / {self.local_body.district}",
+        )
+
+
+class UserModelTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        """
+        Initialize test data for all other methods.
+        """
+        cls.user = User.objects.create_user(
+            username="test", user_type=5, district=1, phone_number=8_888_888_888, gender=1, age=21,
+        )
+
+    def test_max_length_phone_number(self):
+        """Test maximum length for phone number is 14"""
+        user = self.user
+        max_length = user._meta.get_field("phone_number").max_length
+        self.assertEqual(max_length, 14)
+
+    def test_get_absolute_url(self):
+        """Test whether model returns correct url for detail view of a user"""
+        # This is part of django-cookie cutter and isn't used right now
+        # Reference link for the slack thread:
+        # https://rebuildearth.slack.com/archives/C010GQBMFJ9/p1585218577029200?thread_ts=1585218248.028800&cid=C010GQBMFJ9
+        pass
+        # user = self.user
+        # url_absolute = reverse('users:detail', kwargs={'username': user.username})
+        # response = self.client.get(url_absolute)
+        # self.assertEqual(response.status_code, 200)

--- a/care/users/tests/test_views.py
+++ b/care/users/tests/test_views.py
@@ -1,0 +1,114 @@
+from django.test import TestCase
+from django.urls import reverse
+
+
+class HomeView(TestCase):
+    """
+    For HomeView, test
+        - url is accessible by name
+        - correct template is used
+    """
+
+    def test_url_name_for_home_view(self):
+        """Test whether home page is accessible"""
+        url_home = reverse("home")
+        response = self.client.get(url_home)
+        self.assertEqual(response.status_code, 200)
+
+    # This is not required, moving to a react frontend
+
+    # def test_correct_template_used_for_home_view(self):
+    #     """Test whether correct template is used"""
+    #     url_home = reverse("home")
+    #     response = self.client.get(url_home)
+    #     self.assertTemplateUsed(response, template_name="pages/home.html")
+
+
+class SignupViewTest(TestCase):
+    """
+    For SignupView, test
+        - url name is accessible for
+            - volunteer
+            - doctor
+            - staff
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(SignupViewTest, self).__init__(*args, **kwargs)
+        self.username = "doctor"
+        self.user_type = 5
+        self.first_name = "Jach"
+        self.last_name = "Karta"
+        self.email = "a@a.com"
+        self.district = 1
+        self.phone_number = 8_888_888_888
+        self.gender = 2
+        self.age = 22
+        self.password = "user123#"
+
+    @classmethod
+    def setUpTestData(cls):
+        """
+        Initialize the form data
+            - create a user
+        """
+        cls.data = {
+            "username": "tester",
+            "first_name": "Jach",
+            "last_name": "Karta",
+            "email": "a@a.com",
+            "district": 1,
+            "phone_number": 8_888_888_888,
+            "gender": 1,
+            "age": 22,
+            "password1": "user123#",
+            "password2": "user123#",
+        }
+
+    def test_url_name_for_signin_view_volunteer(self):
+        """Test whether home page is accessible for volunteer"""
+        url_signup = reverse("users:signup-volunteer")
+        response = self.client.get(url_signup)
+        self.assertEqual(response.status_code, 200)
+
+    def test_url_name_for_signin_view_doctor(self):
+        """Test whether home page is accessible for doctor"""
+        url_signup = reverse("users:signup-doctor")
+        response = self.client.get(url_signup)
+        self.assertEqual(response.status_code, 200)
+
+    def test_url_name_for_signin_view_staff(self):
+        """Test whether home page is accessible for staff"""
+        url_signup = reverse("users:signup-staff")
+        response = self.client.get(url_signup)
+        self.assertEqual(response.status_code, 200)
+
+    # This is not required, moving to a react frontend
+
+    # def test_correct_template_used_for_signin_view(self):
+    #     """Test whether correct template is used"""
+    #     url_signup = reverse("users:signup-doctor")
+    #     response = self.client.get(url_signup)
+    #     self.assertTemplateUsed(response, template_name="users/signup.html")
+
+    def test_username_integrity(self):
+        """
+        Test invalidation for use of 1 username by more than 1 accounts,\
+        raising of appropriate validation error
+        """
+        url_signup = reverse("users:signup-staff")
+        # create first_user
+        response = self.client.post(url_signup, data=self.data)
+        response = self.client.post(url_signup, data=self.data)
+        # Test invalidation of form
+        form = response.content["form"]
+        self.assertEqual(form.is_valid(), False)
+        # Test if validation error is raised
+        self.assertEqual(form.has_error("duplicate_username", code="invalid"), True)
+
+    def test_redirect_on_successful_registration(self):
+        """Test redirect to home page on successful registration"""
+        data = self.data
+        # change username
+        response = self.client.post(reverse("users:signup-doctor"), data=data)
+        self.assertRedirects(response, expected_url=reverse("home"))


### PR DESCRIPTION
Move all tests to `django` `unittest`
- Some tests that seemed integration tests have now be transformed to unit tests
- Some tests might fail because of the recent changes to the models

The modules used by `pytest` have not yet been deleted for others to view and compare current tests with the present one.
Once this request is ready to merge, we can delete them maybe.
More tests have to be added.
Addresses #175 and #112 #7 