### PR TITLE
Fix facility filters

### DIFF
--- a/care/facility/api/viewsets/facility.py
+++ b/care/facility/api/viewsets/facility.py
@@ -14,16 +14,15 @@ from care.facility.api.serializers.facility import (
 )
 from care.facility.api.serializers.patient import PatientListSerializer
 from care.facility.models import Facility, FacilityCapacity, PatientRegistration
-
 from care.users.models import User
 
 
 class FacilityFilter(filters.FilterSet):
     name = filters.CharFilter(field_name="name", lookup_expr="icontains")
-    district = filters.NumberFilter(field_name="facilitylocalgovtbody__district_id")
-    district_name = filters.CharFilter(field_name="facilitylocalgovtbody__district__name", lookup_expr="icontains")
-    local_body = filters.NumberFilter(field_name="facilitylocalgovtbody__local_body_id")
-    local_body_name = filters.CharFilter(field_name="facilitylocalgovtbody__local_body__name", lookup_expr="icontains")
+    district = filters.NumberFilter(field_name="district__id")
+    district_name = filters.CharFilter(field_name="district__name", lookup_expr="icontains")
+    local_body = filters.NumberFilter(field_name="local_body__id")
+    local_body_name = filters.CharFilter(field_name="local_body__name", lookup_expr="icontains")
 
 
 class FacilityQSPermissions(DRYPermissionFiltersBase):


### PR DESCRIPTION
The facility filters API seemed to be broken (notice the invalid fields):
![capture](https://user-images.githubusercontent.com/22353313/78122667-b4dc3400-742a-11ea-8cf5-6225461559a6.png)

This commit fixes this.
Please check if this does not break how the API is being used by the frontend. (Although it shouldn't because the way it was before did not work)

Related issue: #98 