### PR TITLE
Improve readme and add support for Windows and remove Python3.7 dependencies.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,6 @@ repos:
     hooks:
       - id: black
         args: [--line-length=120, --safe]
-        language_version: python3.7
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     hooks:
       - id: black
         args: [--line-length=120, --safe]
-
+        language_version: python3.7	
   - repo: local
     hooks:
       - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,8 @@ repos:
     hooks:
       - id: black
         args: [--line-length=120, --safe]
-        language_version: python3.7	
+        language_version: python3.7
+
   - repo: local
     hooks:
       - id: flake8

--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,9 @@ You also might have to install PostGIS scripts.
 
     $ sudo apt install postgresql-<version>-postgis-scripts
 
-* Windows users can install PostGIS through Application Stack Builder which is installed along PostgreSQL using standard PostgreSQL installer.
+* Windows users can install
+    - PostGIS through Application Stack Builder which is installed along PostgreSQL using standard PostgreSQL installer.
+    - OSGeo4W from this site_. 
 
 Then follow the steps listed here_.
 
@@ -122,7 +124,7 @@ Pre-Commit is a package manager and tool for running and organising your git hoo
 .. _here: https://cookiecutter-django.readthedocs.io/en/latest/developing-locally.html
 .. _answer: https://stackoverflow.com/a/12670521/4385622
 .. _pre_commit_site: https://pre-commit.com/
-
+.. _site: https://trac.osgeo.org/osgeo4w/
 
 Settings
 --------

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -1,3 +1,5 @@
+import os
+
 from .base import *  # noqa
 from .base import env
 
@@ -49,6 +51,20 @@ INTERNAL_IPS = ["127.0.0.1", "10.0.2.2"]
 # ------------------------------------------------------------------------------
 # https://django-extensions.readthedocs.io/en/latest/installation_instructions.html#configuration
 INSTALLED_APPS += ["django_extensions"]  # noqa F405
+
+# Required for gis on windows platform
+# Make sure to install OSGeo4W from https://trac.osgeo.org/osgeo4w/
+if os.name == "nt":
+    import platform
+
+    OSGEO4W = r"C:\OSGeo4W"
+    if "64" in platform.architecture()[0]:
+        OSGEO4W += "64"
+    assert os.path.isdir(OSGEO4W), "Directory does not exist: " + OSGEO4W
+    os.environ["OSGEO4W_ROOT"] = OSGEO4W
+    os.environ["GDAL_DATA"] = OSGEO4W + r"\share\gdal"
+    os.environ["PROJ_LIB"] = OSGEO4W + r"\share\proj"
+    os.environ["PATH"] = OSGEO4W + r"\bin;" + os.environ["PATH"]
 
 # Your stuff...
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
On Windows, we now just need to install osgeo4w additionally for using gis with Django.

Fixes https://github.com/coronasafe/care/issues/262#issue-593934741