### PR TITLE
pop does not take the default value as a keyword argument

### DIFF
--- a/care/facility/tests/test_patient_api.py
+++ b/care/facility/tests/test_patient_api.py
@@ -24,7 +24,7 @@ class TestPatient(TestBase):
     def get_list_representation(self, patient=None):
 
         if isinstance(patient, dict):
-            medical_history = patient.pop("medical_history", default="[]")
+            medical_history = patient.pop("medical_history", [])
             patient = PatientRegistration(**patient)
             patient.medical_history.set(medical_history)
 


### PR DESCRIPTION
This does not cause an error right now because in the current usage the `if` condition does not evaluate to true. If it did when things change later, this would cause an error.