### PR TITLE
fix migration and change phone number serializer

### DIFF
--- a/care/facility/api/serializers/patient.py
+++ b/care/facility/api/serializers/patient.py
@@ -2,7 +2,6 @@ import datetime
 
 from django.db import transaction
 from django.utils.timezone import make_aware
-from phonenumber_field.serializerfields import PhoneNumberField
 from rest_framework import serializers
 
 from care.facility.api.serializers import TIMESTAMP_FIELDS
@@ -21,6 +20,7 @@ from care.facility.models.patient_base import DISEASE_STATUS_CHOICES, DiseaseSta
 from care.facility.models.patient_consultation import PatientConsultation
 from care.facility.models.patient_tele_consultation import PatientTeleConsultation
 from care.users.api.serializers.lsg import DistrictSerializer, LocalBodySerializer, StateSerializer
+from care.utils.serializer.phonenumber_ispossible_field import PhoneNumberIsPossibleField
 from config.serializers import ChoiceField
 
 
@@ -48,7 +48,7 @@ class PatientDetailSerializer(PatientListSerializer):
             model = PatientTeleConsultation
             fields = "__all__"
 
-    phone_number = PhoneNumberField()
+    phone_number = PhoneNumberIsPossibleField()
     facility = serializers.IntegerField(source="facility_id", allow_null=True, required=False)
     medical_history = serializers.ListSerializer(child=MedicalHistorySerializer(), required=False)
 
@@ -121,7 +121,7 @@ class FacilityPatientStatsHistorySerializer(serializers.ModelSerializer):
 
 class PatientSearchSerializer(serializers.ModelSerializer):
     gender = ChoiceField(choices=GENDER_CHOICES)
-    phone_number = PhoneNumberField()
+    phone_number = PhoneNumberIsPossibleField()
 
     class Meta:
         model = PatientSearch

--- a/care/facility/migrations/0082_populate_patient_search.py
+++ b/care/facility/migrations/0082_populate_patient_search.py
@@ -7,6 +7,7 @@ from django.db import migrations
 def populate_patient_search(apps, *args, **kwargs):
     PatientRegistration = apps.get_model('facility', 'PatientRegistration')
     PatientSearch = apps.get_model('facility', 'PatientSearch')
+    State = apps.get_model('users', 'State')
     if not PatientRegistration:
         # in future if the model is renamed / removed, migration should not throw exception
         return
@@ -21,6 +22,8 @@ def populate_patient_search(apps, *args, **kwargs):
             patient.district = patient.local_body.district
         if patient.district:
             patient.state = patient.district.state
+        if not patient.state:
+            patient.state = State.objects.filter(deleted=False).first()
 
         if patient.patient_search_id is None:
             ps = PatientSearch.objects.create(

--- a/care/facility/migrations/0082_populate_patient_search.py
+++ b/care/facility/migrations/0082_populate_patient_search.py
@@ -23,7 +23,7 @@ def populate_patient_search(apps, *args, **kwargs):
         if patient.district:
             patient.state = patient.district.state
         if not patient.state:
-            patient.state = State.objects.filter(deleted=False).first()
+            patient.state = State.objects.all().first()
 
         if patient.patient_search_id is None:
             ps = PatientSearch.objects.create(

--- a/care/utils/serializer/phonenumber_ispossible_field.py
+++ b/care/utils/serializer/phonenumber_ispossible_field.py
@@ -1,0 +1,18 @@
+import phonenumbers
+from django.utils.translation import gettext_lazy as _
+from phonenumber_field.phonenumber import to_python
+from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
+
+
+class PhoneNumberIsPossibleField(serializers.CharField):
+    default_error_messages = {"invalid": _("Enter a valid phone number.")}
+
+    def to_internal_value(self, data):
+        phone_number = to_python(data)
+        if phone_number and not phonenumbers.is_possible_number(phone_number):
+            # attempting to check if this is a possible Indian number
+            phone_number = to_python(data, region="IN")
+            if phone_number and not phonenumbers.is_possible_number(phone_number):
+                raise ValidationError(self.error_messages["invalid"])
+        return phone_number

--- a/care/utils/serializer/tests/test_phonenumber_ispossible_field.py
+++ b/care/utils/serializer/tests/test_phonenumber_ispossible_field.py
@@ -1,0 +1,27 @@
+from unittest import TestCase
+
+from rest_framework.exceptions import ValidationError
+
+from care.utils.serializer.phonenumber_ispossible_field import PhoneNumberIsPossibleField
+
+
+class TestPhoneNumberIsPossibleField(TestCase):
+    def test_phone_number(self):
+        # map -> input value -> output value
+        # if output value is None, the it is invalid
+
+        test_cases = {
+            "7795937091": "+917795937091",
+            "07795937091": "+917795937091",
+            "+917795937091": "+917795937091",
+            "+1 470-485-8757": "+14704858757",
+            "+18944775567": "+18944775567",
+            "+911234": None,
+        }
+
+        for ip, op in test_cases.items():
+            if op is None:
+                with self.assertRaises(ValidationError):
+                    PhoneNumberIsPossibleField().to_internal_value(ip)
+            else:
+                self.assertEqual(PhoneNumberIsPossibleField().to_internal_value(ip), op)


### PR DESCRIPTION
There are still a few cases where the state is not mapped to the patients, which is causing the migrations to fail. This PR fixes it by mapping the patient to the first state available. Since we are handling only one state now, it should be a problem. 