### PR TITLE
Fixes #501 Added `district_id` filter to the User List View

### DIFF
--- a/care/users/api/viewsets/users.py
+++ b/care/users/api/viewsets/users.py
@@ -39,6 +39,7 @@ class UserFilterSet(filters.FilterSet):
     username = filters.CharFilter(field_name="username", lookup_expr="icontains")
     phone_number = filters.CharFilter(field_name="phone_number", lookup_expr="icontains")
     last_login = filters.DateFromToRangeFilter(field_name="last_login")
+    district_id = filters.NumberFilter(field_name="district_id", lookup_expr="exact")
 
     def get_user_type(
         self,


### PR DESCRIPTION
    Added district_id filter to User List API Viewset
    
    Fixes: https://github.com/coronasafe/care/issues/501
    We can filter the users api by district_id as follows:
    http://127.0.0.1:8000/api/v1/users/?district_id=2
    
    Previous functionality is preserved as-is: leaving out the district ID will
    return all results
    http://127.0.0.1:8000/api/v1/users/
