### PR TITLE
Change offset to page number in paginated apis

### DIFF
--- a/care/facility/api/viewsets/facility.py
+++ b/care/facility/api/viewsets/facility.py
@@ -10,6 +10,7 @@ from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from simple_history.utils import bulk_create_with_history
+from rest_framework.pagination import PageNumberPagination
 
 from care.facility.api.serializers.facility import (
     FacilityBasicInfoSerializer,
@@ -65,6 +66,10 @@ class FacilityQSPermissions(DRYPermissionFiltersBase):
         return queryset
 
 
+class PaginataionOverrideClass(PageNumberPagination):
+    page_size = 14
+
+
 class FacilityViewSet(
     mixins.CreateModelMixin,
     mixins.ListModelMixin,
@@ -84,6 +89,7 @@ class FacilityViewSet(
         filters.DjangoFilterBackend,
     )
     filterset_class = FacilityFilter
+    pagination_class = PaginataionOverrideClass
     lookup_field = "external_id"
 
     FACILITY_CAPACITY_CSV_KEY = "capacity"

--- a/care/facility/api/viewsets/patient_consultation.py
+++ b/care/facility/api/viewsets/patient_consultation.py
@@ -5,11 +5,16 @@ from rest_framework import mixins, status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
+from rest_framework.pagination import PageNumberPagination
 
 from care.facility.api.serializers.patient_consultation import DailyRoundSerializer, PatientConsultationSerializer
 from care.facility.models.patient_consultation import DailyRound, PatientConsultation
 from care.facility.models.patient import PatientRegistration
 from care.users.models import User
+
+
+class PaginataionOverrideClass(PageNumberPagination):
+    page_size = 5
 
 
 class PatientConsultationFilter(filters.FilterSet):
@@ -29,6 +34,7 @@ class PatientConsultationViewSet(
     queryset = PatientConsultation.objects.all().select_related("facility").order_by("-id")
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = PatientConsultationFilter
+    pagination_class = PaginataionOverrideClass
 
     def get_queryset(self):
         if self.request.user.is_superuser:
@@ -61,6 +67,7 @@ class DailyRoundsViewSet(
         DRYPermissions,
     )
     queryset = DailyRound.objects.all().order_by("-id")
+    pagination_class = PaginataionOverrideClass
 
     def get_queryset(self):
         queryset = self.queryset.filter(consultation__external_id=self.kwargs["consultation_external_id"])

--- a/care/facility/api/viewsets/patient_sample.py
+++ b/care/facility/api/viewsets/patient_sample.py
@@ -7,6 +7,7 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.pagination import PageNumberPagination
 
 from care.facility.api.serializers.patient_icmr import PatientICMRSerializer
 from care.facility.api.serializers.patient_sample import (
@@ -41,6 +42,11 @@ class PatientSampleFilterSet(filters.FilterSet):
     patient_name = filters.CharFilter(field_name="patient__name", lookup_expr="icontains")
 
 
+class PaginataionOverrideClass(PageNumberPagination):
+    page_size = 10
+    page_size_query_param = 'page_size'
+
+
 class PatientSampleViewSet(
     mixins.CreateModelMixin,
     mixins.ListModelMixin,
@@ -72,6 +78,7 @@ class PatientSampleViewSet(
     )
     filterset_class = PatientSampleFilterSet
     http_method_names = ["get", "post", "patch", "delete"]
+    pagination_class = PaginataionOverrideClass
 
     def get_serializer_class(self):
         serializer_class = self.serializer_class

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -307,7 +307,7 @@ REST_FRAMEWORK = {
         "config.authentication.CustomBasicAuthentication",
         "rest_framework.authentication.SessionAuthentication",
     ),
-    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 15,
 }
 


### PR DESCRIPTION
Fixes coronasafe/care_fe#1045

The default page size is 15.
Some of the classes have different page size. I have overridden page size of following classes:
Facility - 14
Patient consultation - 5.
test_sample - 10 (can be changed using page_size parameter. Ex - `http://localhost:8000/api/v1/patient/:patient_id/test_sample/?page_size=5&page=2` ).

I have looked at all the pages. Still, if I have missed any route please let me know.