### PR TITLE
Fix : Patient CSV export duration check

### DIFF
--- a/care/facility/api/viewsets/patient.py
+++ b/care/facility/api/viewsets/patient.py
@@ -242,8 +242,8 @@ class PatientViewSet(
                 slice_obj = temp.form.cleaned_data.get(field)
                 if slice_obj:
                     days_difference = (
-                        temp.form.cleaned_data.get("created_date").stop
-                        - temp.form.cleaned_data.get("created_date").start
+                        temp.form.cleaned_data.get(field).stop
+                        - temp.form.cleaned_data.get(field).start
                     ).days
                     if days_difference <= self.CSV_EXPORT_LIMIT:
                         within_limits = True


### PR DESCRIPTION
fixes #644 

Fix a bug where only `created_date` was checked for 7 day restriction and other fields were ignored.