### PR TITLE
fix export error when only upper or lower limit is set

### DIFF
--- a/care/facility/api/viewsets/patient.py
+++ b/care/facility/api/viewsets/patient.py
@@ -241,6 +241,10 @@ class PatientViewSet(
             for field in self.date_range_fields:
                 slice_obj = temp.form.cleaned_data.get(field)
                 if slice_obj:
+                    if not slice_obj.start or not slice_obj.stop:
+                        raise ValidationError(
+                            {field: f"both starting and ending date must be provided for export"}
+                        )
                     days_difference = (
                         temp.form.cleaned_data.get(field).stop
                         - temp.form.cleaned_data.get(field).start


### PR DESCRIPTION
fixes #646

This PR will Prevent crash and raise appropriate error when only upper or lower limit (but not both) is set for Patient CSV export.