### PR TITLE
Make Daily Round clone error more user friendly

### DIFF
--- a/care/facility/api/serializers/daily_round.py
+++ b/care/facility/api/serializers/daily_round.py
@@ -122,7 +122,7 @@ class DailyRoundSerializer(serializers.ModelSerializer):
                 )
                 last_objects = DailyRound.objects.filter(consultation=consultation).order_by("-created_date")
                 if not last_objects.exists():
-                    raise ValidationError({"daily_round": "No Daily Round objects available to clone"})
+                    raise ValidationError({"daily_round": "No Daily Round record available to copy"})
                 cloned_daily_round_obj = last_objects[0]
                 cloned_daily_round_obj.pk = None
                 cloned_daily_round_obj.created_by = self.context["request"].user


### PR DESCRIPTION
Related frontend issue: https://github.com/coronasafe/care_fe/issues/2251
Related frontend PR: https://github.com/coronasafe/care_fe/pull/2309

This simply changes the error message displayed on the Frontend when the user tries to copy last Daily Round object when it does not exist, making the error message more user friendly as requested in the linked issue report.