### PR TITLE
Summarize beds under facility

### DIFF
--- a/care/facility/management/commands/summarize.py
+++ b/care/facility/management/commands/summarize.py
@@ -1,13 +1,9 @@
 from django.core.management.base import BaseCommand
 
-from care.facility.api.serializers.facility import FacilitySerializer
-from care.facility.api.serializers.facility_capacity import FacilityCapacitySerializer
-from care.facility.models import FacilityCapacity, FacilityRelatedSummary
-
+from care.facility.summarisation.bed_summarization import FacilityBedSummary
+from care.facility.summarisation.district.patient_summary import DistrictPatientSummary
 from care.facility.summarisation.facility_capacity import FacilityCapacitySummary
 from care.facility.summarisation.patient_summary import PatientSummary
-
-from care.facility.summarisation.district.patient_summary import DistrictPatientSummary
 
 
 class Command(BaseCommand):
@@ -24,4 +20,5 @@ class Command(BaseCommand):
         print("Capacity Summarised")
         DistrictPatientSummary()
         print("District Wise Patient Summarised")
-
+        FacilityBedSummary()
+        print("Summarised Beds under Facilities")

--- a/care/facility/models/summary.py
+++ b/care/facility/models/summary.py
@@ -9,6 +9,7 @@ from care.users.models import District, LocalBody
 SUMMARY_CHOICES = (
     ("FacilityCapacity", "FacilityCapacity"),
     ("PatientSummary", "PatientSummary"),
+    ("FacilityBedsSummary", "FacilityBedsSummary"),
     ("TestSummary", "TestSummary"),
     ("TriageSummary", "TriageSummary"),
 )

--- a/care/facility/summarisation/bed_summarization.py
+++ b/care/facility/summarisation/bed_summarization.py
@@ -1,0 +1,62 @@
+from celery.decorators import periodic_task
+from celery.schedules import crontab
+from django.db.models import Sum
+from django.utils.decorators import method_decorator
+from django.utils.timezone import localtime, now
+from django.views.decorators.cache import cache_page
+from django_filters import rest_framework as filters
+from rest_framework.mixins import ListModelMixin
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.viewsets import GenericViewSet
+
+from care.facility.models import Facility, FacilityRelatedSummary
+from care.facility.models.bed import Bed, ConsultationBed
+from care.facility.summarisation.facility_capacity import FacilitySummaryFilter, FacilitySummarySerializer
+
+
+class FaclityBedSummaryViewSet(ListModelMixin, GenericViewSet):
+    lookup_field = "external_id"
+    queryset = FacilityRelatedSummary.objects.filter(s_type="FacilityBedsSummary").order_by(
+        "-created_date"
+    )
+    permission_classes = (IsAuthenticatedOrReadOnly,)
+    serializer_class = FacilitySummarySerializer
+    filter_backends = (filters.DjangoFilterBackend,)
+    filterset_class = FacilitySummaryFilter
+
+    @method_decorator(cache_page(60 * 10))
+    def dispatch(self, request, *args, **kwargs):
+        return super().dispatch(request, *args, **kwargs)
+
+
+def FacilityBedSummary():
+    facility_bed_summary = {}
+    current_date = localtime(now()).replace(hour=0, minute=0, second=0, microsecond=0)
+
+    for facility_obj in Facility.objects.all():
+        bed_count = Bed.objects.filter(facility=facility_obj).count()
+        occupied_bed_count = ConsultationBed.objects.filter(
+            bed__facility=facility_obj, end_date__isnull=True
+        ).count()
+
+        facility_bed_summary[facility_obj.id] = {
+            "facility_name": facility_obj.name,
+            "beds_count": bed_count,
+            "occupied_beds_count": occupied_bed_count,
+            "utilization_percent": occupied_bed_count / bed_count * 100,
+        }
+
+    for i in list(facility_bed_summary.keys()):
+        try:
+            summary_obj = FacilityRelatedSummary.objects.get(
+                s_type="FacilityBedsSummary", facility_id=i, created_date__gte=current_date)
+        except:
+            summary_obj = FacilityRelatedSummary(s_type="FacilityBedsSummary", facility_id=i)
+        summary_obj.data = facility_bed_summary[i]
+        summary_obj.save()
+
+
+@periodic_task(run_every=crontab(minute="*/5"))
+def run_every_five_minute():
+    FacilityBedSummary()
+    print("Summarised Beds under Facility")

--- a/care/facility/summarisation/bed_summarization.py
+++ b/care/facility/summarisation/bed_summarization.py
@@ -1,32 +1,15 @@
 from celery.decorators import periodic_task
 from celery.schedules import crontab
-from django.db.models import Sum
-from django.utils.decorators import method_decorator
 from django.utils.timezone import localtime, now
-from django.views.decorators.cache import cache_page
-from django_filters import rest_framework as filters
-from rest_framework.mixins import ListModelMixin
-from rest_framework.permissions import IsAuthenticatedOrReadOnly
-from rest_framework.viewsets import GenericViewSet
 
 from care.facility.models import Facility, FacilityRelatedSummary
 from care.facility.models.bed import Bed, ConsultationBed
-from care.facility.summarisation.facility_capacity import FacilitySummaryFilter, FacilitySummarySerializer
+from care.facility.summarisation.summary import SummaryViewSet
 
 
-class FaclityBedSummaryViewSet(ListModelMixin, GenericViewSet):
-    lookup_field = "external_id"
-    queryset = FacilityRelatedSummary.objects.filter(s_type="FacilityBedsSummary").order_by(
-        "-created_date"
-    )
-    permission_classes = (IsAuthenticatedOrReadOnly,)
-    serializer_class = FacilitySummarySerializer
-    filter_backends = (filters.DjangoFilterBackend,)
-    filterset_class = FacilitySummaryFilter
-
-    @method_decorator(cache_page(60 * 10))
-    def dispatch(self, request, *args, **kwargs):
-        return super().dispatch(request, *args, **kwargs)
+class FaclityBedSummaryViewSet(SummaryViewSet):
+    def get_queryset(self):
+        return super().get_queryset().filter(s_type="FacilityBedsSummary")
 
 
 def FacilityBedSummary():

--- a/care/facility/summarisation/facility_capacity.py
+++ b/care/facility/summarisation/facility_capacity.py
@@ -45,7 +45,6 @@ class FacilityCapacitySummaryViewSet(
     queryset = (
         FacilityRelatedSummary.objects.filter(s_type="FacilityCapacity")
         .order_by("-created_date")
-        .select_related("facility", "facility__state", "facility__district", "facility__local_body")
     )
     permission_classes = (IsAuthenticatedOrReadOnly,)
     serializer_class = FacilitySummarySerializer

--- a/care/facility/summarisation/patient_summary.py
+++ b/care/facility/summarisation/patient_summary.py
@@ -1,42 +1,15 @@
-from care.facility.models import patient
 from celery.decorators import periodic_task
 from celery.schedules import crontab
-from django.db.models import Q, Subquery
-from django.utils.decorators import method_decorator
+from django.db.models import Q
 from django.utils.timezone import now
-from django.views.decorators.cache import cache_page
-from django_filters import rest_framework as filters
-from rest_framework.mixins import ListModelMixin
-from rest_framework.permissions import IsAuthenticatedOrReadOnly
-from rest_framework.viewsets import GenericViewSet
 
-from care.facility.models import (
-    PatientRegistration,
-    Facility,
-    FacilityRelatedSummary,
-    PatientConsultation,
-    ADMIT_CHOICES,
-)
-from care.facility.summarisation.facility_capacity import (
-    FacilitySummaryFilter,
-    FacilitySummarySerializer,
-)
+from care.facility.models import ADMIT_CHOICES, Facility, FacilityRelatedSummary, PatientRegistration
+from care.facility.summarisation.summary import SummaryViewSet
 
 
-class PatientSummaryViewSet(ListModelMixin, GenericViewSet):
-    lookup_field = "external_id"
-    queryset = FacilityRelatedSummary.objects.filter(s_type="PatientSummary").order_by(
-        "-created_date"
-    )
-    permission_classes = (IsAuthenticatedOrReadOnly,)
-    serializer_class = FacilitySummarySerializer
-
-    filter_backends = (filters.DjangoFilterBackend,)
-    filterset_class = FacilitySummaryFilter
-
-    @method_decorator(cache_page(60 * 10))
-    def dispatch(self, request, *args, **kwargs):
-        return super().dispatch(request, *args, **kwargs)
+class PatientSummaryViewSet(SummaryViewSet):
+    def get_queryset(self):
+        return super().get_queryset().filter(s_type="PatientSummary")
 
     # def get_queryset(self):
     #     user = self.request.user

--- a/care/facility/summarisation/summary.py
+++ b/care/facility/summarisation/summary.py
@@ -1,0 +1,43 @@
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
+from django_filters import rest_framework as filters
+from rest_framework import serializers
+from rest_framework.mixins import ListModelMixin
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.viewsets import GenericViewSet
+
+from care.facility.api.serializers.facility import FacilitySerializer
+from care.facility.models import FacilityRelatedSummary
+
+
+class FacilitySummarySerializer(serializers.ModelSerializer):
+    facility = FacilitySerializer()
+
+    class Meta:
+        model = FacilityRelatedSummary
+        exclude = (
+            "id",
+            "s_type",
+        )
+
+
+class FacilitySummaryFilter(filters.FilterSet):
+    start_date = filters.DateFilter(field_name="created_date", lookup_expr="gte")
+    end_date = filters.DateFilter(field_name="created_date", lookup_expr="lte")
+    facility = filters.UUIDFilter(field_name="facility__external_id")
+    district = filters.NumberFilter(field_name="facility__district__id")
+    local_body = filters.NumberFilter(field_name="facility__local_body__id")
+    state = filters.NumberFilter(field_name="facility__state__id")
+
+
+class SummaryViewSet(ListModelMixin, GenericViewSet):
+    lookup_field = "external_id"
+    queryset = FacilityRelatedSummary.objects.all().order_by("-created_date")
+    permission_classes = [IsAuthenticatedOrReadOnly]
+    filter_backends = [filters.DjangoFilterBackend]
+    serializer_class = FacilitySummarySerializer
+    filterset_class = FacilitySummaryFilter
+
+    @method_decorator(cache_page(60 * 10))
+    def dispatch(self, request, *args, **kwargs):
+        return super().dispatch(request, *args, **kwargs)

--- a/care/facility/summarisation/tests_summary.py
+++ b/care/facility/summarisation/tests_summary.py
@@ -4,23 +4,14 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
-from django_filters import rest_framework as filters
-from rest_framework.mixins import ListModelMixin
-from rest_framework.permissions import IsAuthenticatedOrReadOnly
-from rest_framework.viewsets import GenericViewSet
 
 from care.facility.models import Facility, FacilityRelatedSummary, PatientSample
-from care.facility.summarisation.facility_capacity import FacilitySummaryFilter, FacilitySummarySerializer
+from care.facility.summarisation.summary import SummaryViewSet
 
 
-class TestsSummaryViewSet(ListModelMixin, GenericViewSet):
-    lookup_field = "external_id"
-    queryset = FacilityRelatedSummary.objects.filter(s_type="TestSummary").order_by("-created_date")
-    permission_classes = (IsAuthenticatedOrReadOnly,)
-    serializer_class = FacilitySummarySerializer
-
-    filter_backends = (filters.DjangoFilterBackend,)
-    filterset_class = FacilitySummaryFilter
+class TestsSummaryViewSet(SummaryViewSet):
+    def get_queryset(self):
+        return super().get_queryset().filter(s_type="TestSummary")
 
     # def get_queryset(self):
     #     user = self.request.user
@@ -33,7 +24,7 @@ class TestsSummaryViewSet(ListModelMixin, GenericViewSet):
     #         return queryset.filter(facility__state=user.state)
     #     return queryset.filter(facility__users__id__exact=user.id)
 
-    @method_decorator(cache_page(60 *60* 10))
+    @method_decorator(cache_page(60 * 60 * 10))
     def dispatch(self, request, *args, **kwargs):
         return super().dispatch(request, *args, **kwargs)
 

--- a/care/facility/summarisation/triage_summary.py
+++ b/care/facility/summarisation/triage_summary.py
@@ -1,26 +1,15 @@
 from celery.decorators import periodic_task
 from celery.schedules import crontab
 from django.db.models import Count, Sum
-from django.utils.decorators import method_decorator
 from django.utils.timezone import localtime, now
-from django.views.decorators.cache import cache_page
-from django_filters import rest_framework as filters
-from rest_framework.mixins import ListModelMixin
-from rest_framework.permissions import IsAuthenticatedOrReadOnly
-from rest_framework.viewsets import GenericViewSet
 
 from care.facility.models import Facility, FacilityPatientStatsHistory, FacilityRelatedSummary
-from care.facility.summarisation.facility_capacity import FacilitySummaryFilter, FacilitySummarySerializer
+from care.facility.summarisation.summary import SummaryViewSet
 
 
-class TriageSummaryViewSet(ListModelMixin, GenericViewSet):
-    lookup_field = "external_id"
-    queryset = FacilityRelatedSummary.objects.filter(s_type="TriageSummary").order_by("-created_date")
-    permission_classes = (IsAuthenticatedOrReadOnly,)
-    serializer_class = FacilitySummarySerializer
-
-    filter_backends = (filters.DjangoFilterBackend,)
-    filterset_class = FacilitySummaryFilter
+class TriageSummaryViewSet(SummaryViewSet):
+    def get_queryset(self):
+        return super().get_queryset().filter(s_type="TriageSummary")
 
     # def get_queryset(self):
     #     user = self.request.user
@@ -32,10 +21,6 @@ class TriageSummaryViewSet(ListModelMixin, GenericViewSet):
     #     elif self.request.user.user_type >= User.TYPE_VALUE_MAP["StateReadOnlyAdmin"]:
     #         return queryset.filter(facility__state=user.state)
     #     return queryset.filter(facility__users__id__exact=user.id)
-
-    @method_decorator(cache_page(60 * 60 * 1))
-    def dispatch(self, request, *args, **kwargs):
-        return super().dispatch(request, *args, **kwargs)
 
 
 def TriageSummary():

--- a/config/api_router.py
+++ b/config/api_router.py
@@ -42,6 +42,7 @@ from care.facility.api.viewsets.prescription_supplier import (
 )
 from care.facility.api.viewsets.resources import ResourceRequestCommentViewSet, ResourceRequestViewSet
 from care.facility.api.viewsets.shifting import ShifitngRequestCommentViewSet, ShiftingViewSet
+from care.facility.summarisation.bed_summarization import FaclityBedSummaryViewSet
 from care.facility.summarisation.district.patient_summary import DistrictPatientSummaryViewSet
 from care.facility.summarisation.facility_capacity import FacilityCapacitySummaryViewSet
 from care.facility.summarisation.patient_summary import PatientSummaryViewSet
@@ -109,6 +110,7 @@ router.register("facility_summary", FacilityCapacitySummaryViewSet, basename="su
 router.register("patient_summary", PatientSummaryViewSet, basename="summary-patient")
 router.register("tests_summary", TestsSummaryViewSet, basename="summary-tests")
 router.register("triage_summary", TriageSummaryViewSet, basename="summary-triage")
+router.register("facility_bed_summary", FaclityBedSummaryViewSet, basename="summary-beds")
 
 # District Summary
 


### PR DESCRIPTION
Added summarization for the beds under facility in the `FacilityRelatedSummary` table, which will be visible via the `/api/v1/facility_bed_summary/` API.

Summary will be of the form:
```
{
  "count": 1,
  "next": null,
  "previous": null,
  "results": [
    {
      "facility": {...},
      "created_date": "...",
      "modified_date": "...",
      "data": {
        "beds_count": 2,
        "utilization_percent": 0,
        "facility_name": "...",
        "occupied_beds_count": 0
      }
    }
  ]
}
```

Fixes: #709 