### PR TITLE
Update pre-commit requirement and fix it's branch name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ fail_fast: true
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: master
+    rev: main
     hooks:
       - id: trailing-whitespace
         files: (^|/)a/.+\.(py|html|sh|css|js)$

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -10,7 +10,7 @@ flake8-isort==2.9.0  # https://github.com/gforcada/flake8-isort
 coverage==5.0.4  # https://github.com/nedbat/coveragepy
 black==19.10b0  # https://github.com/ambv/black
 pylint-django==2.0.14  # https://github.com/PyCQA/pylint-django
-pre-commit==2.2.0  # https://github.com/pre-commit/pre-commit
+pre-commit==2.19.0  # https://github.com/pre-commit/pre-commit
 # Django
 # ------------------------------------------------------------------------------
 factory-boy==2.12.0  # https://github.com/FactoryBoy/factory_boy


### PR DESCRIPTION
Currently running the pre-commit throws the below error:

```
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Restored changes from /root/.cache/pre-commit/patch1653563922.
An unexpected error has occurred: CalledProcessError: command: ('/usr/lib/git-core/git', 'checkout', 'master')
return code: 1
expected return code: 0
stdout: (none)
stderr:
    error: pathspec 'master' did not match any file(s) known to git
    
Check the log at /root/.cache/pre-commit/pre-commit.log
```

This seems to be because in `.pre-commit-config` , the branch `master` is being used as the revision for `https://github.com/pre-commit/pre-commit-hooks` . Which does not exist (at least anymore).

This change fixes the branch name to `main`.

It also updates `pre-commit` PIP requirement to version `2.19.0` which is needed to support `black` hook.

```
INFO] Initializing environment for https://github.com/asottile/seed-isort-config.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-isort.
[INFO] Initializing environment for https://github.com/ambv/black.
[ERROR] The hook `black` requires pre-commit version 2.9.2 but version 2.2.0 is installed.  Perhaps run `pip install --upgrade pre-commit`.
```