### PR TITLE
Fix error format for external test

### DIFF
--- a/care/facility/api/viewsets/patient_external_test.py
+++ b/care/facility/api/viewsets/patient_external_test.py
@@ -123,7 +123,7 @@ class PatientExternalTestViewSet(
             raise ValidationError({"sample_tests": "No Data was provided"})
         if type(request.data["sample_tests"]) != type([]):
             raise ValidationError({"sample_tests": "Data should be provided as a list"})
-        errors = {}
+        errors = []
         counter = 0
         ser_objects = []
         invalid = False
@@ -133,7 +133,7 @@ class PatientExternalTestViewSet(
             valid = serialiser_obj.is_valid()
             current_error = prettyerrors(serialiser_obj._errors)
             if current_error and (not valid):
-                errors[counter] = current_error
+                errors.append(current_error)
                 invalid = True
             ser_objects.append(serialiser_obj)
         if invalid:


### PR DESCRIPTION
Required for https://github.com/coronasafe/care_fe/pull/2614

Just a minor change to how list of errors are sent to the client for the external test page.