### PR TITLE
Endpoint analyse/ fixed for read-only users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,7 +156,7 @@ typings/
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
-
+.devcontainer/*
 
 # Provided default Pycharm Run/Debug Configurations should be tracked by git
 # In case of local modifications made by Pycharm, use update-index command

--- a/care/facility/models/daily_round.py
+++ b/care/facility/models/daily_round.py
@@ -406,12 +406,14 @@ class DailyRound(PatientBaseModel):
 
     @staticmethod
     def has_write_permission(request):
-        if (
-            request.user.user_type == User.TYPE_VALUE_MAP["DistrictReadOnlyAdmin"]
-            or request.user.user_type == User.TYPE_VALUE_MAP["StateReadOnlyAdmin"]
-            or request.user.user_type == User.TYPE_VALUE_MAP["StaffReadOnly"]
-        ):
-            return False
+        endpoint = request.get_full_path().split("/")[-2]
+        if(endpoint != "analyse"):
+            if (
+                request.user.user_type == User.TYPE_VALUE_MAP["DistrictReadOnlyAdmin"]
+                or request.user.user_type == User.TYPE_VALUE_MAP["StateReadOnlyAdmin"]
+                or request.user.user_type == User.TYPE_VALUE_MAP["StaffReadOnly"]
+            ):
+                return False
         return DailyRound.has_read_permission(request)
 
     @staticmethod

--- a/care/facility/models/daily_round.py
+++ b/care/facility/models/daily_round.py
@@ -406,8 +406,7 @@ class DailyRound(PatientBaseModel):
 
     @staticmethod
     def has_write_permission(request):
-        endpoint = request.get_full_path().split("/")[-2]
-        if(endpoint != "analyse"):
+        if("/analyse" not in request.get_full_path()):
             if (
                 request.user.user_type == User.TYPE_VALUE_MAP["DistrictReadOnlyAdmin"]
                 or request.user.user_type == User.TYPE_VALUE_MAP["StateReadOnlyAdmin"]


### PR DESCRIPTION
### Issue Fixed
fixes #813 

### Updates
The bug is because analyze is a post request
```
//viewset/daily_round.py line 49
@action(methods=["POST"], detail=False)
    def analyse(self, request, **kwargs):
```
and DailyRound model doesn't  allow POST,PUT,PATCH by read-only users
```
models/daily_round.py line 407  
@staticmethod
    def has_write_permission(request):
        if (
            request.user.user_type == User.TYPE_VALUE_MAP["DistrictReadOnlyAdmin"]
            or request.user.user_type == User.TYPE_VALUE_MAP["StateReadOnlyAdmin"]
            or request.user.user_type == User.TYPE_VALUE_MAP["StaffReadOnly"]
        ):
            return False
        return DailyRound.has_read_permission(request)
```
So adding an exception to /analyze route fixed the issue, we are still checking has_read_permission() to identify whether user is of same facility or not...

### Demo
![Screenshot from 2022-06-03 17-15-07](https://user-images.githubusercontent.com/39593226/171848503-b1d015d7-0ed8-456d-85bb-4ffa334e19a9.png)

