### PR TITLE
DRY Permissions added for assetLocation viewset

### DIFF
--- a/care/facility/models/asset.py
+++ b/care/facility/models/asset.py
@@ -6,6 +6,7 @@ from django.db import models
 from django.db.models import Q
 
 from care.facility.models.facility import Facility
+from care.facility.models.mixins.permissions.asset import AssetsPermissionMixin
 from care.users.models import User, phone_number_regex
 from care.utils.assetintegration.asset_classes import AssetClasses
 from care.utils.models.base import BaseModel
@@ -15,7 +16,7 @@ def get_random_asset_id():
     return str(uuid.uuid4())
 
 
-class AssetLocation(BaseModel):
+class AssetLocation(BaseModel, AssetsPermissionMixin):
     """
     This model is also used to store rooms that the assets are in, Since these rooms are mapped to
     actual rooms in the hospital, Beds are also connected to this model to remove duplication of efforts
@@ -29,8 +30,12 @@ class AssetLocation(BaseModel):
 
     name = models.CharField(max_length=1024, blank=False, null=False)
     description = models.TextField(default="", null=True, blank=True)
-    location_type = models.IntegerField(choices=RoomTypeChoices, default=RoomType.OTHER.value)
-    facility = models.ForeignKey(Facility, on_delete=models.PROTECT, null=False, blank=False)
+    location_type = models.IntegerField(
+        choices=RoomTypeChoices, default=RoomType.OTHER.value
+    )
+    facility = models.ForeignKey(
+        Facility, on_delete=models.PROTECT, null=False, blank=False
+    )
 
 
 class Asset(BaseModel):
@@ -50,10 +55,16 @@ class Asset(BaseModel):
 
     name = models.CharField(max_length=1024, blank=False, null=False)
     description = models.TextField(default="", null=True, blank=True)
-    asset_type = models.IntegerField(choices=AssetTypeChoices, default=AssetType.INTERNAL.value)
-    asset_class = models.CharField(choices=AssetClassChoices, default=None, null=True, blank=True, max_length=20)
+    asset_type = models.IntegerField(
+        choices=AssetTypeChoices, default=AssetType.INTERNAL.value
+    )
+    asset_class = models.CharField(
+        choices=AssetClassChoices, default=None, null=True, blank=True, max_length=20
+    )
     status = models.IntegerField(choices=StatusChoices, default=Status.ACTIVE.value)
-    current_location = models.ForeignKey(AssetLocation, on_delete=models.PROTECT, null=False, blank=False)
+    current_location = models.ForeignKey(
+        AssetLocation, on_delete=models.PROTECT, null=False, blank=False
+    )
     is_working = models.BooleanField(default=None, null=True, blank=True)
     not_working_reason = models.CharField(max_length=1024, blank=True, null=True)
     serial_number = models.CharField(max_length=1024, blank=True, null=True)
@@ -62,14 +73,18 @@ class Asset(BaseModel):
     # Vendor Details
     vendor_name = models.CharField(max_length=1024, blank=True, null=True)
     support_name = models.CharField(max_length=1024, blank=True, null=True)
-    support_phone = models.CharField(max_length=14, validators=[phone_number_regex], default="")
+    support_phone = models.CharField(
+        max_length=14, validators=[phone_number_regex], default=""
+    )
     support_email = models.EmailField(blank=True, null=True)
     qr_code_id = models.CharField(max_length=1024, blank=True, default=None, null=True)
 
     class Meta:
         constraints = [
             models.UniqueConstraint(
-                fields=["qr_code_id"], name="qr_code_unique_when_not_null", condition=Q(qr_code_id__isnull=False)
+                fields=["qr_code_id"],
+                name="qr_code_unique_when_not_null",
+                condition=Q(qr_code_id__isnull=False),
             ),
         ]
 
@@ -79,20 +94,36 @@ class Asset(BaseModel):
 
 class UserDefaultAssetLocation(BaseModel):
     user = models.ForeignKey(User, on_delete=models.PROTECT, null=False, blank=False)
-    location = models.ForeignKey(AssetLocation, on_delete=models.PROTECT, null=False, blank=False)
+    location = models.ForeignKey(
+        AssetLocation, on_delete=models.PROTECT, null=False, blank=False
+    )
 
 
 class FacilityDefaultAssetLocation(BaseModel):
-    facility = models.ForeignKey(Facility, on_delete=models.PROTECT, null=False, blank=False)
-    location = models.ForeignKey(AssetLocation, on_delete=models.PROTECT, null=False, blank=False)
+    facility = models.ForeignKey(
+        Facility, on_delete=models.PROTECT, null=False, blank=False
+    )
+    location = models.ForeignKey(
+        AssetLocation, on_delete=models.PROTECT, null=False, blank=False
+    )
 
 
 class AssetTransaction(BaseModel):
     asset = models.ForeignKey(Asset, on_delete=models.PROTECT, null=False, blank=False)
     from_location = models.ForeignKey(
-        AssetLocation, on_delete=models.PROTECT, related_name="from_location", null=False, blank=False,
+        AssetLocation,
+        on_delete=models.PROTECT,
+        related_name="from_location",
+        null=False,
+        blank=False,
     )
     to_location = models.ForeignKey(
-        AssetLocation, on_delete=models.PROTECT, related_name="to_location", null=False, blank=False,
+        AssetLocation,
+        on_delete=models.PROTECT,
+        related_name="to_location",
+        null=False,
+        blank=False,
     )
-    performed_by = models.ForeignKey(User, on_delete=models.PROTECT, null=False, blank=False)
+    performed_by = models.ForeignKey(
+        User, on_delete=models.PROTECT, null=False, blank=False
+    )

--- a/care/facility/models/mixins/permissions/asset.py
+++ b/care/facility/models/mixins/permissions/asset.py
@@ -1,0 +1,27 @@
+from care.facility.models.mixins.permissions.base import BasePermissionMixin
+from care.users.models import User
+
+
+class AssetsPermissionMixin(BasePermissionMixin):
+    def has_object_read_permission(self, request):
+        return True
+
+    def has_object_update_permission(self, request):
+        if (
+            request.user.user_type == User.TYPE_VALUE_MAP["DistrictReadOnlyAdmin"]
+            or request.user.user_type == User.TYPE_VALUE_MAP["StateReadOnlyAdmin"]
+            or request.user.user_type == User.TYPE_VALUE_MAP["StaffReadOnly"]
+        ):
+            return False
+        else:
+            return True
+
+    def has_object_destroy_permission(self, request):
+        if (
+            request.user.user_type == User.TYPE_VALUE_MAP["DistrictReadOnlyAdmin"]
+            or request.user.user_type == User.TYPE_VALUE_MAP["StateReadOnlyAdmin"]
+            or request.user.user_type == User.TYPE_VALUE_MAP["StaffReadOnly"]
+        ):
+            return False
+        else:
+            return True

--- a/care/facility/models/mixins/permissions/asset.py
+++ b/care/facility/models/mixins/permissions/asset.py
@@ -6,22 +6,19 @@ class AssetsPermissionMixin(BasePermissionMixin):
     def has_object_read_permission(self, request):
         return True
 
-    def has_object_update_permission(self, request):
+    def has_object_write_permission(self, request):
         if (
             request.user.user_type == User.TYPE_VALUE_MAP["DistrictReadOnlyAdmin"]
             or request.user.user_type == User.TYPE_VALUE_MAP["StateReadOnlyAdmin"]
             or request.user.user_type == User.TYPE_VALUE_MAP["StaffReadOnly"]
         ):
             return False
-        else:
-            return True
+        
+        return True
+
+
+    def has_object_update_permission(self, request):
+        return self.has_object_write_permission(request)
 
     def has_object_destroy_permission(self, request):
-        if (
-            request.user.user_type == User.TYPE_VALUE_MAP["DistrictReadOnlyAdmin"]
-            or request.user.user_type == User.TYPE_VALUE_MAP["StateReadOnlyAdmin"]
-            or request.user.user_type == User.TYPE_VALUE_MAP["StaffReadOnly"]
-        ):
-            return False
-        else:
-            return True
+        return self.has_object_write_permission(request)


### PR DESCRIPTION
### Issue Fixed
fixes #818 

### Updates
**Read only users can now only read the location list and will not be able to perform any create/edit on it**
- Added new DRY permission class *models/mixins/permissions/asset.py*
- Updated AssetLocation model to inherit from DRYPermission class
- Updated AssetLocationViewset to use DryPermission and isAuthenticated Permission