### PR TITLE
Add check for empty comments and notes

### DIFF
--- a/care/facility/api/serializers/patient.py
+++ b/care/facility/api/serializers/patient.py
@@ -1,5 +1,4 @@
 import datetime
-import re
 
 from django.db import transaction
 from django.utils.timezone import localtime, make_aware, now
@@ -353,7 +352,7 @@ class PatientNotesSerializer(serializers.ModelSerializer):
     created_by_object = UserBaseMinimumSerializer(source="created_by", read_only=True)
 
     def validate_empty_values(self, data):
-        if not data.get("note") or re.match(r"^\s*$", data["note"]):
+        if not data.get("note", "").strip():
             raise serializers.ValidationError({"note": ["Note cannot be empty"]})
         return super().validate_empty_values(data)
 

--- a/care/facility/api/serializers/patient.py
+++ b/care/facility/api/serializers/patient.py
@@ -1,4 +1,5 @@
 import datetime
+import re
 
 from django.db import transaction
 from django.utils.timezone import localtime, make_aware, now
@@ -119,7 +120,10 @@ class PatientDetailSerializer(PatientListSerializer):
     #     source="nearest_facility", read_only=True
     # )
 
-    source = ChoiceField(choices=PatientRegistration.SourceChoices, default=PatientRegistration.SourceEnum.CARE.value,)
+    source = ChoiceField(
+        choices=PatientRegistration.SourceChoices,
+        default=PatientRegistration.SourceEnum.CARE.value,
+    )
     disease_status = ChoiceField(choices=DISEASE_STATUS_CHOICES, default=DiseaseStatusEnum.SUSPECTED.value)
 
     meta_info = PatientMetaInfoSerializer(required=False, allow_null=True)
@@ -215,9 +219,7 @@ class PatientDetailSerializer(PatientListSerializer):
                 patient.save()
 
             if contacted_patients:
-                contacted_patient_objs = [
-                    PatientContactDetails(**data, patient=patient) for data in contacted_patients
-                ]
+                contacted_patient_objs = [PatientContactDetails(**data, patient=patient) for data in contacted_patients]
                 PatientContactDetails.objects.bulk_create(contacted_patient_objs)
 
             patient.last_edited = self.context["request"].user
@@ -264,9 +266,7 @@ class PatientDetailSerializer(PatientListSerializer):
                 patient.contacted_patients.all().delete()
 
             if contacted_patients:
-                contacted_patient_objs = [
-                    PatientContactDetails(**data, patient=patient) for data in contacted_patients
-                ]
+                contacted_patient_objs = [PatientContactDetails(**data, patient=patient) for data in contacted_patients]
                 PatientContactDetails.objects.bulk_create(contacted_patient_objs)
 
             patient.last_edited = self.context["request"].user
@@ -315,7 +315,12 @@ class PatientSearchSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = PatientSearch
-        exclude = ("date_of_birth", "year_of_birth", "external_id", "id",) + TIMESTAMP_FIELDS
+        exclude = (
+            "date_of_birth",
+            "year_of_birth",
+            "external_id",
+            "id",
+        ) + TIMESTAMP_FIELDS
 
 
 class PatientTransferSerializer(serializers.ModelSerializer):
@@ -346,6 +351,11 @@ class PatientTransferSerializer(serializers.ModelSerializer):
 class PatientNotesSerializer(serializers.ModelSerializer):
     facility = FacilityBasicInfoSerializer(read_only=True)
     created_by_object = UserBaseMinimumSerializer(source="created_by", read_only=True)
+
+    def validate_empty_values(self, data):
+        if not data.get("note") or re.match(r"^\s*$", data["note"]):
+            raise serializers.ValidationError({"note": ["Note cannot be empty"]})
+        return super().validate_empty_values(data)
 
     class Meta:
         model = PatientNotes

--- a/care/facility/api/serializers/resources.py
+++ b/care/facility/api/serializers/resources.py
@@ -1,5 +1,3 @@
-import re
-
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
@@ -158,7 +156,7 @@ class ResourceRequestCommentSerializer(serializers.ModelSerializer):
     created_by_object = UserBaseMinimumSerializer(source="created_by", read_only=True)
 
     def validate_empty_values(self, data):
-        if not data.get("comment") or re.match(r"^\s*$", data["comment"]):
+        if not data.get("comment", "").strip():
             raise serializers.ValidationError({"comment": ["Comment cannot be empty"]})
         return super().validate_empty_values(data)
 

--- a/care/facility/api/serializers/resources.py
+++ b/care/facility/api/serializers/resources.py
@@ -1,4 +1,5 @@
-from care.facility.models.resources import RESOURCE_SUB_CATEGORY_CHOICES
+import re
+
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
@@ -9,9 +10,10 @@ from care.facility.models import (
     RESOURCE_STATUS_CHOICES,
     Facility,
     ResourceRequest,
-    User,
     ResourceRequestComment,
+    User,
 )
+from care.facility.models.resources import RESOURCE_SUB_CATEGORY_CHOICES
 from care.users.api.serializers.user import UserBaseMinimumSerializer
 from config.serializers import ChoiceField
 
@@ -47,18 +49,14 @@ class ResourceRequestSerializer(serializers.ModelSerializer):
     status = ChoiceField(choices=RESOURCE_STATUS_CHOICES)
 
     orgin_facility_object = FacilityBasicInfoSerializer(source="orgin_facility", read_only=True, required=False)
-    approving_facility_object = FacilityBasicInfoSerializer(
-        source="approving_facility", read_only=True, required=False
-    )
+    approving_facility_object = FacilityBasicInfoSerializer(source="approving_facility", read_only=True, required=False)
     assigned_facility_object = FacilityBasicInfoSerializer(source="assigned_facility", read_only=True, required=False)
 
     category = ChoiceField(choices=RESOURCE_CATEGORY_CHOICES)
     sub_category = ChoiceField(choices=RESOURCE_SUB_CATEGORY_CHOICES)
 
     orgin_facility = serializers.UUIDField(source="orgin_facility.external_id", allow_null=False, required=True)
-    approving_facility = serializers.UUIDField(
-        source="approving_facility.external_id", allow_null=False, required=True
-    )
+    approving_facility = serializers.UUIDField(source="approving_facility.external_id", allow_null=False, required=True)
     assigned_facility = serializers.UUIDField(source="assigned_facility.external_id", allow_null=True, required=False)
 
     assigned_to_object = UserBaseMinimumSerializer(source="assigned_to", read_only=True)
@@ -158,6 +156,11 @@ class ResourceRequestCommentSerializer(serializers.ModelSerializer):
     id = serializers.UUIDField(source="external_id", read_only=True)
 
     created_by_object = UserBaseMinimumSerializer(source="created_by", read_only=True)
+
+    def validate_empty_values(self, data):
+        if not data.get("comment") or re.match(r"^\s*$", data["comment"]):
+            raise serializers.ValidationError({"comment": ["Comment cannot be empty"]})
+        return super().validate_empty_values(data)
 
     def create(self, validated_data):
         validated_data["created_by"] = self.context["request"].user

--- a/care/facility/api/serializers/shifting.py
+++ b/care/facility/api/serializers/shifting.py
@@ -1,5 +1,3 @@
-import re
-
 from django.db.models import Q
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
@@ -243,7 +241,7 @@ class ShiftingRequestCommentSerializer(serializers.ModelSerializer):
     created_by_object = UserBaseMinimumSerializer(source="created_by", read_only=True)
 
     def validate_empty_values(self, data):
-        if not data.get("comment") or re.match(r"^\s*$", data["comment"]):
+        if not data.get("comment", "").strip():
             raise serializers.ValidationError({"comment": ["Comment cannot be empty"]})
         return super().validate_empty_values(data)
 


### PR DESCRIPTION
Builds on https://github.com/coronasafe/care_fe/pull/2525

Adds a check for empty comments and notes from the backend and rejects with proper validation message when needed.

Also some minor formatting change performed automatically by `pre-commit-hooks`