### PR TITLE
Cleanup leftover admitted_to references

### DIFF
--- a/care/facility/api/serializers/daily_round.py
+++ b/care/facility/api/serializers/daily_round.py
@@ -12,7 +12,7 @@ from care.facility.models import CATEGORY_CHOICES, PatientRegistration
 from care.facility.models.bed import Bed
 from care.facility.models.daily_round import DailyRound
 from care.facility.models.notification import Notification
-from care.facility.models.patient_base import ADMIT_CHOICES, CURRENT_HEALTH_CHOICES, SYMPTOM_CHOICES
+from care.facility.models.patient_base import CURRENT_HEALTH_CHOICES, SYMPTOM_CHOICES
 from care.users.api.serializers.user import UserBaseMinimumSerializer
 from care.utils.notification_handler import NotificationGenerator
 from care.utils.queryset.consultation import get_consultation_queryset

--- a/care/facility/api/viewsets/patient.py
+++ b/care/facility/api/viewsets/patient.py
@@ -49,7 +49,7 @@ from care.facility.models.patient_base import DISEASE_STATUS_DICT
 from care.facility.tasks.patient.discharge_report import generate_discharge_report
 from care.users.models import User
 from care.utils.cache.cache_allowed_facilities import get_accessible_facilities
-from care.utils.filters import CareChoiceFilter, MultiSelectFilter
+from care.utils.filters import CareChoiceFilter
 from care.utils.queryset.patient import get_patient_queryset
 from config.authentication import CustomBasicAuthentication, CustomJWTAuthentication, MiddlewareAuthentication
 
@@ -97,8 +97,6 @@ class PatientFilterSet(filters.FilterSet):
     last_consultation_symptoms_onset_date = filters.DateFromToRangeFilter(
         field_name="last_consultation__symptoms_onset_date"
     )
-    last_consultation_admitted_to_list = MultiSelectFilter(field_name="last_consultation__admitted_to")
-    last_consultation_admitted_to = filters.NumberFilter(field_name="last_consultation__admitted_to")
     last_consultation_assigned_to = filters.NumberFilter(field_name="last_consultation__assigned_to")
     last_consultation_is_telemedicine = filters.BooleanFilter(field_name="last_consultation__is_telemedicine")
 
@@ -109,10 +107,12 @@ class PatientFilterSet(filters.FilterSet):
     # Permission Filters
     assigned_to = filters.NumberFilter(field_name="assigned_to")
     # Other Filters
-    has_bed = filters.BooleanFilter(field_name="has_bed", method='filter_bed_not_null')
+    has_bed = filters.BooleanFilter(field_name="has_bed", method="filter_bed_not_null")
 
     def filter_bed_not_null(self, queryset, name, value):
-        return queryset.filter(last_consultation__bed_number__isnull=value, last_consultation__discharge_date__isnull=True)
+        return queryset.filter(
+            last_consultation__bed_number__isnull=value, last_consultation__discharge_date__isnull=True
+        )
 
 
 class PatientDRYFilter(DRYPermissionFiltersBase):

--- a/care/facility/models/daily_round.py
+++ b/care/facility/models/daily_round.py
@@ -6,7 +6,6 @@ from django.db import models
 from multiselectfield import MultiSelectField
 
 from care.facility.models import CATEGORY_CHOICES, PatientBaseModel
-from care.facility.models.bed import Bed
 from care.facility.models.json_schema.daily_round import (
     BLOOD_PRESSURE,
     FEED,
@@ -17,7 +16,7 @@ from care.facility.models.json_schema.daily_round import (
     OUTPUT,
     PRESSURE_SORE,
 )
-from care.facility.models.patient_base import ADMIT_CHOICES, CURRENT_HEALTH_CHOICES, SYMPTOM_CHOICES
+from care.facility.models.patient_base import CURRENT_HEALTH_CHOICES, SYMPTOM_CHOICES
 from care.facility.models.patient_consultation import PatientConsultation
 from care.users.models import User
 from care.utils.models.validators import JSONFieldSchemaValidator

--- a/care/facility/models/patient.py
+++ b/care/facility/models/patient.py
@@ -24,7 +24,6 @@ from care.facility.models.mixins.permissions.patient import PatientPermissionMix
 from care.facility.models.patient_base import (
     BLOOD_GROUP_CHOICES,
     DISEASE_STATUS_CHOICES,
-    REVERSE_ADMIT_CHOICES,
     REVERSE_BLOOD_GROUP_CHOICES,
     REVERSE_DISEASE_STATUS_CHOICES,
     REVERSE_SYMPTOM_CATEGORY_CHOICES,
@@ -495,7 +494,6 @@ class PatientRegistration(PatientBaseModel, PatientPermissionMixin):
         "last_consultation__category": (lambda x: REVERSE_SYMPTOM_CATEGORY_CHOICES.get(x, "-")),
         "last_consultation__suggestion": (lambda x: PatientConsultation.REVERSE_SUGGESTION_CHOICES.get(x, "-")),
         "last_consultation__admitted": pretty_boolean,
-        "last_consultation__admitted_to": (lambda x: REVERSE_ADMIT_CHOICES.get(x, "-")),
     }
 
 

--- a/care/facility/models/patient_base.py
+++ b/care/facility/models/patient_base.py
@@ -16,18 +16,7 @@ CURRENT_HEALTH_CHOICES = [
     (3, "STATUS QUO"),
     (4, "BETTER"),
 ]
-ADMIT_CHOICES = [
-    (None, "Not admitted"),
-    (1, "Isolation Room"),
-    (2, "ICU"),
-    (3, "ICU with Non Invasive Ventilator"),
-    (4, "ICU with Oxygen Support"),
-    (5, "ICU with Invasive Ventilator"),
-    (6, "Bed with Oxygen Support"),
-    (20, "Home Isolation"),
-    (30, "Gynaecology Ward"),
-    (40, "Paediatric Ward"),
-]
+
 SYMPTOM_CHOICES = [
     (1, "ASYMPTOMATIC"),
     (2, "FEVER"),
@@ -98,4 +87,3 @@ SuggestionChoices = SimpleNamespace(HI="HI", A="A", R="R", OP="OP", DC="DC")
 REVERSE_BLOOD_GROUP_CHOICES = reverse_choices(BLOOD_GROUP_CHOICES)
 REVERSE_DISEASE_STATUS_CHOICES = reverse_choices(DISEASE_STATUS_CHOICES)
 REVERSE_SYMPTOM_CATEGORY_CHOICES = reverse_choices(CATEGORY_CHOICES)
-REVERSE_ADMIT_CHOICES = reverse_choices(ADMIT_CHOICES)

--- a/care/facility/models/patient_consultation.py
+++ b/care/facility/models/patient_consultation.py
@@ -6,7 +6,6 @@ from multiselectfield import MultiSelectField
 from care.facility.models import CATEGORY_CHOICES, PatientBaseModel
 from care.facility.models.mixins.permissions.patient import PatientRelatedPermissionMixin
 from care.facility.models.patient_base import (
-    ADMIT_CHOICES,
     REVERSE_SYMPTOM_CATEGORY_CHOICES,
     SYMPTOM_CHOICES,
     SuggestionChoices,
@@ -44,7 +43,11 @@ class PatientConsultation(PatientBaseModel, PatientRelatedPermissionMixin):
     prescriptions = JSONField(default=dict)  # Deprecated
     suggestion = models.CharField(max_length=4, choices=SUGGESTION_CHOICES)
     referred_to = models.ForeignKey(
-        "Facility", null=True, blank=True, on_delete=models.PROTECT, related_name="referred_patients",
+        "Facility",
+        null=True,
+        blank=True,
+        on_delete=models.PROTECT,
+        related_name="referred_patients",
     )  # Deprecated
     admitted = models.BooleanField(default=False)  # Deprecated
     admission_date = models.DateTimeField(null=True, blank=True)  # Deprecated
@@ -74,10 +77,16 @@ class PatientConsultation(PatientBaseModel, PatientRelatedPermissionMixin):
     # Physical Information
 
     height = models.FloatField(
-        default=None, null=True, verbose_name="Patient's Height in CM", validators=[MinValueValidator(0)],
+        default=None,
+        null=True,
+        verbose_name="Patient's Height in CM",
+        validators=[MinValueValidator(0)],
     )
     weight = models.FloatField(
-        default=None, null=True, verbose_name="Patient's Weight in KG", validators=[MinValueValidator(0)],
+        default=None,
+        null=True,
+        verbose_name="Patient's Weight in KG",
+        validators=[MinValueValidator(0)],
     )
     HBA1C = models.FloatField(
         default=None,
@@ -140,6 +149,7 @@ class PatientConsultation(PatientBaseModel, PatientRelatedPermissionMixin):
                 check=~models.Q(suggestion=SuggestionChoices.R) | models.Q(referred_to__isnull=False),
             ),
             models.CheckConstraint(
-                name="if_admitted", check=models.Q(admitted=False) | models.Q(admission_date__isnull=False),
+                name="if_admitted",
+                check=models.Q(admitted=False) | models.Q(admission_date__isnull=False),
             ),
         ]

--- a/care/facility/summarisation/district/patient_summary.py
+++ b/care/facility/summarisation/district/patient_summary.py
@@ -1,6 +1,6 @@
 from celery.decorators import periodic_task
 from celery.schedules import crontab
-from django.db.models import Q, Subquery
+from django.db.models import Q
 from django.utils.decorators import method_decorator
 from django.utils.timezone import now
 from django.views.decorators.cache import cache_page
@@ -10,16 +10,7 @@ from rest_framework.mixins import ListModelMixin
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.viewsets import GenericViewSet
 
-from care.facility.models import (
-    ADMIT_CHOICES,
-    DistrictScopedSummary,
-    Facility,
-    FacilityRelatedSummary,
-    PatientConsultation,
-    PatientRegistration,
-    patient,
-)
-
+from care.facility.models import DistrictScopedSummary, PatientRegistration
 from care.users.models import District, LocalBody
 
 
@@ -74,14 +65,13 @@ def DistrictPatientSummary():
             "name": district_object.name,
             "id": district_object.id,
         }
-        for local_body_object in LocalBody.objects.filter(
-            district_id=district_object.id
-        ):
+        for local_body_object in LocalBody.objects.filter(district_id=district_object.id):
             district_summary[local_body_object.id] = {
                 "name": local_body_object.name,
                 "code": local_body_object.localbody_code,
                 "total_inactive": PatientRegistration.objects.filter(
-                    is_active=False, local_body_id=local_body_object.id,
+                    is_active=False,
+                    local_body_id=local_body_object.id,
                 ).count(),
             }
             patients = PatientRegistration.objects.filter(
@@ -90,73 +80,37 @@ def DistrictPatientSummary():
                 local_body_id=local_body_object.id,
             )
 
-            # Get Total Counts
-
-            for admitted_choice in ADMIT_CHOICES:
-                db_value = admitted_choice[0]
-                text = admitted_choice[1]
-                filter = {"last_consultation__" + "admitted_to": db_value}
-                count = patients.filter(**filter).count()
-                clean_name = "total_patients_" + "_".join(text.lower().split())
-                district_summary[local_body_object.id][clean_name] = count
-
             home_quarantine = Q(last_consultation__suggestion="HI")
 
             total_patients_home_quarantine = patients.filter(home_quarantine).count()
-            district_summary[local_body_object.id][
-                "total_patients_home_quarantine"
-            ] = total_patients_home_quarantine
+            district_summary[local_body_object.id]["total_patients_home_quarantine"] = total_patients_home_quarantine
 
             # Apply Date Filters
 
-            patients_today = patients.filter(
-                last_consultation__created_date__startswith=now().date()
-            )
+            patients_today = patients.filter(last_consultation__created_date__startswith=now().date())
 
             # Get Todays Counts
 
-            today_patients_home_quarantine = patients_today.filter(
-                home_quarantine
-            ).count()
-
-            for admitted_choice in ADMIT_CHOICES:
-                db_value = admitted_choice[0]
-                text = admitted_choice[1]
-                filter = {"last_consultation__" + "admitted_to": db_value}
-                count = patients_today.filter(**filter).count()
-                clean_name = "today_patients_" + "_".join(text.lower().split())
-                district_summary[local_body_object.id][clean_name] = count
+            today_patients_home_quarantine = patients_today.filter(home_quarantine).count()
 
             # Update Anything Extra
-            district_summary[local_body_object.id][
-                "today_patients_home_quarantine"
-            ] = today_patients_home_quarantine
+            district_summary[local_body_object.id]["today_patients_home_quarantine"] = today_patients_home_quarantine
 
-        object_filter = Q(s_type="PatientSummary") & Q(
-            created_date__startswith=now().date()
-        )
-        if (
-            DistrictScopedSummary.objects.filter(district_id=district_object.id)
-            .filter(object_filter)
-            .exists()
-        ):
-            district_summary_old = DistrictScopedSummary.objects.filter(
-                object_filter
-            ).get(district_id=district_object.id)
+        object_filter = Q(s_type="PatientSummary") & Q(created_date__startswith=now().date())
+        if DistrictScopedSummary.objects.filter(district_id=district_object.id).filter(object_filter).exists():
+            district_summary_old = DistrictScopedSummary.objects.filter(object_filter).get(
+                district_id=district_object.id
+            )
             district_summary_old.created_date = now()
             district_summary_old.data.pop("modified_date")
 
             district_summary_old.data = district_summary
             latest_modification_date = now()
-            district_summary_old.data.update(
-                {"modified_date": latest_modification_date.strftime("%d-%m-%Y %H:%M")}
-            )
+            district_summary_old.data.update({"modified_date": latest_modification_date.strftime("%d-%m-%Y %H:%M")})
             district_summary_old.save()
         else:
             modified_date = now()
-            district_summary.update(
-                {"modified_date": modified_date.strftime("%d-%m-%Y %H:%M")}
-            )
+            district_summary.update({"modified_date": modified_date.strftime("%d-%m-%Y %H:%M")})
             DistrictScopedSummary(
                 s_type="PatientSummary",
                 district_id=district_object.id,

--- a/care/facility/summarisation/patient_summary.py
+++ b/care/facility/summarisation/patient_summary.py
@@ -1,7 +1,6 @@
-from care.facility.models import patient
 from celery.decorators import periodic_task
 from celery.schedules import crontab
-from django.db.models import Q, Subquery
+from django.db.models import Q
 from django.utils.decorators import method_decorator
 from django.utils.timezone import now
 from django.views.decorators.cache import cache_page
@@ -10,24 +9,13 @@ from rest_framework.mixins import ListModelMixin
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.viewsets import GenericViewSet
 
-from care.facility.models import (
-    PatientRegistration,
-    Facility,
-    FacilityRelatedSummary,
-    PatientConsultation,
-    ADMIT_CHOICES,
-)
-from care.facility.summarisation.facility_capacity import (
-    FacilitySummaryFilter,
-    FacilitySummarySerializer,
-)
+from care.facility.models import Facility, FacilityRelatedSummary, PatientRegistration
+from care.facility.summarisation.facility_capacity import FacilitySummaryFilter, FacilitySummarySerializer
 
 
 class PatientSummaryViewSet(ListModelMixin, GenericViewSet):
     lookup_field = "external_id"
-    queryset = FacilityRelatedSummary.objects.filter(s_type="PatientSummary").order_by(
-        "-created_date"
-    )
+    queryset = FacilityRelatedSummary.objects.filter(s_type="PatientSummary").order_by("-created_date")
     permission_classes = (IsAuthenticatedOrReadOnly,)
     serializer_class = FacilitySummarySerializer
 
@@ -68,60 +56,26 @@ def PatientSummary():
                 last_consultation__facility=facility_object,
             )
 
-            # Get Total Counts
-
-            for admitted_choice in ADMIT_CHOICES:
-                db_value = admitted_choice[0]
-                text = admitted_choice[1]
-                filter = {"last_consultation__" + "admitted_to": db_value}
-                count = patients.filter(**filter).count()
-                clean_name = "total_patients_" + "_".join(text.lower().split())
-                patient_summary[facility_id][clean_name] = count
-
             home_quarantine = Q(last_consultation__suggestion="HI")
 
             total_patients_home_quarantine = patients.filter(home_quarantine).count()
-            patient_summary[facility_id][
-                "total_patients_home_quarantine"
-            ] = total_patients_home_quarantine
+            patient_summary[facility_id]["total_patients_home_quarantine"] = total_patients_home_quarantine
 
             # Apply Date Filters
 
-            patients_today = patients.filter(
-                last_consultation__created_date__startswith=now().date()
-            )
+            patients_today = patients.filter(last_consultation__created_date__startswith=now().date())
 
             # Get Todays Counts
 
-            today_patients_home_quarantine = patients_today.filter(
-                home_quarantine
-            ).count()
-
-            for admitted_choice in ADMIT_CHOICES:
-                db_value = admitted_choice[0]
-                text = admitted_choice[1]
-                filter = {"last_consultation__" + "admitted_to": db_value}
-                count = patients_today.filter(**filter).count()
-                clean_name = "today_patients_" + "_".join(text.lower().split())
-                patient_summary[facility_id][clean_name] = count
+            today_patients_home_quarantine = patients_today.filter(home_quarantine).count()
 
             # Update Anything Extra
-            patient_summary[facility_id][
-                "today_patients_home_quarantine"
-            ] = today_patients_home_quarantine
+            patient_summary[facility_id]["today_patients_home_quarantine"] = today_patients_home_quarantine
 
     for i in list(patient_summary.keys()):
-        object_filter = Q(s_type="PatientSummary") & Q(
-            created_date__startswith=now().date()
-        )
-        if (
-            FacilityRelatedSummary.objects.filter(facility_id=i)
-            .filter(object_filter)
-            .exists()
-        ):
-            facility = FacilityRelatedSummary.objects.filter(object_filter).get(
-                facility_id=i
-            )
+        object_filter = Q(s_type="PatientSummary") & Q(created_date__startswith=now().date())
+        if FacilityRelatedSummary.objects.filter(facility_id=i).filter(object_filter).exists():
+            facility = FacilityRelatedSummary.objects.filter(object_filter).get(facility_id=i)
             facility.created_date = now()
             facility.data.pop("modified_date")
             if facility.data == patient_summary[i]:
@@ -129,22 +83,12 @@ def PatientSummary():
             else:
                 facility.data = patient_summary[i]
                 latest_modification_date = now()
-                facility.data.update(
-                    {
-                        "modified_date": latest_modification_date.strftime(
-                            "%d-%m-%Y %H:%M"
-                        )
-                    }
-                )
+                facility.data.update({"modified_date": latest_modification_date.strftime("%d-%m-%Y %H:%M")})
                 facility.save()
         else:
             modified_date = now()
-            patient_summary[i].update(
-                {"modified_date": modified_date.strftime("%d-%m-%Y %H:%M")}
-            )
-            FacilityRelatedSummary(
-                s_type="PatientSummary", facility_id=i, data=patient_summary[i]
-            ).save()
+            patient_summary[i].update({"modified_date": modified_date.strftime("%d-%m-%Y %H:%M")})
+            FacilityRelatedSummary(s_type="PatientSummary", facility_id=i, data=patient_summary[i]).save()
     return True
 
 


### PR DESCRIPTION
The attribute `admitted_to` was removed from the `PatientConsultationSerializer` ([here](https://github.com/coronasafe/care/commit/9277da54831c510b580b79f4399a454af95f017e#diff-e126fcc15b8000c9011ba8d450d085f128e2d698d87e331912f1fa8c145f970eL32)) but is still referred to in some parts. This change cleans up all the leftover code working with `admitted_to`. It also removes `ADMIT_CHOICES` which was exclusively used by `admitted_to`.

This change would be an addition to fix https://github.com/coronasafe/care_fe/issues/2642 since the search filter there (Last Admitted to (Bed Type)) points to this deprecated and removed attribute.

Also some formatting issues by pre-commit-hooks

Frontend change: https://github.com/coronasafe/care_fe/pull/2659

closes #911 