### PR TITLE
update patient bed switching logic

### DIFF
--- a/care/facility/api/serializers/bed.py
+++ b/care/facility/api/serializers/bed.py
@@ -125,14 +125,15 @@ class ConsultationBedSerializer(ModelSerializer):
     def create(self, validated_data):
         consultation = validated_data["consultation"]
         bed = validated_data["bed"]
-        current_bed = consultation.current_bed.bed if consultation.current_bed else None
+
         existing_beds = ConsultationBed.objects.filter(
-            consultation=consultation,
-            bed=current_bed,
-            end_date__isnull=True,
-        )
+            consultation=consultation, end_date__isnull=True)
+        if existing_beds.filter(bed=bed).exists():
+            raise ValidationError({"Bed:": ["Bed already in use by patient"]})
         existing_beds.update(end_date=validated_data["start_date"])
+
         obj = super().create(validated_data)
-        consultation.current_bed = obj  # This needs better logic, when an update occurs and the latest bed is no longer the last bed consultation relation added.
+        # This needs better logic, when an update occurs and the latest bed is no longer the last bed consultation relation added.
+        consultation.current_bed = obj
         consultation.save(update_fields=["current_bed"])
         return obj

--- a/care/facility/api/serializers/bed.py
+++ b/care/facility/api/serializers/bed.py
@@ -130,12 +130,12 @@ class ConsultationBedSerializer(ModelSerializer):
             raise ValidationError(
                 {"patient:": ["Patient is already discharged from CARE"]})
 
-        existing_beds = ConsultationBed.objects.filter(
-            consultation=consultation, end_date__isnull=True)
+        occupied_beds = ConsultationBed.objects.filter(end_date__isnull=True)
 
-        if existing_beds.filter(bed=bed).exists():
+        if occupied_beds.filter(bed=bed).exists():
             raise ValidationError({"bed:": ["Bed already in use by patient"]})
-        existing_beds.update(end_date=validated_data["start_date"])
+
+        occupied_beds.filter(consultation=consultation).update(end_date=validated_data["start_date"])
 
         # This needs better logic, when an update occurs and the latest bed is no longer the last bed consultation relation added.
         obj = super().create(validated_data)


### PR DESCRIPTION
Prevent patients from switching to the same bed during consultation while the previous one hasn't ended.
fixes: #850 
fixes: #847 (both are similar/related issues)