### PR TITLE
Fix unused network in docker-compose and removes unnecessary port bindings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,6 @@ build:
 	docker-compose -f $(docker_config_file) build
 
 up:
-	docker network inspect care >/dev/null 2>&1 || \
-		docker network create care 
 	docker-compose -f $(docker_config_file) up -d
 
 down:

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -11,8 +11,6 @@ services:
     restart: always
     env_file:
       - ./docker/.local.env
-    ports:
-      - "5432:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
 
@@ -35,8 +33,6 @@ services:
     container_name: care_redis
     image: redis:alpine
     restart: always
-    ports:
-      - "6379:6379"
 
   celery:
     container_name: care_celery
@@ -59,8 +55,6 @@ services:
       - AWS_DEFAULT_REGION=ap-south-1
       - EDGE_PORT=4566
       - SERVICES=s3
-    ports:
-      - '4566:4566'
     volumes:
       - "${TEMPDIR:-/tmp/localstack}:/tmp/localstack"
       - "./docker/awslocal:/docker-entrypoint-initaws.d"

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -1,5 +1,9 @@
 version: '3.4'
 
+networks:
+  default:
+    name: care
+
 services:
   db:
     container_name: care_db


### PR DESCRIPTION
Closes #886 

- [x] Removes network creation from Makefile and let compose itself handle it.
- [x] Removes unnecessary port bindings.

Now only `care` service's port is bound to the host.

![image](https://user-images.githubusercontent.com/25143503/175478625-0c1b6bf6-bd7a-4357-8b94-d6b787b86e48.png)
