### PR TITLE
Fix validation while Shifting Bed

### DIFF
--- a/care/facility/api/serializers/bed.py
+++ b/care/facility/api/serializers/bed.py
@@ -31,8 +31,12 @@ class BedSerializer(ModelSerializer):
     def validate(self, attrs):
         user = self.context["request"].user
         if "location" in attrs and "facility" in attrs:
-            location = get_object_or_404(AssetLocation.objects.filter(external_id=attrs["location"]))
-            facility = get_object_or_404(Facility.objects.filter(external_id=attrs["facility"]))
+            location = get_object_or_404(
+                AssetLocation.objects.filter(external_id=attrs["location"])
+            )
+            facility = get_object_or_404(
+                Facility.objects.filter(external_id=attrs["facility"])
+            )
             facilities = get_facility_queryset(user)
             if (not facilities.filter(id=location.facility.id).exists()) or (
                 not facilities.filter(id=facility.id).exists()
@@ -42,7 +46,9 @@ class BedSerializer(ModelSerializer):
             attrs["location"] = location
             attrs["facility"] = facility
         else:
-            raise ValidationError({"location": "Field is Required", "facility": "Field is Required"})
+            raise ValidationError(
+                {"location": "Field is Required", "facility": "Field is Required"}
+            )
         return super().validate(attrs)
 
 
@@ -66,16 +72,20 @@ class AssetBedSerializer(ModelSerializer):
             asset = get_object_or_404(Asset.objects.filter(external_id=attrs["asset"]))
             bed = get_object_or_404(Bed.objects.filter(external_id=attrs["bed"]))
             facilities = get_facility_queryset(user)
-            if (not facilities.filter(id=asset.current_location.facility.id).exists()) or (
-                not facilities.filter(id=bed.facility.id).exists()
-            ):
+            if (
+                not facilities.filter(id=asset.current_location.facility.id).exists()
+            ) or (not facilities.filter(id=bed.facility.id).exists()):
                 raise PermissionError()
             attrs["asset"] = asset
             attrs["bed"] = bed
             if asset.current_location.facility.id != bed.facility.id:
-                raise ValidationError({"asset": "Should be in the same facility as the bed"})
+                raise ValidationError(
+                    {"asset": "Should be in the same facility as the bed"}
+                )
         else:
-            raise ValidationError({"asset": "Field is Required", "bed": "Field is Required"})
+            raise ValidationError(
+                {"asset": "Field is Required", "bed": "Field is Required"}
+            )
         return super().validate(attrs)
 
 
@@ -84,8 +94,12 @@ class ConsultationBedSerializer(ModelSerializer):
 
     bed_object = BedSerializer(source="bed", read_only=True)
 
-    consultation = ExternalIdSerializerField(queryset=PatientConsultation.objects.all(), write_only=True, required=True)
-    bed = ExternalIdSerializerField(queryset=Bed.objects.all(), write_only=True, required=True)
+    consultation = ExternalIdSerializerField(
+        queryset=PatientConsultation.objects.all(), write_only=True, required=True
+    )
+    bed = ExternalIdSerializerField(
+        queryset=Bed.objects.all(), write_only=True, required=True
+    )
 
     class Meta:
         model = ConsultationBed
@@ -98,30 +112,48 @@ class ConsultationBedSerializer(ModelSerializer):
             bed = attrs["bed"]
             facilities = get_facility_queryset(user)
             permitted_consultations = get_consultation_queryset(user)
-            consultation = get_object_or_404(permitted_consultations.filter(id=attrs["consultation"].id))
+            consultation = get_object_or_404(
+                permitted_consultations.filter(id=attrs["consultation"].id)
+            )
             if not facilities.filter(id=bed.facility.id).exists():
                 raise PermissionError()
             if consultation.facility.id != bed.facility.id:
-                raise ValidationError({"consultation": "Should be in the same facility as the bed"})
+                raise ValidationError(
+                    {"consultation": "Should be in the same facility as the bed"}
+                )
             start_date = attrs["start_date"]
             end_date = attrs.get("end_date", None)
-            existing_qs = ConsultationBed.objects.filter(consultation=consultation, bed=bed)
-            latest_qs = ConsultationBed.objects.filter(consultation=consultation).latest("id")
+            existing_qs = ConsultationBed.objects.filter(
+                consultation=consultation, bed=bed
+            )
+            latest_qs = ConsultationBed.objects.filter(
+                consultation=consultation
+            ).latest("id")
             # Validations based of the latest entry
             if latest_qs.exists():
                 if latest_qs.bed == bed:
-                        raise ValidationError({"bed": "Bed is already in use"})
+                    raise ValidationError({"bed": "Bed is already in use"})
                 if start_date < latest_qs.start_date:
-                    raise ValidationError({"start_date": "Start date cannot be before the latest start date"})
+                    raise ValidationError(
+                        {
+                            "start_date": "Start date cannot be before the latest start date"
+                        }
+                    )
                 if end_date and end_date < latest_qs.start_date:
-                    raise ValidationError({"end_date": "End date cannot be before the latest start date"})
+                    raise ValidationError(
+                        {"end_date": "End date cannot be before the latest start date"}
+                    )
             existing_qs = ConsultationBed.objects.filter(consultation=consultation)
             # Conflict checking logic
             if existing_qs.filter(start_date__gt=start_date).exists():
                 raise ValidationError({"start_date": "Cannot create conflicting entry"})
             if end_date:
-                if existing_qs.filter(start_date__gt=end_date, end_date__lt=end_date).exists():
-                    raise ValidationError({"end_date": "Cannot create conflicting entry"})
+                if existing_qs.filter(
+                    start_date__gt=end_date, end_date__lt=end_date
+                ).exists():
+                    raise ValidationError(
+                        {"end_date": "Cannot create conflicting entry"}
+                    )
         else:
             raise ValidationError(
                 {
@@ -138,14 +170,17 @@ class ConsultationBedSerializer(ModelSerializer):
 
         if not consultation.patient.is_active:
             raise ValidationError(
-                {"patient:": ["Patient is already discharged from CARE"]})
+                {"patient:": ["Patient is already discharged from CARE"]}
+            )
 
         occupied_beds = ConsultationBed.objects.filter(end_date__isnull=True)
 
         if occupied_beds.filter(bed=bed).exists():
             raise ValidationError({"bed:": ["Bed already in use by patient"]})
 
-        occupied_beds.filter(consultation=consultation).update(end_date=validated_data["start_date"])
+        occupied_beds.filter(consultation=consultation).update(
+            end_date=validated_data["start_date"]
+        )
 
         # This needs better logic, when an update occurs and the latest bed is no longer the last bed consultation relation added.
         obj = super().create(validated_data)

--- a/care/facility/api/serializers/bed.py
+++ b/care/facility/api/serializers/bed.py
@@ -126,11 +126,10 @@ class ConsultationBedSerializer(ModelSerializer):
             existing_qs = ConsultationBed.objects.filter(
                 consultation=consultation, bed=bed
             )
-            latest_qs = ConsultationBed.objects.filter(
-                consultation=consultation
-            ).latest("id")
+            qs = ConsultationBed.objects.filter(consultation=consultation)
             # Validations based of the latest entry
-            if latest_qs.exists():
+            if qs.exists():
+                latest_qs = qs.latest("id")
                 if latest_qs.bed == bed:
                     raise ValidationError({"bed": "Bed is already in use"})
                 if start_date < latest_qs.start_date:


### PR DESCRIPTION
Fixes https://github.com/coronasafe/care_fe/issues/3072

The validation logic while shifting beds was recently updated in https://github.com/coronasafe/care/pull/731 , which included a query to check if any `ConsultationBed` exist and fetch the latest one.

This change fixes the way the existence of the object is checked.  

exists() [is a method of a QuerySet](https://docs.djangoproject.com/en/dev/ref/models/querysets/#django.db.models.query.QuerySet.exists) and hence would raise an Exception when called on latest object itself fetched from the `.latest()`  method.

Now, the existence is checked first then the latest object is fetched, if exists.

```
qs = ConsultationBed.objects.filter(consultation=consultation)
# Validations based of the latest entry
if qs.exists():
    latest_qs = qs.latest("id")
```