### PR TITLE
add ONVIF action to get streaming token

### DIFF
--- a/care/utils/assetintegration/base.py
+++ b/care/utils/assetintegration/base.py
@@ -21,8 +21,8 @@ class BaseAssetIntegration:
             protocol += "s"
         return f"{protocol}://{self.middleware_hostname}/{endpoint}"
 
-    def api_post(self, url, data=None):
-        req = requests.post(url, json=data)
+    def api_post(self, url, data=None, headers={}):
+        req = requests.post(url, json=data, headers=headers)
         try:
             response = req.json()
             if req.status_code >= 400:
@@ -31,8 +31,8 @@ class BaseAssetIntegration:
         except json.decoder.JSONDecodeError as e:
             return {"error": "Invalid Response"}
 
-    def api_get(self, url, data=None):
-        req = requests.get(url, params=data)
+    def api_get(self, url, data=None, headers={}):
+        req = requests.get(url, params=data, headers=headers)
         try:
             response = req.json()
             if req.status_code >= 400:

--- a/care/utils/assetintegration/onvif.py
+++ b/care/utils/assetintegration/onvif.py
@@ -14,6 +14,7 @@ class OnvifAsset(BaseAssetIntegration):
         GOTO_PRESET = "goto_preset"
         ABSOLUTE_MOVE = "absolute_move"
         RELATIVE_MOVE = "relative_move"
+        GET_STREAM_TOKEN = "get_streaming_token"
 
     def __init__(self, meta):
         try:
@@ -26,7 +27,7 @@ class OnvifAsset(BaseAssetIntegration):
             raise ValidationError(
                 dict((key, f"{key} not found in asset metadata") for key in e.args))
 
-    def handle_action(self, action):
+    def handle_action(self, action, client_headers={}):
         action_type = action["type"]
         action_data = action.get("data", {})
 
@@ -53,5 +54,8 @@ class OnvifAsset(BaseAssetIntegration):
 
         if action_type == self.OnvifActions.RELATIVE_MOVE.value:
             return self.api_post(self.get_url("relativeMove"), request_body)
+
+        if action_type == self.OnvifActions.GET_STREAM_TOKEN.value:
+            return self.api_post(self.get_url("get_streaming_token"), request_body, client_headers)
 
         raise ValidationError({"action": "invalid action type"})


### PR DESCRIPTION
Add ONVIF asset action to get streaming token from middleware server.

Note: API is yet to be implemented in the middleware.