### PR TITLE
Fix permission issue when deleting users

### DIFF
--- a/care/users/api/viewsets/users.py
+++ b/care/users/api/viewsets/users.py
@@ -139,12 +139,12 @@ class UserViewSet(
             pass
         elif request.user.user_type >= User.TYPE_VALUE_MAP["StateLabAdmin"]:
             queryset = queryset.filter(
-                state=request.user.state, user_type__lte=User.TYPE_VALUE_MAP["StateAdmin"], is_superuser=False,
+                state=request.user.state, user_type__lt=User.TYPE_VALUE_MAP["StateAdmin"], is_superuser=False,
             )
         elif request.user.user_type >= User.TYPE_VALUE_MAP["DistrictLabAdmin"]:
             queryset = queryset.filter(
                 district=request.user.district,
-                user_type__lte=User.TYPE_VALUE_MAP["DistrictAdmin"],
+                user_type__lt=User.TYPE_VALUE_MAP["DistrictAdmin"],
                 is_superuser=False,
             )
         else:


### PR DESCRIPTION
Fixes https://github.com/coronasafe/care_fe/issues/3355

This PR fixes a permission check issue when deleting users. The user should only be allowed to delete other users strictly below its  permission level. 

This also fixes the issue where the user was able to delete its own account.