### PR TITLE
Fix CSV export for patients

### DIFF
--- a/care/facility/models/patient.py
+++ b/care/facility/models/patient.py
@@ -430,8 +430,6 @@ class PatientRegistration(PatientBaseModel, PatientPermissionMixin):
         "nationality": "Nationality",
         "disease_status": "Disease Status",
         # "state_test_id": "State Test ID",
-        "last_consultation__admitted": "Admission Status",
-        "last_consultation__admitted_to": "Admission Room Type",
         # Reffered or transferred
         # remarks
         "number_of_aged_dependents": "Number of people aged above 60 living with the patient",


### PR DESCRIPTION
The commit https://github.com/coronasafe/care/commit/9277da54831c510b580b79f4399a454af95f017e#diff-5f86d36c9415c5c40e8820c1e4f86aa28dd713d6a74a1adc1f387598b8b542b9L66 removed `admitted_to` from Patient Consultation. 

However, the CSV export still references it, this causes patient exports to fail since this attribute no longer exists. This PR removes that attribute from CSV Columns. It also removes the `admitted` attribute, which is marked deprecated. ([patient_consultation.py#L65](https://github.com/coronasafe/care/blob/master/care/facility/models/patient_consultation.py#L65))