### PR TITLE
Prevent removal of user's home facility

### DIFF
--- a/care/users/api/viewsets/users.py
+++ b/care/users/api/viewsets/users.py
@@ -231,6 +231,8 @@ class UserViewSet(
             raise ValidationError({"facility": "Facility Access not Present"})
         if not self.has_facility_permission(user, facility):
             raise ValidationError({"facility": "Intended User Does not have permission to this facility"})
+        if user.home_facility == facility:
+            raise ValidationError({"facility": "Cannot Delete User's Home Facility"})
         FacilityUser.objects.filter(facility=facility, user=user).delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
Fixes https://github.com/coronasafe/care_fe/issues/3319

This PR adds a check so that the user's home facility can not be unassigned accidently.

![image](https://user-images.githubusercontent.com/3626859/183910116-a2fb701d-ba5b-40c5-a8b6-42bac4a08958.png)
