### PR TITLE
add update and delete apis for consultation files

### DIFF
--- a/care/facility/api/serializers/file_upload.py
+++ b/care/facility/api/serializers/file_upload.py
@@ -106,6 +106,15 @@ class FileUploadListSerializer(serializers.ModelSerializer):
         read_only_fields = ("associating_id", "name", "created_date")
 
 
+class FileUploadUpdateSerializer(serializers.ModelSerializer):
+
+    id = serializers.UUIDField(source="external_id", read_only=True)
+
+    class Meta:
+        model = FileUpload
+        fields = ("id", "name")
+
+
 class FileUploadRetrieveSerializer(serializers.ModelSerializer):
 
     id = serializers.UUIDField(source="external_id", read_only=True)

--- a/care/facility/api/viewsets/file_upload.py
+++ b/care/facility/api/viewsets/file_upload.py
@@ -14,6 +14,7 @@ from care.facility.api.serializers.file_upload import (
     FileUploadCreateSerializer,
     FileUploadListSerializer,
     FileUploadRetrieveSerializer,
+    FileUploadUpdateSerializer,
     check_permissions,
 )
 from care.facility.models.file_upload import FileUpload
@@ -37,8 +38,10 @@ class FileUploadViewSet(
             return FileUploadRetrieveSerializer
         elif self.action == "list":
             return FileUploadListSerializer
-        else:
+        elif self.action =="create":
             return FileUploadCreateSerializer
+        else:
+            return FileUploadUpdateSerializer
 
     def get_queryset(self):
         if "file_type" not in self.request.GET:

--- a/care/facility/api/viewsets/file_upload.py
+++ b/care/facility/api/viewsets/file_upload.py
@@ -1,6 +1,12 @@
-from django.core.exceptions import ValidationError
 from django_filters import rest_framework as filters
-from rest_framework.mixins import CreateModelMixin, ListModelMixin, RetrieveModelMixin
+from rest_framework.exceptions import ValidationError
+from rest_framework.mixins import (
+    CreateModelMixin,
+    DestroyModelMixin,
+    ListModelMixin,
+    RetrieveModelMixin,
+    UpdateModelMixin,
+)
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import GenericViewSet
 
@@ -18,7 +24,7 @@ class FileUploadFilter(filters.FilterSet):
 
 
 class FileUploadViewSet(
-    CreateModelMixin, RetrieveModelMixin, ListModelMixin, GenericViewSet,
+    CreateModelMixin, RetrieveModelMixin, ListModelMixin, UpdateModelMixin, DestroyModelMixin, GenericViewSet,
 ):
     queryset = FileUpload.objects.all().select_related("uploaded_by").order_by("-created_date")
     permission_classes = [IsAuthenticated]
@@ -27,22 +33,24 @@ class FileUploadViewSet(
     filterset_class = FileUploadFilter
 
     def get_serializer_class(self):
-        if self.action == "create":
-            return FileUploadCreateSerializer
+        if self.action == "retrieve":
+            return FileUploadRetrieveSerializer
         elif self.action == "list":
             return FileUploadListSerializer
-        elif self.action == "retrieve":
-            return FileUploadRetrieveSerializer
         else:
-            raise Exception()
+            return FileUploadCreateSerializer
 
     def get_queryset(self):
-        if "file_type" not in self.request.GET or "associating_id" not in self.request.GET:
-            raise ValidationError("Bad Request")
+        if "file_type" not in self.request.GET:
+            raise ValidationError({"file_type": "file_type missing in request params"})
+        if "associating_id" not in self.request.GET:
+            raise ValidationError(
+                {"associating_id": "associating_id missing in request params"})
         file_type = self.request.GET["file_type"]
         associating_id = self.request.GET["associating_id"]
         if file_type not in FileUpload.FileType.__members__:
-            raise ValidationError("Bad Request")
+            raise ValidationError({"file_type": "invalid file type"})
         file_type = FileUpload.FileType[file_type].value
-        associating_internal_id = check_permissions(file_type, associating_id, self.request.user)
+        associating_internal_id = check_permissions(
+            file_type, associating_id, self.request.user)
         return self.queryset.filter(file_type=file_type, associating_id=associating_internal_id)

--- a/care/facility/models/file_upload.py
+++ b/care/facility/models/file_upload.py
@@ -47,14 +47,13 @@ class FileUpload(FacilityBaseModel):
     )
 
     def save(self, *args, **kwargs):
-        if "force_insert" in kwargs or (not self.internal_name):
-            internal_name = str(uuid4()) + str(int(time.time()))
-            if self.internal_name:
-                parts = self.internal_name.split(".")
-                if len(parts) > 1:
-                    internal_name = internal_name + "." + parts[-1]
-            self.internal_name = internal_name
-            return super().save(*args, **kwargs)
+        internal_name = str(uuid4()) + str(int(time.time()))
+        if self.internal_name:
+            parts = self.internal_name.split(".")
+            if len(parts) > 1:
+                internal_name = internal_name + "." + parts[-1]
+        self.internal_name = internal_name
+        return super().save(*args, **kwargs)
 
     def signed_url(self):
         s3Client = boto3.client("s3", **cs_provider.get_client_config())

--- a/care/facility/models/file_upload.py
+++ b/care/facility/models/file_upload.py
@@ -47,12 +47,13 @@ class FileUpload(FacilityBaseModel):
     )
 
     def save(self, *args, **kwargs):
-        internal_name = str(uuid4()) + str(int(time.time()))
-        if self.internal_name:
-            parts = self.internal_name.split(".")
-            if len(parts) > 1:
-                internal_name = internal_name + "." + parts[-1]
-        self.internal_name = internal_name
+        if "force_insert" in kwargs or (not self.internal_name):
+            internal_name = str(uuid4()) + str(int(time.time()))
+            if self.internal_name:
+                parts = self.internal_name.split(".")
+                if len(parts) > 1:
+                    internal_name = internal_name + "." + parts[-1]
+            self.internal_name = internal_name
         return super().save(*args, **kwargs)
 
     def signed_url(self):


### PR DESCRIPTION
## Proposed Changes

- Create APIs for updating and deleting the consultation files.
- Improve error handling for invalid requests (initially giving internal server errors).

@coronasafe/code-reviewers
fixes: #973 
