### PR TITLE
Add public asset fetch endpoint

### DIFF
--- a/care/facility/api/serializers/asset.py
+++ b/care/facility/api/serializers/asset.py
@@ -1,4 +1,5 @@
 from re import L
+from django.core.cache import cache
 from django.db import transaction
 from django.shortcuts import get_object_or_404
 from rest_framework.exceptions import ValidationError
@@ -74,6 +75,11 @@ class AssetSerializer(ModelSerializer):
                 ).save()
             updated_instance = super().update(instance, validated_data)
         return updated_instance
+
+    def save(self, **kwargs):
+        cache_key = "asset:" + str(self.instance.external_id)
+        cache.delete(cache_key)
+        return super().save(**kwargs)
 
 
 class AssetBareMinimumSerializer(ModelSerializer):

--- a/care/facility/api/viewsets/asset.py
+++ b/care/facility/api/viewsets/asset.py
@@ -102,7 +102,6 @@ class AssetPublicViewSet(RetrieveModelMixin, GenericViewSet):
     queryset = Asset.objects.all()
     serializer_class = AssetSerializer
     lookup_field = "external_id"
-    filter_backends = (filters.DjangoFilterBackend, drf_filters.SearchFilter)
     permission_classes = [IsAuthenticatedOrReadOnly]
     
 class AssetViewSet(

--- a/care/facility/api/viewsets/asset.py
+++ b/care/facility/api/viewsets/asset.py
@@ -14,7 +14,7 @@ from rest_framework.mixins import (
     RetrieveModelMixin,
     UpdateModelMixin,
 )
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 from rest_framework.serializers import CharField, JSONField, Serializer, UUIDField
 from rest_framework.viewsets import GenericViewSet
@@ -98,6 +98,13 @@ class AssetFilter(filters.FilterSet):
     qr_code_id = filters.CharFilter(field_name="qr_code_id", lookup_expr="icontains")
 
 
+class AssetPublicViewSet(RetrieveModelMixin, GenericViewSet):
+    queryset = Asset.objects.all()
+    serializer_class = AssetSerializer
+    lookup_field = "external_id"
+    filter_backends = (filters.DjangoFilterBackend, drf_filters.SearchFilter)
+    permission_classes = [IsAuthenticatedOrReadOnly]
+    
 class AssetViewSet(
     ListModelMixin,
     RetrieveModelMixin,

--- a/care/facility/api/viewsets/asset.py
+++ b/care/facility/api/viewsets/asset.py
@@ -15,7 +15,7 @@ from rest_framework.mixins import (
     RetrieveModelMixin,
     UpdateModelMixin,
 )
-from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.serializers import CharField, JSONField, Serializer, UUIDField
 from rest_framework.viewsets import GenericViewSet

--- a/config/api_router.py
+++ b/config/api_router.py
@@ -11,6 +11,7 @@ from care.facility.api.viewsets.asset import (
     AssetLocationViewSet,
     AssetTransactionViewSet,
     AssetViewSet,
+    AssetPublicViewSet
 )
 from care.facility.api.viewsets.bed import (
     AssetBedViewSet,
@@ -186,6 +187,9 @@ consultation_nested_router = NestedSimpleRouter(
     router, r"consultation", lookup="consultation")
 consultation_nested_router.register(r"daily_rounds", DailyRoundsViewSet)
 consultation_nested_router.register(r"investigation", InvestigationValueViewSet)
+
+# Public endpoints
+router.register("public/asset", AssetPublicViewSet)
 
 app_name = "api"
 urlpatterns = [


### PR DESCRIPTION
Fixes https://github.com/coronasafe/care_fe/issues/3480

As per the discussion with @gigincg , This PR adds a new public API endpoint for retrieving an asset by it's external ID. 

This endpoint can later be used to serve the asset details on a public page which can be referred to by the QR code. 

`GET public/asset/<id>`  - Returns the details of the asset identified by it's external id.

It includes only fetching a particular asset and does not allow any other operations including listing.

```
curl -D - "http://127.0.0.1:8000/api/v1/public/asset/b8b71bff-7cf0-4fad-9180-7fc79f2b060d/"
HTTP/1.1 200 OK
Date: Sat, 03 Sep 2022 18:29:22 GMT
Server: WSGIServer/0.2 CPython/3.10.4
Content-Type: application/json
Vary: Accept, Accept-Language, Cookie, Origin
Allow: GET, HEAD, OPTIONS
X-Frame-Options: DENY
Content-Length: 832
Content-Language: en
X-XSS-Protection: 1; mode=block

{"id":"b8b71bff-7cf0-4fad-9180-7fc79f2b060d","status":"ACTIVE","asset_type":"INTERNAL","location_object":{"id":"cce9bf87-4525-4d2e-85ca-e2164e8b4261","facility":{"id":"4a3dbe9c-8d1b-4dc1-b939-237d79d96233","name":"Hero Health Center"},"created_date":"2022-05-19T16:07:17.203203+05:30","modified_date":"2022-05-25T01:57:12.982253+05:30","name":"Loc 2","description":"","location_type":1},"created_date":"2022-05-25T01:55:51.295497+05:30","modified_date":"2022-09-03T13:58:19.823531+05:30","name":"Testttttt122","description":"","asset_class":"","is_working":true,"not_working_reason":"","serial_number":"","warranty_details":"","meta":{},"vendor_name":"","support_name":"","support_phone":"+916655877888","support_email":"","qr_code_id":null,"manufacturer":null,"warranty_amc_end_of_validity":null,"last_serviced_on":null,"notes":""}
```

```
curl -D - "http://127.0.0.1:8000/api/v1/public/asset/random-random/"
HTTP/1.1 404 Not Found
Date: Sat, 03 Sep 2022 18:29:19 GMT
Server: WSGIServer/0.2 CPython/3.10.4
Content-Type: application/json
Vary: Accept, Accept-Language, Cookie, Origin
Allow: GET, HEAD, OPTIONS
X-Frame-Options: DENY
Content-Length: 23
Content-Language: en
X-XSS-Protection: 1; mode=block

{"detail":"Not found."}
```
