### PR TITLE
add dry permissions for facility cover_image

### DIFF
--- a/care/facility/models/facility.py
+++ b/care/facility/models/facility.py
@@ -168,7 +168,9 @@ class Facility(FacilityBaseModel, FacilityPermissionMixin):
         verbose_name_plural = "Facilities"
 
     def read_cover_image_url(self):
-        return settings.FACILITY_S3_STATIC_PREFIX + (self.cover_image_url or "")
+        if self.cover_image_url:
+            return settings.FACILITY_S3_STATIC_PREFIX + self.cover_image_url
+        return None
 
     def __str__(self):
         return f"{self.name}"


### PR DESCRIPTION
Fix was to add object level dry permissions for cover_image route and relaxing model level permissions as we weren't sending district, state or lsb fields

The code was also refactored to improve api documentation