### PR TITLE
Deprecates text field `warranty_details` of Asset

### DIFF
--- a/care/facility/models/asset.py
+++ b/care/facility/models/asset.py
@@ -60,10 +60,7 @@ class Asset(BaseModel):
     is_working = models.BooleanField(default=None, null=True, blank=True)
     not_working_reason = models.CharField(max_length=1024, blank=True, null=True)
     serial_number = models.CharField(max_length=1024, blank=True, null=True)
-    warranty_details = models.TextField(null=True, blank=True, default="")
-    """
-    Deprecated as fields that are more specific related to warranty are present.
-    """
+    warranty_details = models.TextField(null=True, blank=True, default="")  # Deprecated
     meta = JSONField(default=dict, blank=True, validators=[JSONFieldSchemaValidator(ASSET_META)])
     # Vendor Details
     vendor_name = models.CharField(max_length=1024, blank=True, null=True)

--- a/care/facility/models/asset.py
+++ b/care/facility/models/asset.py
@@ -61,6 +61,9 @@ class Asset(BaseModel):
     not_working_reason = models.CharField(max_length=1024, blank=True, null=True)
     serial_number = models.CharField(max_length=1024, blank=True, null=True)
     warranty_details = models.TextField(null=True, blank=True, default="")
+    """
+    Deprecated as fields that are more specific related to warranty are present.
+    """
     meta = JSONField(default=dict, blank=True, validators=[JSONFieldSchemaValidator(ASSET_META)])
     # Vendor Details
     vendor_name = models.CharField(max_length=1024, blank=True, null=True)


### PR DESCRIPTION
Follow up of #984 

Marks text field warranty_details as deprecated.

**Reason:**
More specific fields related to warranty was added in #984 