### PR TITLE
Clear asset cache only when updating an existing asset

### DIFF
--- a/care/facility/api/serializers/asset.py
+++ b/care/facility/api/serializers/asset.py
@@ -1,4 +1,5 @@
 from re import L
+
 from django.core.cache import cache
 from django.db import transaction
 from django.shortcuts import get_object_or_404
@@ -77,8 +78,9 @@ class AssetSerializer(ModelSerializer):
         return updated_instance
 
     def save(self, **kwargs):
-        cache_key = "asset:" + str(self.instance.external_id)
-        cache.delete(cache_key)
+        if self.instance:
+            cache_key = "asset:" + str(self.instance.external_id)
+            cache.delete(cache_key)
         return super().save(**kwargs)
 
 


### PR DESCRIPTION
Fixes https://github.com/coronasafe/care_fe/issues/3561

This fixes a bug where it would try to clear the cache for a newly created asset on `save`. Now the cache is only deleted if the `save` was triggered on a pre-existing asset object.

@coronasafe/code-reviewers
