### PR TITLE
Add serializer constraints to AssetBed

### DIFF
--- a/care/facility/api/serializers/bed.py
+++ b/care/facility/api/serializers/bed.py
@@ -82,6 +82,23 @@ class AssetBedSerializer(ModelSerializer):
                 raise ValidationError(
                     {"asset": "Should be in the same facility as the bed"}
                 )
+
+            if asset.asset_class == "HL7MONITOR" and asset.bed_set.all().count() > 1:
+                raise ValidationError(
+                    {
+                        "asset": "HL7Monitor Assets can have only 1 Bed Associated with them"
+                    }
+                )
+            elif (
+                asset.asset_class != "HL7MONITOR"
+                and asset.asset_class != "ONVIF"
+                and asset.bed_set.all().count() > 0
+            ):
+                raise ValidationError(
+                    {
+                        "asset": "Assets that are neither HL7Monitor nor ONVIFCamera should not have Bed Relations"
+                    }
+                )
         else:
             raise ValidationError(
                 {"asset": "Field is Required", "bed": "Field is Required"}


### PR DESCRIPTION
Fixes issue #934 

## Proposed Changes
AssetBed Serializer was updated to validate the following constraints:
* HL7Monitor Assets can have only 1 Bed Associated with it.
* Assets that are neither HL7Monitor nor ONVIFCamera should not have Bed Relations

@coronasafe/code-reviewers

## Merge Checklist

- [x] Request for Peer Reviews
- [x] Completion of QA
