### PR TITLE
Send pretty details when password reset fails

### DIFF
--- a/care/users/reset_password_views.py
+++ b/care/users/reset_password_views.py
@@ -52,7 +52,7 @@ class ResetPasswordConfirm(GenericAPIView):
         reset_password_token = ResetPasswordToken.objects.filter(key=token).first()
 
         if reset_password_token is None:
-            return Response({"status": "notfound"}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"status": "notfound", "detail": "The password reset link is invalid" }, status=status.HTTP_404_NOT_FOUND)
 
         # check expiry date
         expiry_date = reset_password_token.created_at + timedelta(hours=password_reset_token_validation_time)
@@ -60,7 +60,7 @@ class ResetPasswordConfirm(GenericAPIView):
         if timezone.now() > expiry_date:
             # delete expired token
             reset_password_token.delete()
-            return Response({"status": "expired"}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"status": "expired", "detail": "The password reset link has expired" }, status=status.HTTP_404_NOT_FOUND)
 
         # change users password (if we got to this code it means that the user is_active)
         if reset_password_token.user.eligible_for_reset():


### PR DESCRIPTION
## Proposed Changes

- This sends a pretty message to the frontend whenever a password reset attempt fails.
- The frontend expects the `detail` field on 4xx error, instead of adding a special case for this, it's better to follow the standard and send a `detail` when the reset fails from the backend itself.

### Associated Issue
  - Fixes https://github.com/coronasafe/care_fe/issues/3120

@coronasafe/code-reviewers

![image](https://user-images.githubusercontent.com/3626859/191081652-81f66588-d172-4c50-adf5-5151fea7a118.png)

![image](https://user-images.githubusercontent.com/3626859/191081817-7fffe1cd-bd25-49a6-8ad5-440bdcdfadea.png)
