### PR TITLE
fix: update of last_daily_round on auto log update

### DIFF
--- a/care/facility/api/serializers/daily_round.py
+++ b/care/facility/api/serializers/daily_round.py
@@ -37,7 +37,9 @@ class DailyRoundSerializer(serializers.ModelSerializer):
     current_health = ChoiceField(choices=CURRENT_HEALTH_CHOICES, required=False)
 
     action = ChoiceField(
-        choices=PatientRegistration.ActionChoices, write_only=True, required=False
+        choices=PatientRegistration.ActionChoices,
+        write_only=True,
+        required=False,
     )
     review_interval = serializers.IntegerField(default=-1, required=False)
 
@@ -197,7 +199,6 @@ class DailyRoundSerializer(serializers.ModelSerializer):
                     cloned_daily_round_obj.modified_date = timezone.now()
                     cloned_daily_round_obj.external_id = uuid4()
                     cloned_daily_round_obj.save()
-                    self.update_last_daily_round(cloned_daily_round_obj)
                     return self.update(cloned_daily_round_obj, validated_data)
 
             if "action" in validated_data or "review_interval" in validated_data:


### PR DESCRIPTION
# Bug Fix

## Proposed Changes

- Removed update of the daily round on cloned log update

## Associated Issue

- Fixes https://github.com/coronasafe/care/issues/1061

@coronasafe/code-reviewers
