### PR TITLE
Added is_occupied read-only field in Bed

### DIFF
--- a/care/facility/api/serializers/bed.py
+++ b/care/facility/api/serializers/bed.py
@@ -1,6 +1,6 @@
 from django.shortcuts import get_object_or_404
 from rest_framework.exceptions import ValidationError
-from rest_framework.serializers import ModelSerializer, UUIDField
+from rest_framework.serializers import BooleanField, ModelSerializer, UUIDField
 
 from care.facility.api.serializers import TIMESTAMP_FIELDS
 from care.facility.api.serializers.asset import AssetLocationSerializer, AssetSerializer
@@ -20,6 +20,7 @@ class BedSerializer(ModelSerializer):
     bed_type = ChoiceField(choices=BedTypeChoices)
 
     location_object = AssetLocationSerializer(source="location", read_only=True)
+    is_occupied = BooleanField(default=False, read_only=True)
 
     location = UUIDField(write_only=True, required=True)
     facility = UUIDField(write_only=True, required=True)

--- a/care/facility/models/bed.py
+++ b/care/facility/models/bed.py
@@ -30,6 +30,10 @@ class Bed(BaseModel):
         AssetLocation, on_delete=models.PROTECT, null=False, blank=False
     )
 
+    @property
+    def is_occupied(self) -> bool:
+        return ConsultationBed.objects.filter(bed=self, end_date__isnull=True).exists()
+
     def __str__(self):
         return self.name
 


### PR DESCRIPTION
Fixes #1082 

## Proposed Changes

- Added is_occupied read-only field in Bed
This is required to filter beds based on weather it is occupied or not

### Associated Issue
  - https://github.com/coronasafe/care_fe/pull/3690 (requirement mentioned here)
  - https://github.com/coronasafe/care_fe/issues/3842 (feature needed for this issue)

### Architecture changes
  - none
 
@coronasafe/code-reviewers

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
