### PR TITLE
Add endpoint to check the validity of a password reset token

### DIFF
--- a/care/users/reset_password_views.py
+++ b/care/users/reset_password_views.py
@@ -30,6 +30,37 @@ class ResetPasswordUserSerializer(serializers.Serializer):
     username = serializers.CharField()
 
 
+class ResetPasswordCheck(GenericAPIView):
+    """
+    An Api View which provides a method to check if a password reset token is valid
+    """
+
+    throttle_classes = ()
+    permission_classes = ()
+
+    def post(self, request, *args, **kwargs):
+        token = request.data.get("token", None)
+
+        # get token validation time
+        password_reset_token_validation_time = get_password_reset_token_expiry_time()
+
+        # find token
+        reset_password_token = ResetPasswordToken.objects.filter(key=token).first()
+
+        if reset_password_token is None:
+            return Response({"status": "notfound", "detail": "The password reset link is invalid" }, status=status.HTTP_404_NOT_FOUND)
+
+        # check expiry date
+        expiry_date = reset_password_token.created_at + timedelta(hours=password_reset_token_validation_time)
+
+        if timezone.now() > expiry_date:
+            # delete expired token
+            reset_password_token.delete()
+            return Response({"status": "expired", "detail": "The password reset link has expired" }, status=status.HTTP_404_NOT_FOUND)
+
+        return Response({"status": "OK"})
+
+
 class ResetPasswordConfirm(GenericAPIView):
     """
     An Api View which provides a method to reset a password based on a unique token

--- a/care/users/reset_password_views.py
+++ b/care/users/reset_password_views.py
@@ -2,7 +2,10 @@ from datetime import timedelta
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.contrib.auth.password_validation import get_password_validators, validate_password
+from django.contrib.auth.password_validation import (
+    get_password_validators,
+    validate_password,
+)
 from django.core.exceptions import ValidationError
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
@@ -12,8 +15,12 @@ from django_rest_passwordreset.models import (
     get_password_reset_lookup_field,
     get_password_reset_token_expiry_time,
 )
-from django_rest_passwordreset.serializers import PasswordTokenSerializer, TokenSerializer
-from django_rest_passwordreset.signals import post_password_reset, pre_password_reset, reset_password_token_created
+from django_rest_passwordreset.serializers import PasswordTokenSerializer
+from django_rest_passwordreset.signals import (
+    post_password_reset,
+    pre_password_reset,
+    reset_password_token_created,
+)
 from rest_framework import exceptions, serializers, status
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
@@ -22,8 +29,12 @@ from config.ratelimit import ratelimit
 
 User = get_user_model()
 
-HTTP_USER_AGENT_HEADER = getattr(settings, "DJANGO_REST_PASSWORDRESET_HTTP_USER_AGENT_HEADER", "HTTP_USER_AGENT")
-HTTP_IP_ADDRESS_HEADER = getattr(settings, "DJANGO_REST_PASSWORDRESET_IP_ADDRESS_HEADER", "REMOTE_ADDR")
+HTTP_USER_AGENT_HEADER = getattr(
+    settings, "DJANGO_REST_PASSWORDRESET_HTTP_USER_AGENT_HEADER", "HTTP_USER_AGENT"
+)
+HTTP_IP_ADDRESS_HEADER = getattr(
+    settings, "DJANGO_REST_PASSWORDRESET_IP_ADDRESS_HEADER", "REMOTE_ADDR"
+)
 
 
 class ResetPasswordUserSerializer(serializers.Serializer):
@@ -34,6 +45,7 @@ class ResetPasswordCheck(GenericAPIView):
     """
     An Api View which provides a method to check if a password reset token is valid
     """
+
     permission_classes = ()
 
     def post(self, request, *args, **kwargs):
@@ -52,15 +64,23 @@ class ResetPasswordCheck(GenericAPIView):
         reset_password_token = ResetPasswordToken.objects.filter(key=token).first()
 
         if reset_password_token is None:
-            return Response({"status": "notfound", "detail": "The password reset link is invalid" }, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"status": "notfound", "detail": "The password reset link is invalid"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
 
         # check expiry date
-        expiry_date = reset_password_token.created_at + timedelta(hours=password_reset_token_validation_time)
+        expiry_date = reset_password_token.created_at + timedelta(
+            hours=password_reset_token_validation_time
+        )
 
         if timezone.now() > expiry_date:
             # delete expired token
             reset_password_token.delete()
-            return Response({"status": "expired", "detail": "The password reset link has expired" }, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"status": "expired", "detail": "The password reset link has expired"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
 
         return Response({"status": "OK"})
 
@@ -92,25 +112,37 @@ class ResetPasswordConfirm(GenericAPIView):
         reset_password_token = ResetPasswordToken.objects.filter(key=token).first()
 
         if reset_password_token is None:
-            return Response({"status": "notfound", "detail": "The password reset link is invalid" }, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"status": "notfound", "detail": "The password reset link is invalid"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
 
         # check expiry date
-        expiry_date = reset_password_token.created_at + timedelta(hours=password_reset_token_validation_time)
+        expiry_date = reset_password_token.created_at + timedelta(
+            hours=password_reset_token_validation_time
+        )
 
         if timezone.now() > expiry_date:
             # delete expired token
             reset_password_token.delete()
-            return Response({"status": "expired", "detail": "The password reset link has expired" }, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"status": "expired", "detail": "The password reset link has expired"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
 
         # change users password (if we got to this code it means that the user is_active)
         if reset_password_token.user.eligible_for_reset():
-            pre_password_reset.send(sender=self.__class__, user=reset_password_token.user)
+            pre_password_reset.send(
+                sender=self.__class__, user=reset_password_token.user
+            )
             try:
                 # validate the password against existing validators
                 validate_password(
                     password,
                     user=reset_password_token.user,
-                    password_validators=get_password_validators(settings.AUTH_PASSWORD_VALIDATORS),
+                    password_validators=get_password_validators(
+                        settings.AUTH_PASSWORD_VALIDATORS
+                    ),
                 )
             except ValidationError as e:
                 # raise a validation error for the serializer
@@ -118,7 +150,9 @@ class ResetPasswordConfirm(GenericAPIView):
 
             reset_password_token.user.set_password(password)
             reset_password_token.user.save()
-            post_password_reset.send(sender=self.__class__, user=reset_password_token.user)
+            post_password_reset.send(
+                sender=self.__class__, user=reset_password_token.user
+            )
 
         # Delete all password reset tokens for this user
         ResetPasswordToken.objects.filter(user=reset_password_token.user).delete()
@@ -137,7 +171,7 @@ class ResetPasswordRequestToken(GenericAPIView):
     permission_classes = ()
     serializer_class = ResetPasswordUserSerializer
 
-    def post(self, request, *args, **kwargs):         
+    def post(self, request, *args, **kwargs):
         serializer = self.serializer_class(data=request.data)
         serializer.is_valid(raise_exception=True)
         username = serializer.validated_data["username"]
@@ -152,13 +186,17 @@ class ResetPasswordRequestToken(GenericAPIView):
         password_reset_token_validation_time = get_password_reset_token_expiry_time()
 
         # datetime.now minus expiry hours
-        now_minus_expiry_time = timezone.now() - timedelta(hours=password_reset_token_validation_time)
+        now_minus_expiry_time = timezone.now() - timedelta(
+            hours=password_reset_token_validation_time
+        )
 
         # delete all tokens where created_at < now - 24 hours
         clear_expired(now_minus_expiry_time)
 
         # find a user
-        users = User.objects.filter(**{"{}__exact".format(get_password_reset_lookup_field()): username})
+        users = User.objects.filter(
+            **{"{}__exact".format(get_password_reset_lookup_field()): username}
+        )
 
         active_user_found = False
 
@@ -171,7 +209,9 @@ class ResetPasswordRequestToken(GenericAPIView):
 
         # No active user found, raise a validation error
         # but not if DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE == True
-        if not active_user_found and not getattr(settings, "DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE", False):
+        if not active_user_found and not getattr(
+            settings, "DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE", False
+        ):
             raise exceptions.ValidationError(
                 {
                     "email": [
@@ -202,6 +242,8 @@ class ResetPasswordRequestToken(GenericAPIView):
                     )
                 # send a signal that the password token was created
                 # let whoever receives this signal handle sending the email for the password reset
-                reset_password_token_created.send(sender=self.__class__, instance=self, reset_password_token=token)
+                reset_password_token_created.send(
+                    sender=self.__class__, instance=self, reset_password_token=token
+                )
         # done
         return Response({"status": "OK"})

--- a/config/ratelimit.py
+++ b/config/ratelimit.py
@@ -1,8 +1,6 @@
-from ratelimit.utils import is_ratelimited
-
-from django.conf import settings
-
 import requests
+from django.conf import settings
+from ratelimit.utils import is_ratelimited
 
 
 def validatecaptcha(request):
@@ -13,7 +11,9 @@ def validatecaptcha(request):
         "secret": settings.GOOGLE_RECAPTCHA_SECRET_KEY,
         "response": recaptcha_response,
     }
-    captcha_response = requests.post("https://www.google.com/recaptcha/api/siteverify", data=values)
+    captcha_response = requests.post(
+        "https://www.google.com/recaptcha/api/siteverify", data=values
+    )
     result = captcha_response.json()
 
     if result["success"] is True:
@@ -21,7 +21,9 @@ def validatecaptcha(request):
     return False
 
 
-def ratelimit(request, group="", keys=[None], rate=settings.DJANGO_RATE_LIMIT, increment=True):
+def ratelimit(
+    request, group="", keys=[None], rate=settings.DJANGO_RATE_LIMIT, increment=True
+):
     if settings.DISABLE_RATELIMIT:
         return False
 
@@ -33,7 +35,13 @@ def ratelimit(request, group="", keys=[None], rate=settings.DJANGO_RATE_LIMIT, i
         else:
             group = group + "-{}".format(key)
             key = settings.GETKEY
-        if is_ratelimited(request, group=group, key=key, rate=rate, increment=increment,):
+        if is_ratelimited(
+            request,
+            group=group,
+            key=key,
+            rate=rate,
+            increment=increment,
+        ):
             checkcaptcha = True
 
     if checkcaptcha:

--- a/config/ratelimit.py
+++ b/config/ratelimit.py
@@ -7,6 +7,8 @@ import requests
 
 def validatecaptcha(request):
     recaptcha_response = request.data.get(settings.GOOGLE_CAPTCHA_POST_KEY)
+    if not recaptcha_response:
+        return False
     values = {
         "secret": settings.GOOGLE_RECAPTCHA_SECRET_KEY,
         "response": recaptcha_response,
@@ -19,7 +21,7 @@ def validatecaptcha(request):
     return False
 
 
-def ratelimit(request, group="", keys=[None], increment=True):
+def ratelimit(request, group="", keys=[None], rate=settings.DJANGO_RATE_LIMIT, increment=True):
     if settings.DISABLE_RATELIMIT:
         return False
 
@@ -31,7 +33,7 @@ def ratelimit(request, group="", keys=[None], increment=True):
         else:
             group = group + "-{}".format(key)
             key = settings.GETKEY
-        if is_ratelimited(request, group=group, key=key, rate=settings.DJANGO_RATE_LIMIT, increment=True,):
+        if is_ratelimited(request, group=group, key=key, rate=rate, increment=increment,):
             checkcaptcha = True
 
     if checkcaptcha:

--- a/config/urls.py
+++ b/config/urls.py
@@ -12,6 +12,7 @@ from rest_framework_simplejwt.views import TokenVerifyView
 from care.facility.api.viewsets.open_id import OpenIdConfigView
 from care.users.api.viewsets.change_password import ChangePasswordView
 from care.users.reset_password_views import (
+    ResetPasswordCheck,
     ResetPasswordConfirm,
     ResetPasswordRequestToken,
 )
@@ -68,6 +69,11 @@ urlpatterns = [
         "api/v1/password_reset/confirm/",
         ResetPasswordConfirm.as_view(),
         name="password_reset_confirm",
+    ),
+    path(
+        "api/v1/password_reset/check/",
+        ResetPasswordCheck.as_view(),
+        name="password_reset_check",
     ),
     path(
         "api/v1/password_change/",


### PR DESCRIPTION
## Proposed Changes

- Adds an endpoint to check if the token provided during a password reset is valid.
- This helps adding a pre-check on the frontend where invalid links are redirected to an error page.
- Currently the user needs to enter a password and submit it, just to be notified afterwards that the link was expired or invalid. This PR targets to remedy this.

### Associated Issue
  - https://github.com/coronasafe/care_fe/issues/3939

### Associated PRs
  - https://github.com/coronasafe/care_fe/pull/3964
 
@coronasafe/code-reviewers
