### PR TITLE
fix(report): correction of logo present in the patient discharge summary

### DIFF
--- a/care/templates/reports/patient_pdf_report.html
+++ b/care/templates/reports/patient_pdf_report.html
@@ -16,9 +16,6 @@
   </head>
   <body class="max-w-5xl mx-10 mt-4 text-sm">
   <div class="bg-white overflow-hidden  sm:rounded-lg m-6">
-  <div class="mx-auto flex justify-center">
-      <img class='h-28' src="https://cdn.coronasafe.network/kgovtlogo.png"/>
-    </div>
   </div>
    <div class="mt-2 text-center w-full font-bold text-3xl">
     {{patient.facility.name}}
@@ -42,7 +39,7 @@
   {% endif %}
     </div>
   </div>
-   <img class='h-12' src="https://cdn.coronasafe.network/coronaSafeLogo.png"/>
+   <img class='h-12' src="https://cdn.coronasafe.network/black-logo.svg"/>
    </div>
   <div class="px-4 py-5 sm:px-6">
     <dl class="">


### PR DESCRIPTION
# Bug Fix

## Proposed Changes

- Tweaks in the patient discharge report:

     - Removed the `Kerala` logo
     - Replaced the `coronasafe` logo with the `care` logo

## Associated Issue

- Fixes https://github.com/coronasafe/care_fe/issues/3978

## Screenshot

![image](https://user-images.githubusercontent.com/77210185/200656401-9653a7b2-d85d-44af-b731-ea2a7d2b60be.png)

## Architecture Changes

N/A

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
