### PR TITLE
check_availability api will also consider deleted users

### DIFF
--- a/care/users/api/viewsets/users.py
+++ b/care/users/api/viewsets/users.py
@@ -292,7 +292,6 @@ class UserViewSet(
         """
         Checks availability of username by getting as query, returns 200 if available, and 409 otherwise.
         """
-        user = User.objects.filter(username=username)
-        if user.exists():
+        if User.check_username_exists(username):
             return Response(status=status.HTTP_409_CONFLICT)
         return Response(status=status.HTTP_200_OK)

--- a/care/users/models.py
+++ b/care/users/models.py
@@ -126,6 +126,9 @@ class CustomUserManager(UserManager):
             "local_body", "district", "state"
         )
 
+    def get_entire_queryset(self):
+        return super().get_queryset().select_related("local_body", "district", "state")
+
     def create_superuser(self, username, email, password, **extra_fields):
         district = District.objects.all()[0]
         extra_fields["district"] = district
@@ -248,9 +251,6 @@ class User(AbstractUser):
 
     objects = CustomUserManager()
 
-    # includes all users, including deleted and inactive
-    _objects = UserManager()
-
     REQUIRED_FIELDS = [
         "email",
     ]
@@ -315,7 +315,7 @@ class User(AbstractUser):
 
     @staticmethod
     def check_username_exists(username):
-        return User._objects.filter(username=username).exists()
+        return User.objects.get_entire_queryset().filter(username=username).exists()
 
     def delete(self, *args, **kwargs):
         self.deleted = True

--- a/care/users/models.py
+++ b/care/users/models.py
@@ -248,6 +248,9 @@ class User(AbstractUser):
 
     objects = CustomUserManager()
 
+    # includes all users, including deleted and inactive
+    _objects = UserManager()
+
     REQUIRED_FIELDS = [
         "email",
     ]
@@ -309,6 +312,10 @@ class User(AbstractUser):
     @staticmethod
     def has_add_user_permission(request):
         return request.user.is_superuser or request.user.verified
+
+    @staticmethod
+    def check_username_exists(username):
+        return User._objects.filter(username=username).exists()
 
     def delete(self, *args, **kwargs):
         self.deleted = True


### PR DESCRIPTION
## Proposed Changes

- check_availability will consider deleted users in users


### Associated Issue
  - Fixes #1096 

### Architecture changes
  - added `_objects` in the User model (_objects fetches all users including deleted and inactive) 
 
@coronasafe/code-reviewers

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
