### PR TITLE
Added Patient is_active validation when uploading a Patient file

### DIFF
--- a/care/facility/api/serializers/patient_consultation.py
+++ b/care/facility/api/serializers/patient_consultation.py
@@ -213,11 +213,6 @@ class PatientConsultationSerializer(serializers.ModelSerializer):
             raise ValidationError(
                 {"facility": "Consultation creates are only allowed in home facility"}
             )
-        
-        # Patient is active Check
-
-        if validated_data["patient"].is_active == False:
-            raise serializers.ValidationError({"Patient": "Patient has been discharged from CARE"})
 
         # End Authorisation Checks
 


### PR DESCRIPTION
Fixes #1099 
If the patient is not active, the Patient file upload raises a validation error and the Consultation File Upload raises error