### PR TITLE
Added validation for 11 digit toll free numbers

### DIFF
--- a/care/facility/models/asset.py
+++ b/care/facility/models/asset.py
@@ -8,7 +8,7 @@ from django.db.models import Q
 from care.facility.models.facility import Facility
 from care.facility.models.json_schema.asset import ASSET_META
 from care.facility.models.mixins.permissions.asset import AssetsPermissionMixin
-from care.users.models import User, phone_number_regex
+from care.users.models import User, phone_number_regex_11
 from care.utils.assetintegration.asset_classes import AssetClasses
 from care.utils.models.base import BaseModel
 from care.utils.models.validators import JSONFieldSchemaValidator
@@ -78,7 +78,7 @@ class Asset(BaseModel):
     vendor_name = models.CharField(max_length=1024, blank=True, null=True)
     support_name = models.CharField(max_length=1024, blank=True, null=True)
     support_phone = models.CharField(
-        max_length=14, validators=[phone_number_regex], default=""
+        max_length=14, validators=[phone_number_regex_11], default=""
     )
     support_email = models.EmailField(blank=True, null=True)
     qr_code_id = models.CharField(max_length=1024, blank=True, default=None, null=True)

--- a/care/users/models.py
+++ b/care/users/models.py
@@ -25,6 +25,13 @@ phone_number_regex = RegexValidator(
     code="invalid_mobile",
 )
 
+phone_number_regex_11 = RegexValidator(
+    # allow 11 digit mobile numbers if the first 4 digits are 1800
+    regex=r"^((\+91|91|0)[\- ]{0,1})?[456789]\d{9}|1800\d{7}$",
+    message="Please Enter 10/11 digit mobile/landline/tollfree number",
+    code="invalid_mobile",
+)
+
 DISTRICT_CHOICES = [
     (1, "Thiruvananthapuram"),
     (2, "Kollam"),

--- a/care/users/models.py
+++ b/care/users/models.py
@@ -26,8 +26,8 @@ phone_number_regex = RegexValidator(
 )
 
 phone_number_regex_11 = RegexValidator(
-    # allow 11 digit mobile numbers if the first 4 digits are 1800
-    regex=r"^((\+91|91|0)[\- ]{0,1})?[456789]\d{9}|1800\d{7}$",
+    # allow 10 to 11 digit mobile numbers if the first 4 digits are 1800
+    regex=r"^((\+91|91|0)[\- ]{0,1})?[456789]\d{9}|1800\d{6,7}$",
     message="Please Enter 10/11 digit mobile/landline/tollfree number",
     code="invalid_mobile",
 )


### PR DESCRIPTION
## Proposed Changes

- Implements a new regex validator called `phone_number_regex_11` that can validate toll free numbers
- This validator is currently only being used in asset `support_phone` field

## Associated Issues
- [https://github.com/coronasafe/care_fe/issues/4289](https://github.com/coronasafe/care_fe/issues/4289)

@coronasafe/code-reviewers

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
