### PR TITLE
Support compose-up for pre-built `care:latest` image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 DOCKER_VERSION := $(shell docker --version 2>/dev/null)
 DOCKER_COMPOSE_VERSION := $(shell docker-compose --version 2>/dev/null)
 
-docker_config_file = 'docker-compose.local.yaml'
+docker_config_file := 'docker-compose.local.yaml'
 
 all:
 ifndef DOCKER_VERSION

--- a/docker-compose.pre-built.yaml
+++ b/docker-compose.pre-built.yaml
@@ -1,0 +1,64 @@
+version: '3.4'
+
+networks:
+  default:
+    name: care
+
+services:
+  db:
+    container_name: care_db
+    image: postgres:latest
+    restart: always
+    env_file:
+      - ./docker/.local.env
+      - ./.env
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+  redis:
+    container_name: care_redis
+    image: redis:alpine
+    restart: always
+
+  backend:
+    container_name: care
+    image: "ghcr.io/coronasafe/care:latest"
+    env_file:
+      - ./docker/.local.env
+      - ./.env
+    ports:
+      - "9000:9000"
+      - "9876:9876" #debugpy
+    depends_on:
+      - db
+    volumes:
+      - .:/app
+
+  celery:
+    container_name: care_celery
+    build:
+      context: .
+      dockerfile: docker/DevDockerfile
+    env_file:
+      - ./docker/.local.env
+      - ./.env
+    entrypoint: [ "bash", "devCelery.sh" ]
+    depends_on:
+      - db
+      - backend
+      - redis
+    volumes:
+      - .:/app
+
+  localstack:
+    image: localstack/localstack:latest
+    environment:
+      - AWS_DEFAULT_REGION=ap-south-1
+      - EDGE_PORT=4566
+      - SERVICES=s3
+    volumes:
+      - "${TEMPDIR:-/tmp/localstack}:/tmp/localstack"
+      - "./docker/awslocal:/docker-entrypoint-initaws.d"
+
+volumes:
+  postgres-data:

--- a/docker-compose.pre-built.yaml
+++ b/docker-compose.pre-built.yaml
@@ -26,13 +26,14 @@ services:
     env_file:
       - ./docker/.local.env
       - ./.env
+    entrypoint: ["bash", "docker/docker-entrypoint.sh"]
     ports:
       - "9000:9000"
       - "9876:9876" #debugpy
     depends_on:
       - db
     volumes:
-      - .:/app
+      - /app
 
   celery:
     container_name: care_celery


### PR DESCRIPTION
## Proposed Changes

- Adds `docker-compose.pre-built.yaml` that uses care image from `ghcr.io/coronasafe/care:latest`
- Adjust makefile so that `docker_config_file` can be adjusted

To make up the prebuilt:
```bash
make docker_config_file=docker-compose.pre-built.yaml up
```
 
@coronasafe/code-reviewers

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
