### PR TITLE
Use configured middleware address for middleware authentication

### DIFF
--- a/care/facility/api/serializers/facility.py
+++ b/care/facility/api/serializers/facility.py
@@ -119,6 +119,14 @@ class FacilitySerializer(FacilityBasicInfoSerializer):
         ]
         read_only_fields = ("modified_date", "created_date")
 
+    def validate_middleware_address(self, value):
+        value = value.strip()
+        if not value or not value.startswith("http"):
+            raise serializers.ValidationError("Invalid URL")
+        if value.endswith("/"):
+            raise serializers.ValidationError("URL should not end with /")
+        return value
+
     def create(self, validated_data):
         validated_data["created_by"] = self.context["request"].user
         return super().create(validated_data)

--- a/config/authentication.py
+++ b/config/authentication.py
@@ -69,13 +69,11 @@ class MiddlewareAuthentication(JWTAuthentication):
             facility = Facility.objects.get(external_id=external_id)
         except (Facility.DoesNotExist, ValidationError) as e:
             raise InvalidToken({"detail": "Invalid Facility", "messages": []}) from e
-        
-        open_id_url = "http://localhost:8090"
-        
-        if facility.middleware_address:
-            open_id_url = f"https://{facility.middleware_address}"
 
-        open_id_url += "/.well-known/openid-configuration/"
+        if not facility.middleware_address:
+            raise InvalidToken({"detail": "Facility not connected to a middleware"})
+
+        open_id_url = f"{facility.middleware_address}/.well-known/openid-configuration/"
 
         validated_token = self.get_validated_token(open_id_url, raw_token)
 


### PR DESCRIPTION
## Proposed Changes

Use configured middleware address for middleware authentication
 
@coronasafe/code-reviewers

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
