### PR TITLE
Added declare death option to decision after consultation

### DIFF
--- a/care/facility/models/patient_base.py
+++ b/care/facility/models/patient_base.py
@@ -96,7 +96,7 @@ BLOOD_GROUP_CHOICES = [
     ("O-", "O-"),
     ("UNK", "UNKNOWN"),
 ]
-SuggestionChoices = SimpleNamespace(HI="HI", A="A", R="R", OP="OP", DC="DC")
+SuggestionChoices = SimpleNamespace(HI="HI", A="A", R="R", OP="OP", DC="DC", DD="DD")
 
 
 class BedType(enum.Enum):

--- a/care/facility/models/patient_consultation.py
+++ b/care/facility/models/patient_consultation.py
@@ -29,6 +29,7 @@ class PatientConsultation(PatientBaseModel, PatientRelatedPermissionMixin):
         (SuggestionChoices.R, "REFERRAL"),
         (SuggestionChoices.OP, "OP CONSULTATION"),
         (SuggestionChoices.DC, "DOMICILIARY CARE"),
+        (SuggestionChoices.DD, "DECLARE DEATH"),
     ]
     REVERSE_SUGGESTION_CHOICES = reverse_choices(SUGGESTION_CHOICES)
 


### PR DESCRIPTION
## Proposed Changes

- Added 'declare death' option to decision after consultation field in PatientConsultation model
- Backend PR to fix https://github.com/coronasafe/care_fe/issues/4497

@coronasafe/code-reviewers

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
