### PR TITLE
Migrate Middleware Address for OpenID

### DIFF
--- a/config/authentication.py
+++ b/config/authentication.py
@@ -69,10 +69,11 @@ class MiddlewareAuthentication(JWTAuthentication):
             facility = Facility.objects.get(external_id=external_id)
         except (Facility.DoesNotExist, ValidationError) as e:
             raise InvalidToken({"detail": "Invalid Facility", "messages": []}) from e
-
-        open_id_url = (
-            "https://" + facility.middleware_address or "http://localhost:8090"
-        )
+        
+        open_id_url = "http://localhost:8090"
+        
+        if facility.middleware_address:
+            open_id_url = f"https://{facility.middleware_address}"
 
         open_id_url += "/.well-known/openid-configuration/"
 

--- a/config/authentication.py
+++ b/config/authentication.py
@@ -71,9 +71,10 @@ class MiddlewareAuthentication(JWTAuthentication):
             raise InvalidToken({"detail": "Invalid Facility", "messages": []}) from e
 
         open_id_url = (
-            facility.middleware_address
-            or "http://localhost:8090" + "/.well-known/openid-configuration/"
+            "https://" + facility.middleware_address or "http://localhost:8090"
         )
+
+        open_id_url += "/.well-known/openid-configuration/"
 
         validated_token = self.get_validated_token(open_id_url, raw_token)
 


### PR DESCRIPTION
## Proposed Changes

Change OpenID Auth URL, to work with `facility.middleware_address` being only the hostname

### Associated Issue
  - Automated Daily Rounds not working

### Architecture changes
  - NA
 
@coronasafe/code-reviewers

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
