### PR TITLE
Fixed errors in asset config validation

### DIFF
--- a/care/facility/api/serializers/asset.py
+++ b/care/facility/api/serializers/asset.py
@@ -66,15 +66,17 @@ class AssetSerializer(ModelSerializer):
             del attrs["location"]
             attrs["current_location"] = location
 
-        # validate that warraty date is not in the past
-        if "warranty_amc_end_of_validity" in attrs:
-            if datetime.strptime(attrs["warranty_amc_end_of_validity"], '%Y-%m-%d') < datetime.now():
-                raise ValidationError("Warranty/AMC end of validity cannot be in the past")
+        # validate that warranty date is not in the past
+        if ("warranty_amc_end_of_validity" in attrs 
+            and attrs["warranty_amc_end_of_validity"] is not None
+            and datetime.strptime(str(attrs["warranty_amc_end_of_validity"]), '%Y-%m-%d') < datetime.now()):
+            raise ValidationError("Warranty/AMC end of validity cannot be in the past")
         
         # validate that last serviced date is not in the future
-        if "last_serviced_on" in attrs:
-            if datetime.strptime(attrs["last_serviced_on"], '%Y-%m-%d') > datetime.now():
-                raise ValidationError("Last serviced on cannot be in the future")
+        if ("last_serviced_on" in attrs 
+            and attrs["last_serviced_on"] is not None 
+            and datetime.strptime(str(attrs["last_serviced_on"]), '%Y-%m-%d') > datetime.now()):
+            raise ValidationError("Last serviced on cannot be in the future")
 
         return super().validate(attrs)
 


### PR DESCRIPTION
## Proposed Changes

- Date validation now converts date to str before comparision
- API now returns 200

### Associated Issue
fixes #1165 
 
@coronasafe/code-reviewers

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
