### PR TITLE
Added new search fields to asset viewset

### DIFF
--- a/care/facility/api/viewsets/asset.py
+++ b/care/facility/api/viewsets/asset.py
@@ -141,7 +141,7 @@ class AssetViewSet(
     serializer_class = AssetSerializer
     lookup_field = "external_id"
     filter_backends = (filters.DjangoFilterBackend, drf_filters.SearchFilter)
-    search_fields = ["name"]
+    search_fields = ["name","serial_number","qr_code_id"]
     permission_classes = [IsAuthenticated]
     filterset_class = AssetFilter
 


### PR DESCRIPTION
## Proposed Changes

- Asset Viewset now has search filters for serial_number and qr_code_id aswell

### Associated Issue
  - https://github.com/coronasafe/care_fe/issues/4490
 
@coronasafe/code-reviewers

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
