### PR TITLE
Fix symptomatic_international_traveller crash

### DIFF
--- a/care/facility/models/patient_icmr.py
+++ b/care/facility/models/patient_icmr.py
@@ -216,7 +216,8 @@ class PatientConsultationICMR(PatientConsultation):
 
     def symptomatic_international_traveller(self,):
         return (
-            len(self.patient.countries_travelled) != 0
+            self.patient.countries_travelled 
+            and len(self.patient.countries_travelled) != 0
             and (
                 self.patient.date_of_return
                 and (

--- a/care/facility/models/patient_icmr.py
+++ b/care/facility/models/patient_icmr.py
@@ -1,5 +1,7 @@
 import datetime
-from dateutil.relativedelta import *
+
+from dateutil.relativedelta import relativedelta
+
 from care.facility.models import (
     DISEASE_CHOICES_MAP,
     SYMPTOM_CHOICES,
@@ -98,16 +100,22 @@ class PatientIcmr(PatientRegistration):
         return None
 
     @property
-    def contact_case_name(self,):
+    def contact_case_name(
+        self,
+    ):
         contact_case = self.contacted_patients.first()
         return "" if not contact_case else contact_case.name
 
     @property
-    def was_quarantined(self,):
+    def was_quarantined(
+        self,
+    ):
         return None
 
     @property
-    def quarantined_type(self,):
+    def quarantined_type(
+        self,
+    ):
         return None
 
 
@@ -214,9 +222,11 @@ class PatientConsultationICMR(PatientConsultation):
         else:
             return False
 
-    def symptomatic_international_traveller(self,):
+    def symptomatic_international_traveller(
+        self,
+    ):
         return (
-            self.patient.countries_travelled 
+            self.patient.countries_travelled
             and len(self.patient.countries_travelled) != 0
             and (
                 self.patient.date_of_return
@@ -228,16 +238,22 @@ class PatientConsultationICMR(PatientConsultation):
             and self.is_symptomatic()
         )
 
-    def symptomatic_contact_of_confirmed_case(self,):
+    def symptomatic_contact_of_confirmed_case(
+        self,
+    ):
         return self.patient.contact_with_confirmed_carrier and self.is_symptomatic()
 
-    def symptomatic_healthcare_worker(self,):
+    def symptomatic_healthcare_worker(
+        self,
+    ):
         return self.patient.is_medical_worker and self.is_symptomatic()
 
     def hospitalized_sari_patient(self):
         return self.patient.has_SARI and self.admitted
 
-    def asymptomatic_family_member_of_confirmed_case(self,):
+    def asymptomatic_family_member_of_confirmed_case(
+        self,
+    ):
         return (
             self.patient.contact_with_confirmed_carrier
             and not self.is_symptomatic()
@@ -248,5 +264,7 @@ class PatientConsultationICMR(PatientConsultation):
             )
         )
 
-    def asymptomatic_healthcare_worker_without_protection(self,):
+    def asymptomatic_healthcare_worker_without_protection(
+        self,
+    ):
         return self.patient.is_medical_worker and not self.is_symptomatic()


### PR DESCRIPTION
## Proposed Changes

- On the ICMR Specimen Referral, the api call to `.../icmr_sample` errors out with the following error:
```
TypeError at /api/v1/patient/7c1d2896-8ebf-45c7-b507-98fcedd48ef3/test_sample/5aef7a72-5e2c-4a0f-b689-747aae8b0dce/icmr_sample/
object of type 'NoneType' has no len()
```

This is because we are calling `len(self.patient.countries_travelled)` when `self.patient.countries_travelled` is `None`. This PR addresses this issue by adding a check for `self.patient.countries_travelled` to be defined before calling `len` on it.

@coronasafe/code-reviewers