### PR TITLE
Fixed get_users for users below district admins

### DIFF
--- a/care/utils/queryset/user.py
+++ b/care/utils/queryset/user.py
@@ -10,5 +10,5 @@ def get_users(user):
     elif user.user_type >= User.TYPE_VALUE_MAP["DistrictLabAdmin"]:
         queryset = queryset.filter(district=user.district)
     else:
-        queryset = queryset.filter(user=user)
+        queryset = queryset.filter(username=user.username)
     return queryset

--- a/care/utils/queryset/user.py
+++ b/care/utils/queryset/user.py
@@ -10,5 +10,5 @@ def get_users(user):
     elif user.user_type >= User.TYPE_VALUE_MAP["DistrictLabAdmin"]:
         queryset = queryset.filter(district=user.district)
     else:
-        queryset = queryset.filter(username=user.username)
+        queryset = queryset.filter(id=user.id)
     return queryset


### PR DESCRIPTION
## Proposed Changes

- Fixed get_users for users below district admins
There seemed to have been key (kwarg) mismatch error in get_users function

cc: @nihal467 

### Associated Issue
  - Fixes #1177 

### Architecture changes
  - None
 
@coronasafe/code-reviewers

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
