### PR TITLE
Add endpoint to clear user's home facility

### DIFF
--- a/care/users/api/viewsets/users.py
+++ b/care/users/api/viewsets/users.py
@@ -265,6 +265,28 @@ class UserViewSet(
         },
     )
     @action(detail=True, methods=["DELETE"], permission_classes=[IsAuthenticated])
+    def clear_home_facility(self, request, *args, **kwargs):
+        user = self.get_object()
+        requesting_user = request.user
+
+        if not user.home_facility:
+            raise ValidationError({"home_facility": "No Home Facility Present"})
+        if not self.has_user_type_permission_elevation(requesting_user, user):
+            raise ValidationError({"home_facility": "Cannot Access Higher Level User"})
+        if not self.has_facility_permission(requesting_user, user.home_facility):
+            raise ValidationError({"home_facility": "Facility Access not Present"})
+        if not self.has_facility_permission(user, user.home_facility):
+            raise ValidationError(
+                {
+                    "home_facility": "Intended User Does not have permission to this facility"
+                }
+            )
+
+        user.home_facility = None
+        user.save(update_fields=["home_facility"])
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @action(detail=True, methods=["DELETE"], permission_classes=[IsAuthenticated])
     def delete_facility(self, request, *args, **kwargs):
         # Remove User Facility Cache
         user = self.get_object()

--- a/care/users/api/viewsets/users.py
+++ b/care/users/api/viewsets/users.py
@@ -273,14 +273,6 @@ class UserViewSet(
             raise ValidationError({"home_facility": "No Home Facility Present"})
         if not self.has_user_type_permission_elevation(requesting_user, user):
             raise ValidationError({"home_facility": "Cannot Access Higher Level User"})
-        if not self.has_facility_permission(requesting_user, user.home_facility):
-            raise ValidationError({"home_facility": "Facility Access not Present"})
-        if not self.has_facility_permission(user, user.home_facility):
-            raise ValidationError(
-                {
-                    "home_facility": "Intended User Does not have permission to this facility"
-                }
-            )
 
         user.home_facility = None
         user.save(update_fields=["home_facility"])


### PR DESCRIPTION
This PR adds a new endpoint to the user API that allows users to clear their home facility. The new endpoint is implemented in the `clear_home_facility` method of the `UserViewSet` and can be accessed via a DELETE request.

### Associated Issue
  - https://github.com/coronasafe/care_fe/issues/4820

### Associated PR
  - https://github.com/coronasafe/care_fe/pull/4838
 
@coronasafe/code-reviewers