### PR TITLE
Only allow >=DistrictAdmin to clear home facility

### DIFF
--- a/care/users/api/viewsets/users.py
+++ b/care/users/api/viewsets/users.py
@@ -278,6 +278,9 @@ class UserViewSet(
         ):
             raise ValidationError({"home_facility": "Insufficient Permissions"})
 
+        if not self.has_user_type_permission_elevation(requesting_user, user):
+            raise ValidationError({"home_facility": "Cannot Access Higher Level User"})
+
         user.home_facility = None
         user.save(update_fields=["home_facility"])
         return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
According to issue https://github.com/coronasafe/care_fe/issues/4820 , only user with district admin or above access (not read-only users) should be able to clear the home facility from a user. They are the same set of users who can link facilities and set home facilities. 

This PR changes the permissions required to clear the home facility to allow only `>=DistrictAdmin` excluding the read only user types.

@coronasafe/code-reviewers
