### PR TITLE
do not accept middleware address with scheme

### DIFF
--- a/care/facility/api/serializers/facility.py
+++ b/care/facility/api/serializers/facility.py
@@ -13,6 +13,7 @@ from care.users.api.serializers.lsg import (
 )
 from care.utils.csp import config as cs_provider
 from config.serializers import ChoiceField
+from config.validators import MiddlewareDomainAddressValidator
 
 User = get_user_model()
 
@@ -123,8 +124,9 @@ class FacilitySerializer(FacilityBasicInfoSerializer):
         value = value.strip()
         if not value:
             return value
-        if value.endswith("/"):
-            raise serializers.ValidationError("URL should not end with /")
+
+        # Check if the address is valid
+        MiddlewareDomainAddressValidator()(value)
         return value
 
     def create(self, validated_data):

--- a/config/authentication.py
+++ b/config/authentication.py
@@ -73,7 +73,9 @@ class MiddlewareAuthentication(JWTAuthentication):
         if not facility.middleware_address:
             raise InvalidToken({"detail": "Facility not connected to a middleware"})
 
-        open_id_url = f"{facility.middleware_address}/.well-known/openid-configuration/"
+        open_id_url = (
+            f"https://{facility.middleware_address}/.well-known/openid-configuration/"
+        )
 
         validated_token = self.get_validated_token(open_id_url, raw_token)
 

--- a/config/validators.py
+++ b/config/validators.py
@@ -1,6 +1,7 @@
 import re
 
 from django.core.exceptions import ValidationError
+from django.core.validators import RegexValidator
 from django.utils.translation import ugettext as _
 
 
@@ -60,3 +61,13 @@ class SymbolValidator(object):
             "Your password must contain at least 1 symbol: " +
             "()[]{}|\`~!@#$%^&*_-+=;:'\",<>./?"
         )
+
+
+class MiddlewareDomainAddressValidator(RegexValidator):
+    regex = r"^(?!https?:\/\/)[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)*\.[a-zA-Z]{2,}$"
+    code = 'invalid_domain_name'
+    message = _(
+        'The domain name is invalid. '
+        'It should not start with scheme and '
+        'should not end with a trailing slash.'
+    )


### PR DESCRIPTION
## Proposed Changes

- prefix middleware address with scheme in openid auth
- update the facility config validator to only accept the domain name without scheme or trailing slash
 
@coronasafe/code-reviewers

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
