### PR TITLE
Add qr_code_id to AssetTransactionFilter

### DIFF
--- a/care/facility/api/viewsets/asset.py
+++ b/care/facility/api/viewsets/asset.py
@@ -141,7 +141,7 @@ class AssetViewSet(
     serializer_class = AssetSerializer
     lookup_field = "external_id"
     filter_backends = (filters.DjangoFilterBackend, drf_filters.SearchFilter)
-    search_fields = ["name","serial_number","qr_code_id"]
+    search_fields = ["name", "serial_number", "qr_code_id"]
     permission_classes = [IsAuthenticated]
     filterset_class = AssetFilter
 
@@ -272,7 +272,8 @@ class AssetViewSet(
 
 
 class AssetTransactionFilter(filters.FilterSet):
-    asset = filters.UUIDFilter(field_name="asset__external_id")
+    qr_code_id = filters.CharFilter(field_name="asset__qr_code_id")
+    external_id = filters.CharFilter(field_name="asset__external_id")
 
 
 class AssetTransactionViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet):


### PR DESCRIPTION
## Proposed Changes

- Allow user to filter Asset Transactions using either `qr_code_id` or `external_id` or both. 

### Associated Issue
  - https://github.com/coronasafe/care_fe/issues/3479#issuecomment-1323359374
 
@coronasafe/code-reviewers