### PR TITLE
feat: Add patient and bed count to Facility serializers

### DIFF
--- a/care/facility/api/serializers/facility.py
+++ b/care/facility/api/serializers/facility.py
@@ -4,7 +4,9 @@ from django.contrib.auth import get_user_model
 from rest_framework import serializers
 
 from care.facility.models import FACILITY_TYPES, Facility, FacilityLocalGovtBody
+from care.facility.models.bed import Bed
 from care.facility.models.facility import FEATURE_CHOICES
+from care.facility.models.patient import PatientRegistration
 from care.users.api.serializers.lsg import (
     DistrictSerializer,
     LocalBodySerializer,
@@ -47,6 +49,16 @@ class FacilityBasicInfoSerializer(serializers.ModelSerializer):
     facility_type = serializers.SerializerMethodField()
     read_cover_image_url = serializers.CharField(read_only=True)
     features = serializers.MultipleChoiceField(choices=FEATURE_CHOICES)
+    patient_count = serializers.SerializerMethodField()
+    bed_count = serializers.SerializerMethodField()
+
+    def get_bed_count(self, facility):
+        return Bed.objects.filter(facility=facility).count()
+
+    def get_patient_count(self, facility):
+        return PatientRegistration.objects.filter(
+            facility=facility, is_active=True
+        ).count()
 
     def get_facility_type(self, facility):
         return {
@@ -69,6 +81,8 @@ class FacilityBasicInfoSerializer(serializers.ModelSerializer):
             "facility_type",
             "read_cover_image_url",
             "features",
+            "patient_count",
+            "bed_count",
         )
 
 
@@ -83,6 +97,8 @@ class FacilitySerializer(FacilityBasicInfoSerializer):
     read_cover_image_url = serializers.URLField(read_only=True)
     # location = PointField(required=False)
     features = serializers.MultipleChoiceField(choices=FEATURE_CHOICES)
+    patient_count = serializers.SerializerMethodField()
+    bed_count = serializers.SerializerMethodField()
 
     class Meta:
         model = Facility
@@ -117,6 +133,8 @@ class FacilitySerializer(FacilityBasicInfoSerializer):
             "expected_type_c_cylinders",
             "expected_type_d_cylinders",
             "read_cover_image_url",
+            "patient_count",
+            "bed_count",
         ]
         read_only_fields = ("modified_date", "created_date")
 

--- a/care/facility/api/serializers/facility.py
+++ b/care/facility/api/serializers/facility.py
@@ -97,7 +97,6 @@ class FacilitySerializer(FacilityBasicInfoSerializer):
     read_cover_image_url = serializers.URLField(read_only=True)
     # location = PointField(required=False)
     features = serializers.MultipleChoiceField(choices=FEATURE_CHOICES)
-    patient_count = serializers.SerializerMethodField()
     bed_count = serializers.SerializerMethodField()
 
     class Meta:


### PR DESCRIPTION
Required for: https://github.com/coronasafe/care_fe/issues/4885
Frontend PR: https://github.com/coronasafe/care_fe/pull/5131

This commit adds two new fields, patient_count and bed_count, to the FacilityBasicInfoSerializer and FacilitySerializer classes in care/facility/api/serializers/facility.py. These fields are calculated using the Bed and PatientRegistration models and return the total number of beds and active patients associated with each facility, respectively.

This information is useful for displaying occupancy rates and other related data in the frontend application.
 
@coronasafe/code-reviewers