### PR TITLE
Add unique constraint for AssetLocation name and facility

### DIFF
--- a/care/facility/api/viewsets/asset.py
+++ b/care/facility/api/viewsets/asset.py
@@ -70,6 +70,12 @@ class AssetLocationViewSet(
     filter_backends = (drf_filters.SearchFilter,)
     search_fields = ["name"]
 
+    def get_serializer_context(self):
+        facility = self.get_facility()
+        context = super().get_serializer_context()
+        context["facility"] = facility
+        return context
+
     def get_queryset(self):
         user = self.request.user
         queryset = self.queryset


### PR DESCRIPTION
Required for https://github.com/coronasafe/care_fe/issues/5152

This PR adds a validation check to the `AssetLocation` serializer to ensure that an asset location with the same name and facility does not already exist. The function `validate` in the `AssetLocationSerializer` compares the passed name with the existing entries in the database and raises a `ValidationError` if a match is found.  In addition, the validation now applies to both create and update operations.

The `unique_together` attribute is added to the `AssetLocation` model in the `models.py` file.

The `get_serializer_context` method is also updated to include the facility information when serializing the data.

@coronasafe/code-reviewers