### PR TITLE
Switch to new fields for discharge prescription

### DIFF
--- a/care/facility/api/viewsets/patient.py
+++ b/care/facility/api/viewsets/patient.py
@@ -402,12 +402,6 @@ class PatientViewSet(
                 )
             last_consultation.discharge_reason = reason
             last_consultation.discharge_notes = notes
-            last_consultation.discharge_prescription = request.data.get(
-                "discharge_prescription", []
-            )
-            last_consultation.discharge_prn_prescription = request.data.get(
-                "discharge_prn_prescription", []
-            )
             if last_consultation.discharge_date is None:
                 last_consultation.discharge_date = current_time
             last_consultation.current_bed = None
@@ -425,15 +419,19 @@ class PatientViewSet(
                 last_consultation.death_datetime = death_datetime
                 last_consultation.death_confirmed_doctor = death_confirmed_doctor
             if reason == "REC":
-                prn_prescription = request.data.get("prn_prescription", [])
-                discharge_advice = request.data.get("discharge_advice", [])
+                discharge_prescription = request.data.get("discharge_prescription", [])
+                discharge_prn_prescription = request.data.get(
+                    "discharge_prn_prescription", []
+                )
                 discharge_date = request.data.get("discharge_date")
                 if discharge_date is None:
                     raise serializers.ValidationError(
                         {"discharge_date": "Please set the discharge date"}
                     )
-                last_consultation.prn_prescription = prn_prescription
-                last_consultation.discharge_advice = discharge_advice
+                last_consultation.discharge_prescription = discharge_prescription
+                last_consultation.discharge_prn_prescription = (
+                    discharge_prn_prescription
+                )
                 last_consultation.discharge_date = discharge_date
             last_consultation.save()
             ConsultationBed.objects.filter(


### PR DESCRIPTION
Switch to using `discharge_prescription` and `discharge_prn_prescription` instead of overwriting the consultation form's prescription (old logic).

@coronasafe/code-reviewers
