### PR TITLE
Fixes Patient Category Filter

### DIFF
--- a/care/facility/api/viewsets/patient.py
+++ b/care/facility/api/viewsets/patient.py
@@ -94,8 +94,24 @@ class PatientFilterSet(filters.FilterSet):
         choices=COVID_CATEGORY_CHOICES,
     )
     category = filters.ChoiceFilter(
-        field_name="last_consultation__category", choices=CATEGORY_CHOICES
+        method="filter_by_category",
+        choices=CATEGORY_CHOICES,
     )
+
+    def filter_by_category(self, queryset, name, value):
+        if value:
+            queryset = queryset.filter(
+                (
+                    Q(last_consultation__last_daily_round__isnull=False)
+                    & Q(last_consultation__last_daily_round__patient_category=value)
+                )
+                | (
+                    Q(last_consultation__last_daily_round__isnull=True)
+                    & Q(last_consultation__category=value)
+                )
+            )
+        return queryset
+
     created_date = filters.DateFromToRangeFilter(field_name="created_date")
     modified_date = filters.DateFromToRangeFilter(field_name="modified_date")
     srf_id = filters.CharFilter(field_name="srf_id")


### PR DESCRIPTION
## Proposed Changes

- Fixes coronasafe/care_fe#5327
- Converted category to a custom filter:

If a patient has a last daily round, it's filtered by the last daily round category.
Else filter by the last consultation's category as usual.

Co-authored by @Ashesh3 
 
@coronasafe/code-reviewers

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
