### PR TITLE
Reorders and Adds Policy to Patient Export

### DIFF
--- a/care/facility/models/patient.py
+++ b/care/facility/models/patient.py
@@ -518,21 +518,33 @@ class PatientRegistration(PatientBaseModel, PatientPermissionMixin):
         "age": "Age",
         # Policy Details
         "policy__policy_id": "Policy ID/Name",
-        "created_date": "Date and time of Registration",
+        "created_date": "Date of Registration",
+        "created_date__time": "Time of Registration",
         # Last Consultation Details
         "last_consultation__consultation_status": "Status during consultation",
-        "last_consultation__created_date": "Date and time of last consultation",
+        "last_consultation__created_date": "Date of last consultation",
+        "last_consultation__created_date__time": "Time of last consultation",
         "last_consultation__icd11_diagnoses": "Final Diagnoses",
         "last_consultation__icd11_provisional_diagnoses": "Provisional Diagnoses",
         "last_consultation__suggestion": "Decision after consultation",
         "last_consultation__category": "Category",
         "last_consultation__discharge_reason": "Discharge reason",
-        "last_consultation__discharge_date": "Date and time of discharge",
+        "last_consultation__discharge_date": "Date of discharge",
+        "last_consultation__discharge_date__time": "Time of discharge",
     }
+
+    def format_as_date(date):
+        return date.strftime("%d/%m/%Y")
+
+    def format_as_time(time):
+        return time.strftime("%H:%M")
 
     CSV_MAKE_PRETTY = {
         "gender": (lambda x: REVERSE_GENDER_CHOICES[x]),
-        "created_date": lambda x: x.strftime("%d/%m/%Y %H:%M"),
+        "created_date": format_as_date,
+        "created_date__time": format_as_time,
+        "last_consultation__created_date": format_as_date,
+        "last_consultation__created_date__time": format_as_time,
         "last_consultation__suggestion": (
             lambda x: PatientConsultation.REVERSE_SUGGESTION_CHOICES.get(x, "-")
         ),
@@ -542,7 +554,6 @@ class PatientRegistration(PatientBaseModel, PatientPermissionMixin):
         "last_consultation__icd11_provisional_diagnoses": (
             lambda x: ", ".join([ICDDiseases.by.id[id].label.strip() for id in x])
         ),
-        "last_consultation__created_date": lambda x: x.strftime("%d/%m/%Y %H:%M"),
         "last_consultation__consultation_status": (
             lambda x: REVERSE_CONSULTATION_STATUS_CHOICES.get(x, "-")
         ),
@@ -550,7 +561,8 @@ class PatientRegistration(PatientBaseModel, PatientPermissionMixin):
         "last_consultation__discharge_reason": (
             lambda x: REVERSE_DISCHARGE_REASON_CHOICES.get(x, "-")
         ),
-        "last_consultation__discharge_date": lambda x: x.strftime("%d/%m/%Y %H:%M"),
+        "last_consultation__discharge_date": format_as_date,
+        "last_consultation__discharge_date__time": format_as_time,
     }
 
 

--- a/care/facility/models/patient.py
+++ b/care/facility/models/patient.py
@@ -523,8 +523,8 @@ class PatientRegistration(PatientBaseModel, PatientPermissionMixin):
         # Last Consultation Details
         "last_consultation__consultation_status": "Status during consultation",
         "last_consultation__created_date": "Date of first consultation",
-        "last_consultation__created_date__time": "Time of last consultation",
-        "last_consultation__icd11_diagnoses": "Final Diagnoses",
+        "last_consultation__created_date__time": "Time of first consultation",
+        "last_consultation__icd11_diagnoses": "Diagnoses",
         "last_consultation__icd11_provisional_diagnoses": "Provisional Diagnoses",
         "last_consultation__suggestion": "Decision after consultation",
         "last_consultation__category": "Category",
@@ -555,7 +555,7 @@ class PatientRegistration(PatientBaseModel, PatientPermissionMixin):
             lambda x: ", ".join([ICDDiseases.by.id[id].label.strip() for id in x])
         ),
         "last_consultation__consultation_status": (
-            lambda x: REVERSE_CONSULTATION_STATUS_CHOICES.get(x, "-")
+            lambda x: REVERSE_CONSULTATION_STATUS_CHOICES.get(x, "-").replace("_", " ")
         ),
         "last_consultation__category": lambda x: REVERSE_CATEGORY_CHOICES.get(x, "-"),
         "last_consultation__discharge_reason": (

--- a/care/facility/models/patient.py
+++ b/care/facility/models/patient.py
@@ -522,7 +522,7 @@ class PatientRegistration(PatientBaseModel, PatientPermissionMixin):
         "created_date__time": "Time of Registration",
         # Last Consultation Details
         "last_consultation__consultation_status": "Status during consultation",
-        "last_consultation__created_date": "Date of last consultation",
+        "last_consultation__created_date": "Date of first consultation",
         "last_consultation__created_date__time": "Time of last consultation",
         "last_consultation__icd11_diagnoses": "Final Diagnoses",
         "last_consultation__icd11_provisional_diagnoses": "Provisional Diagnoses",

--- a/care/facility/models/patient.py
+++ b/care/facility/models/patient.py
@@ -510,25 +510,29 @@ class PatientRegistration(PatientBaseModel, PatientPermissionMixin):
             )
 
     CSV_MAPPING = {
+        # Patient Details
         "external_id": "Patient ID",
         "name": "Patient Name",
         "facility__name": "Facility Name",
-        "age": "Age",
         "gender": "Gender",
-        "created_date": "Date of Registration",
-        "last_consultation__icd11_diagnoses": "Diagnoses",
+        "age": "Age",
+        # Policy Details
+        "policy__policy_id": "Policy ID/Name",
+        "created_date": "Date and time of Registration",
+        # Last Consultation Details
+        "last_consultation__consultation_status": "Status during consultation",
+        "last_consultation__created_date": "Date and time of last consultation",
+        "last_consultation__icd11_diagnoses": "Final Diagnoses",
         "last_consultation__icd11_provisional_diagnoses": "Provisional Diagnoses",
-        "last_consultation__suggestion": "Decision after Consultation",
-        "last_consultation__discharge_reason": "Discharge Reason",
-        "last_consultation__discharge_date": "Date of Discharge",
-        "last_consultation__created_date": "Date of Consultation",
+        "last_consultation__suggestion": "Decision after consultation",
         "last_consultation__category": "Category",
-        "last_consultation__consultation_status": "Status during Consultation",
+        "last_consultation__discharge_reason": "Discharge reason",
+        "last_consultation__discharge_date": "Date and time of discharge",
     }
 
     CSV_MAKE_PRETTY = {
         "gender": (lambda x: REVERSE_GENDER_CHOICES[x]),
-        "last_consultation__category": lambda x: REVERSE_CATEGORY_CHOICES.get(x, "-"),
+        "created_date": lambda x: x.strftime("%d/%m/%Y %H:%M"),
         "last_consultation__suggestion": (
             lambda x: PatientConsultation.REVERSE_SUGGESTION_CHOICES.get(x, "-")
         ),
@@ -538,15 +542,15 @@ class PatientRegistration(PatientBaseModel, PatientPermissionMixin):
         "last_consultation__icd11_provisional_diagnoses": (
             lambda x: ", ".join([ICDDiseases.by.id[id].label.strip() for id in x])
         ),
-        "last_consultation__discharge_reason": (
-            lambda x: REVERSE_DISCHARGE_REASON_CHOICES.get(x, "-")
-        ),
-        "created_date": lambda x: x.strftime("%d/%m/%Y %H:%M"),
-        "last_consultation__discharge_date": lambda x: x.strftime("%d/%m/%Y %H:%M"),
         "last_consultation__created_date": lambda x: x.strftime("%d/%m/%Y %H:%M"),
         "last_consultation__consultation_status": (
             lambda x: REVERSE_CONSULTATION_STATUS_CHOICES.get(x, "-")
         ),
+        "last_consultation__category": lambda x: REVERSE_CATEGORY_CHOICES.get(x, "-"),
+        "last_consultation__discharge_reason": (
+            lambda x: REVERSE_DISCHARGE_REASON_CHOICES.get(x, "-")
+        ),
+        "last_consultation__discharge_date": lambda x: x.strftime("%d/%m/%Y %H:%M"),
     }
 
 


### PR DESCRIPTION
## Proposed Changes

- [x] Rename "Date of consultation" to "Date of first consultation"
- [x] Date of registration column has both date and time. separate that into two columns "Date of registration" and "time of registration"
- [x] Same for Date of discharge
- [x] Same for Date of consultation
- [x] Add a column for insurance policy ID/Policy name
- [x] Reorder the export columns in the following order:
- Patient ID
- Patient Name
- Facility Name
- Gender
- Age
- Insurance policy name/ID
- Date and time of registration
- Status during the consultation
- Date and time of first consultation
- Diagnosis and Provisional Diagnosis
- Decision after consultation
- Category
- Discharge reason
- Date and time of discharge

### Associated Issue
  - Fixes coronasafe/care_fe#5309

[export_2023-04-13T16_03_13.035Z.csv](https://github.com/coronasafe/care/files/11224115/export_2023-04-13T16_03_13.035Z.csv)

![image](https://user-images.githubusercontent.com/25143503/231818822-e760e919-3ec2-44e7-b9ed-2a434cbbd4e9.png)

 
@coronasafe/code-reviewers

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
