### PR TITLE
Fix incorrect discharge date for patients

### DIFF
--- a/care/facility/api/viewsets/patient.py
+++ b/care/facility/api/viewsets/patient.py
@@ -416,10 +416,14 @@ class PatientViewSet(
                 raise serializers.ValidationError(
                     {"discharge_reason": "discharge reason is not valid"}
                 )
+            discharge_date = request.data.get("discharge_date", "")
             last_consultation.discharge_reason = reason
             last_consultation.discharge_notes = notes
             if last_consultation.discharge_date is None:
-                last_consultation.discharge_date = current_time
+                if discharge_date:
+                    last_consultation.discharge_date = discharge_date
+                else:
+                    last_consultation.discharge_date = current_time
             last_consultation.current_bed = None
             if reason == "EXP":
                 death_datetime = request.data.get("death_datetime")
@@ -439,7 +443,6 @@ class PatientViewSet(
                 discharge_prn_prescription = request.data.get(
                     "discharge_prn_prescription", []
                 )
-                discharge_date = request.data.get("discharge_date")
                 if discharge_date is None:
                     raise serializers.ValidationError(
                         {"discharge_date": "Please set the discharge date"}


### PR DESCRIPTION
Fixes the discharge date for patients, now the date sent via discharge form is checked first, if absent, only then it's set to current date

Submitted "06/04/2023" as discharge date on discharge form:
![image](https://user-images.githubusercontent.com/3626859/231971735-c6838bb6-6cc8-427c-887f-b2083008ad3f.png)

 
@coronasafe/code-reviewers