### PR TITLE
refactor discharge summary endpoints

### DIFF
--- a/care/facility/api/viewsets/patient.py
+++ b/care/facility/api/viewsets/patient.py
@@ -4,7 +4,6 @@ from json import JSONDecodeError
 
 from django.conf import settings
 from django.contrib.postgres.search import TrigramSimilarity
-from django.core.validators import validate_email
 from django.db import models
 from django.db.models import Case, When
 from django.db.models.query_utils import Q
@@ -51,9 +50,8 @@ from care.facility.models import (
     ShiftingRequest,
 )
 from care.facility.models.base import covert_choice_dict
-from care.facility.models.bed import AssetBed, ConsultationBed
+from care.facility.models.bed import AssetBed
 from care.facility.models.patient_base import DISEASE_STATUS_DICT
-from care.facility.tasks.patient.discharge_report import generate_discharge_report
 from care.users.models import User
 from care.utils.cache.cache_allowed_facilities import get_accessible_facilities
 from care.utils.filters import CareChoiceFilter, MultiSelectFilter
@@ -398,79 +396,6 @@ class PatientViewSet(
         return super(PatientViewSet, self).list(request, *args, **kwargs)
 
     @action(detail=True, methods=["POST"])
-    def discharge_patient(self, request, *args, **kwargs):
-        discharged = bool(request.data.get("discharge", False))
-        patient = self.get_object()
-        patient.is_active = discharged
-        patient.allow_transfer = not discharged
-        patient.review_time = None
-        patient.save(update_fields=["allow_transfer", "is_active", "review_time"])
-        last_consultation = (
-            PatientConsultation.objects.filter(patient=patient).order_by("-id").first()
-        )
-        current_time = localtime(now())
-        if last_consultation:
-            reason = request.data.get("discharge_reason")
-            notes = request.data.get("discharge_notes", "")
-            if reason not in DISCHARGE_REASONS:
-                raise serializers.ValidationError(
-                    {"discharge_reason": "discharge reason is not valid"}
-                )
-            discharge_date = request.data.get("discharge_date", "")
-            last_consultation.discharge_reason = reason
-            last_consultation.discharge_notes = notes
-            if last_consultation.discharge_date is None:
-                if discharge_date:
-                    last_consultation.discharge_date = discharge_date
-                else:
-                    last_consultation.discharge_date = current_time
-            last_consultation.current_bed = None
-            if reason == "EXP":
-                death_datetime = request.data.get("death_datetime")
-                death_confirmed_doctor = request.data.get("death_confirmed_doctor")
-                if death_datetime is None:
-                    raise serializers.ValidationError(
-                        {"death_datetime": "Please provide death date and time"}
-                    )
-                if death_confirmed_doctor is None:
-                    raise serializers.ValidationError(
-                        {"death_confirmed_doctor": "Please provide doctor details"}
-                    )
-                last_consultation.death_datetime = death_datetime
-                last_consultation.death_confirmed_doctor = death_confirmed_doctor
-            if reason == "REC":
-                discharge_prescription = request.data.get("discharge_prescription", [])
-                discharge_prn_prescription = request.data.get(
-                    "discharge_prn_prescription", []
-                )
-                if discharge_date is None:
-                    raise serializers.ValidationError(
-                        {"discharge_date": "Please set the discharge date"}
-                    )
-                last_consultation.discharge_prescription = discharge_prescription
-                last_consultation.discharge_prn_prescription = (
-                    discharge_prn_prescription
-                )
-                last_consultation.discharge_date = discharge_date
-            last_consultation.save()
-            ConsultationBed.objects.filter(
-                consultation=last_consultation, end_date__isnull=True
-            ).update(end_date=current_time)
-
-        return Response(status=status.HTTP_200_OK)
-
-    @action(detail=True, methods=["POST"])
-    def discharge_summary(self, request, *args, **kwargs):
-        patient = self.get_object()
-        email = request.data.get("email", "")
-        try:
-            validate_email(email)
-        except Exception:
-            email = request.user.email
-        generate_discharge_report.delay(patient.id, email)
-        return Response(status=status.HTTP_200_OK)
-
-    @action(detail=True, methods=["POST"])
     def transfer(self, request, *args, **kwargs):
         patient = PatientRegistration.objects.get(
             id=PatientSearch.objects.get(external_id=kwargs["external_id"]).patient_id
@@ -481,8 +406,8 @@ class PatientViewSet(
                 {"Patient": "Cannot Transfer Patient , Source Facility Does Not Allow"},
                 status=status.HTTP_406_NOT_ACCEPTABLE,
             )
-        patient.is_active = True
         patient.allow_transfer = False
+        patient.is_active = True
         serializer = self.get_serializer_class()(patient, data=request.data)
         serializer.is_valid(raise_exception=True)
         serializer.save()
@@ -497,10 +422,7 @@ class PatientViewSet(
             ~Q(status__in=[30, 50, 80]), patient=patient
         ):
             shifting_request.status = 30
-            shifting_request.comments = (
-                shifting_request.comments
-                + f"\n The shifting request was auto rejected by the system as the patient was moved to {patient.facility.name}"
-            )
+            shifting_request.comments = f"{shifting_request.comments}\n The shifting request was auto rejected by the system as the patient was moved to {patient.facility.name}"
             shifting_request.save(update_fields=["status", "comments"])
         return Response(data=response_serializer.data, status=status.HTTP_200_OK)
 

--- a/care/facility/models/file_upload.py
+++ b/care/facility/models/file_upload.py
@@ -27,6 +27,7 @@ class FileUpload(FacilityBaseModel):
         CONSULTATION = 2
         SAMPLE_MANAGEMENT = 3
         CLAIM = 4
+        DISCHARGE_SUMMARY = 5
 
     class FileCategory(enum.Enum):
         UNSPECIFIED = "UNSPECIFIED"
@@ -67,6 +68,10 @@ class FileUpload(FacilityBaseModel):
         max_length=100,
     )
 
+    def get_content(self):
+        response = self.get_object()
+        return response["Body"].read()
+
     def get_extension(self):
         parts = self.internal_name.split(".")
         return f".{parts[-1]}" if len(parts) > 1 else ""
@@ -77,30 +82,45 @@ class FileUpload(FacilityBaseModel):
             if self.internal_name:
                 parts = self.internal_name.split(".")
                 if len(parts) > 1:
-                    internal_name = internal_name + "." + parts[-1]
+                    internal_name = f"{internal_name}.{parts[-1]}"
             self.internal_name = internal_name
         return super().save(*args, **kwargs)
 
     def signed_url(self):
         s3Client = boto3.client("s3", **cs_provider.get_client_config())
-        signed_url = s3Client.generate_presigned_url(
+        return s3Client.generate_presigned_url(
             "put_object",
             Params={
                 "Bucket": settings.FILE_UPLOAD_BUCKET,
-                "Key": self.FileType(self.file_type).name + "/" + self.internal_name,
+                "Key": f"{self.FileType(self.file_type).name}/{self.internal_name}",
             },
-            ExpiresIn=60 * 60,  # One Hour
+            ExpiresIn=60 * 60,
         )
-        return signed_url
 
     def read_signed_url(self):
         s3Client = boto3.client("s3", **cs_provider.get_client_config())
-        signed_url = s3Client.generate_presigned_url(
+        return s3Client.generate_presigned_url(
             "get_object",
             Params={
                 "Bucket": settings.FILE_UPLOAD_BUCKET,
-                "Key": self.FileType(self.file_type).name + "/" + self.internal_name,
+                "Key": f"{self.FileType(self.file_type).name}/{self.internal_name}",
             },
-            ExpiresIn=60 * 60,  # One Hour
+            ExpiresIn=60 * 60,
         )
-        return signed_url
+    
+    def put_object(self, file, bucket=settings.FILE_UPLOAD_BUCKET, **kwargs):
+        s3 = boto3.client("s3", **cs_provider.get_client_config())
+        return s3.put_object(
+            Body=file,
+            Bucket=bucket,
+            Key=f"{self.FileType(self.file_type).name}/{self.internal_name}",
+            **kwargs,
+        )
+
+    def get_object(self, bucket=settings.FILE_UPLOAD_BUCKET, **kwargs):
+        s3 = boto3.client("s3", **cs_provider.get_client_config())
+        return s3.get_object(
+            Bucket=bucket,
+            Key=f"{self.FileType(self.file_type).name}/{self.internal_name}",
+            **kwargs,
+        )

--- a/care/facility/models/patient_consultation.py
+++ b/care/facility/models/patient_consultation.py
@@ -238,3 +238,9 @@ class PatientConsultation(PatientBaseModel, PatientRelatedPermissionMixin):
                 check=models.Q(admitted=False) | models.Q(admission_date__isnull=False),
             ),
         ]
+
+    def has_object_discharge_patient_permission(self, request):
+        return self.has_object_update_permission(request)
+    
+    def has_object_email_discharge_summary_permission(self, request):
+        return self.has_object_read_permission(request)

--- a/care/facility/static_data/icd11.py
+++ b/care/facility/static_data/icd11.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 
 from littletable import Table
@@ -39,3 +40,11 @@ for icd11_object in icd11_objects:
 
 ICDDiseases.create_search_index("label")
 ICDDiseases.create_index("id", unique=True)
+
+def get_icd11_diagnoses_objects_by_ids(diagnoses_ids):
+    diagnosis_objects = []
+    for diagnosis in diagnoses_ids:
+        with contextlib.suppress(BaseException):
+            diagnosis_object = ICDDiseases.by.id[diagnosis].__dict__
+            diagnosis_objects.append(diagnosis_object)
+    return diagnosis_objects

--- a/care/facility/tasks/patient/discharge_report.py
+++ b/care/facility/tasks/patient/discharge_report.py
@@ -1,81 +1,64 @@
-import datetime
-import logging
-import random
-import string
+import tempfile
 import time
+from datetime import timedelta
+from uuid import uuid4
 
+import boto3
 import celery
 from django.conf import settings
-from django.core.files.storage import default_storage
 from django.core.mail import EmailMessage
+from django.db.models import Q
 from django.template.loader import render_to_string
-from django.utils.timezone import make_aware
+from django.utils import timezone
 from hardcopy import bytestring_to_pdf
-import boto3
-from care.utils.csp import config as cs_provider
-from uuid import uuid4 as uuid
 
 from care.facility.models import (
     DailyRound,
-    PatientConsultation,
-    PatientRegistration,
-    PatientSample,
     Disease,
     InvestigationValue,
-    DiseaseStatusEnum,
+    PatientConsultation,
+    PatientSample,
 )
+from care.facility.models.file_upload import FileUpload
+from care.facility.static_data.icd11 import get_icd11_diagnoses_objects_by_ids
+from care.hcx.models.policy import Policy
+from care.utils.csp import config as cs_provider
 
 
-def randomString(stringLength):
-    letters = string.ascii_letters
-    return "".join(random.choice(letters) for i in range(stringLength))
-
-
-@celery.task()
-def generate_discharge_report_signed_url(patient_id):
-    patient = PatientRegistration.objects.get(external_id=patient_id)
-    consultations = PatientConsultation.objects.filter(patient=patient).order_by(
-        "-created_date"
+def get_discharge_summary_data(consultation: PatientConsultation):
+    samples = PatientSample.objects.filter(
+        patient=consultation.patient, consultation=consultation
     )
-    diseases = Disease.objects.filter(patient=patient)
-    if consultations.exists():
-        consultation = consultations.first()
-        samples = PatientSample.objects.filter(
-            patient=patient, consultation=consultation
-        )
-        daily_rounds = DailyRound.objects.filter(consultation=consultation)
-        investigations = InvestigationValue.objects.filter(consultation=consultation.id)
-        investigations = list(
-            filter(
-                lambda inv: inv.value is not None or inv.notes is not None,
-                investigations,
-            )
-        )
-    else:
-        consultation = None
-        samples = None
-        daily_rounds = None
-        investigations = None
-    date = make_aware(datetime.datetime.now())
-    disease_status = DiseaseStatusEnum(patient.disease_status).name.capitalize()
-    html_string = render_to_string(
-        "reports/patient_pdf_report.html",
-        {
-            "patient": patient,
-            "samples": samples,
-            "consultation": consultation,
-            "consultations": consultations,
-            "dailyrounds": daily_rounds,
-            "date": date,
-            "diseases": diseases,
-            "investigations": investigations,
-            "disease_status": disease_status,
-        },
+    hcx = Policy.objects.filter(patient=consultation.patient)
+    daily_rounds = DailyRound.objects.filter(consultation=consultation)
+    diagnosis = get_icd11_diagnoses_objects_by_ids(consultation.icd11_diagnoses)
+    provisional_diagnosis = get_icd11_diagnoses_objects_by_ids(
+        consultation.icd11_provisional_diagnoses
     )
-    filename = str(int(round(time.time() * 1000))) + randomString(10) + ".pdf"
+    investigations = InvestigationValue.objects.filter(
+        Q(consultation=consultation.id)
+        & (Q(value__isnull=False) | Q(notes__isnull=False))
+    )
+    medical_history = Disease.objects.filter(patient=consultation.patient)
+
+    return {
+        "patient": consultation.patient,
+        "samples": samples,
+        "hcx": hcx,
+        "diagnosis": diagnosis,
+        "provisional_diagnosis": provisional_diagnosis,
+        "consultation": consultation,
+        "dailyrounds": daily_rounds,
+        "medical_history": medical_history,
+        "investigations": investigations,
+    }
+
+
+def generate_discharge_summary_pdf(data, file):
+    html_string = render_to_string("reports/patient_pdf_report.html", data)
     bytestring_to_pdf(
         html_string.encode(),
-        default_storage.open(filename, "w+"),
+        file,
         **{
             "no-margins": None,
             "disable-gpu": None,
@@ -83,92 +66,105 @@ def generate_discharge_report_signed_url(patient_id):
             "window-size": "2480,3508",
         },
     )
-    file = default_storage.open(filename, "rb")
-
-    s3 = boto3.client(
-        "s3",
-        **cs_provider.get_client_config(),
-    )
-    image_location = f"discharge_summary/{uuid()}.pdf"
-    s3.put_object(
-        Bucket=settings.FILE_UPLOAD_BUCKET,
-        Key=image_location,
-        Body=file,
-    )
-
-    signed_url = s3.generate_presigned_url(
-        "get_object",
-        Params={
-            "Bucket": settings.FILE_UPLOAD_BUCKET,
-            "Key": image_location,
-        },
-        ExpiresIn=60 * 60 * 24 * 2,  # 2 days
-    )
-    default_storage.delete(filename)
-    return signed_url
 
 
 @celery.task()
-def generate_discharge_report(patient_id, email):
-    patient = PatientRegistration.objects.get(id=patient_id)
-    consultations = PatientConsultation.objects.filter(patient=patient).order_by(
-        "-created_date"
+def generate_and_upload_discharge_summary(consultation_id):
+    currnet_date = timezone.now()
+
+    consultation = PatientConsultation.objects.get(external_id=consultation_id)
+
+    file_db_entry: FileUpload = FileUpload.objects.create(
+        name=f"discharge_summary-{consultation.patient.name}-{currnet_date}.pdf",
+        internal_name=f"{uuid4()}.pdf",
+        file_type=FileUpload.FileType.DISCHARGE_SUMMARY.value,
+        associating_id=consultation.external_id,
     )
-    diseases = Disease.objects.filter(patient=patient)
-    if consultations.exists():
-        consultation = consultations.first()
-        samples = PatientSample.objects.filter(
-            patient=patient, consultation=consultation
+
+    data = get_discharge_summary_data(consultation)
+    data["date"] = currnet_date
+
+    with tempfile.NamedTemporaryFile(suffix=".pdf") as file:
+        generate_discharge_summary_pdf(data, file)
+        file_db_entry.put_object(file, ContentType="application/pdf")
+        file_db_entry.upload_completed = True
+        file_db_entry.save()
+
+    return file_db_entry
+
+
+@celery.task()
+def email_discharge_summary(consultation_id, email):
+    file = (
+        FileUpload.objects.filter(
+            file_type=FileUpload.FileType.DISCHARGE_SUMMARY.value,
+            associating_id=consultation_id,
         )
-        daily_rounds = DailyRound.objects.filter(consultation=consultation)
-        investigations = InvestigationValue.objects.filter(consultation=consultation.id)
-        investigations = list(
-            filter(
-                lambda inv: inv.value is not None or inv.notes is not None,
-                investigations,
-            )
-        )
-    else:
-        consultation = None
-        samples = None
-        daily_rounds = None
-        investigations = None
-    date = make_aware(datetime.datetime.now())
-    disease_status = DiseaseStatusEnum(patient.disease_status).name.capitalize()
-    html_string = render_to_string(
-        "reports/patient_pdf_report.html",
-        {
-            "patient": patient,
-            "samples": samples,
-            "consultation": consultation,
-            "consultations": consultations,
-            "dailyrounds": daily_rounds,
-            "date": date,
-            "diseases": diseases,
-            "investigations": investigations,
-            "disease_status": disease_status,
-        },
+        .order_by("-created_date")
+        .first()
     )
-    filename = str(int(round(time.time() * 1000))) + randomString(10) + ".pdf"
-    bytestring_to_pdf(
-        html_string.encode(),
-        default_storage.open(filename, "w+"),
-        **{
-            "no-margins": None,
-            "disable-gpu": None,
-            "disable-dev-shm-usage": False,
-            "window-size": "2480,3508",
-        },
-    )
-    file = default_storage.open(filename, "rb")
+
+    if file and file.created_date <= timezone.now() - timedelta(minutes=2):
+        # If the file is not uploaded in 10 minutes, delete the file and generate a new one
+        file.delete()
+        file = None
+
+    if file is None:
+        file = generate_and_upload_discharge_summary(consultation_id)
+        time.sleep(2)
+
+    if not file.upload_completed:
+        # wait for file to be uploaded
+        time.sleep(30)
+        if file.upload_completed:
+            file.refresh_from_db()
+        else:
+            return False
+
     msg = EmailMessage(
         "Patient Discharge Summary",
         "Please find the attached file",
         settings.DEFAULT_FROM_EMAIL,
         (email,),
     )
-    msg.content_subtype = "html"  # Main content is now text/html
-    msg.attach(patient.name + "-Discharge_Summary.pdf", file.read(), "application/pdf")
+    msg.content_subtype = "html"
+    msg.attach(file.name, file.get_content(), "application/pdf")
     msg.send()
-    # logging.error(filename, html_string, msg)
-    default_storage.delete(filename)
+
+    return True
+
+
+@celery.task()
+def generate_discharge_report_signed_url(patient_external_id):
+    consultation = (
+        PatientConsultation.objects.filter(patient__external_id=patient_external_id)
+        .order_by("-created_date")
+        .first()
+    )
+    if not consultation:
+        return None
+
+    data = get_discharge_summary_data(consultation)
+
+    signed_url = None
+    with tempfile.NamedTemporaryFile(suffix=".pdf") as file:
+        generate_discharge_summary_pdf(data, file)
+        s3 = boto3.client(
+            "s3",
+            **cs_provider.get_client_config(),
+        )
+        image_location = f"discharge_summary/{uuid4()}.pdf"
+        s3.put_object(
+            Bucket=settings.FILE_UPLOAD_BUCKET,
+            Key=image_location,
+            Body=file,
+        )
+        signed_url = s3.generate_presigned_url(
+            "get_object",
+            Params={
+                "Bucket": settings.FILE_UPLOAD_BUCKET,
+                "Key": image_location,
+            },
+            ExpiresIn=2 * 24 * 60 * 60,  # seconds
+        )
+    return signed_url

--- a/care/facility/templatetags/filters.py
+++ b/care/facility/templatetags/filters.py
@@ -1,4 +1,5 @@
 from django.template import Library
+from datetime import datetime
 
 register = Library()
 
@@ -16,3 +17,11 @@ def suggestion_string(suggestion_code: str):
     if suggestion_code == "DC":
         return "Domiciliary Care"
     return "Other"
+
+@register.filter()
+def field_name_to_label(value):
+    return value.replace('_', ' ').capitalize()
+
+@register.filter(expects_localtime=True)
+def parse_datetime(value):
+    return datetime.strptime(value, "%Y-%m-%dT%H:%M")

--- a/care/templates/reports/patient_pdf_report.html
+++ b/care/templates/reports/patient_pdf_report.html
@@ -1,479 +1,586 @@
-{% load filters %}
+{% load filters static %}
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link href="https://unpkg.com/tailwindcss@^1.0/dist/tailwind.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tailwindcss/ui@latest/dist/tailwind-ui.min.css">
-    <style>
-      @media print {
-      pre, div, dt, dd, blockquote {page-break-inside: avoid;}
-      @page { margin: 0; }
-      body { margin: 1.6cm; }
+
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="https://unpkg.com/tailwindcss@^1.0/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tailwindcss/ui@latest/dist/tailwind-ui.min.css">
+  <style>
+    @media print {
+
+      /* pre,
+      div,
+      dt,
+      dd,
+      blockquote {
+        page-break-inside: avoid;
+      } */
+
+      @page {
+        margin: 1.6cm;
       }
-    </style>
-  </head>
-  <body class="max-w-5xl mx-10 mt-4 text-sm">
-  <div class="bg-white overflow-hidden  sm:rounded-lg m-6">
+
+      body {
+        margin: 0;
+      }
+    }
+  </style>
+</head>
+
+<body class="max-w-5xl mx-10 mt-4 text-sm">
+  <div class="bg-white overflow-hidden m-6">
   </div>
-   <div class="mt-2 text-center w-full font-bold text-3xl">
+  <div class="mt-2 text-center w-full font-bold text-3xl">
     {{patient.facility.name}}
-   </div>
-  <div class="px-4 py-5 border-b border-gray-200 sm:px-6 flex justify-between">
-  <div class="mt-4">
+  </div>
+  <div class="px-4 py-5 border-b border-gray-200 flex justify-between">
+    <div class="mt-4">
+      <h3 class="text-lg text-gray-900">
+        Patient Discharge Summary
+      </h3>
+      <p class="mt-1 text-sm text-gray-500">
+        Created on {{date}}
+      </p>
+    </div>
+    <img class='h-12' src="https://cdn.coronasafe.network/black-logo.svg"/>
+  </div>
+  <div class="px-4 py-5 ">
+    <div class="flex flex-wrap gap-x-2">
+      <p>
+        <span class="text-sm text-gray-500">Full name:</span> {{patient.name}}
+      </p>
+      <p>
+        <span class="text-sm text-gray-500">Gender:</span> {{patient.get_gender_display}}
+      </p>
+      <p>
+        <span class="text-sm text-gray-500">Age:</span> {{patient.age}}
+      </p>
+      <p>
+        <span class="text-sm text-gray-500">Date of Birth:</span> {{patient.date_of_birth}}
+      </p>
+      <p>
+        <span class="text-sm text-gray-500">Blood Group:</span> {{patient.blood_group}}
+      </p>
+    </div>
+    <div class="flex flex-wrap gap-x-2">
+      <p class="w-max flex-shrink-0">
+        <span class="text-sm text-gray-500">Phone Number:</span> {{patient.phone_number}}
+      </p>
+      <p class="flex-grow">
+        <span class="text-sm text-gray-500">Address:</span> {{patient.address}}
+      </p>
+    </div>
+  </div>
+
+  <div class=" px-4 py-5 border-b border-t border-gray-200">
     <h3 class="text-lg leading-6 font-medium text-gray-900">
-      Patient Discharge Summary
+      Admission Details
     </h3>
-    <p class="mt-1 text-sm leading-5 text-gray-500">
-      Created on {{date}}
+  </div>
+  <div class="px-4 py-5">
+    <p>
+      <span class="text-sm leading-5 font-medium text-gray-500">Status during consultation:</span>
+      {{consultation.get_consultation_status_display|field_name_to_label}}
     </p>
-    <div class="flex w-full justify-between">
-      <p class="mt-1 text-sm  leading-5 text-gray-500 mr-10">
-        Id:  {{patient.external_id}}
+    <p>
+      <span class="text-sm leading-5 font-medium text-gray-500">Decision after consultation:</span>
+      {{consultation.get_suggestion_display|field_name_to_label}}
+    </p>
+    {% if consultation.suggestion == 'A' %}
+    <p>
+      <span class="text-sm leading-5 font-medium text-gray-500">Date of addmission:</span>
+      {{consultation.admission_date.date}}
+    </p>
+    {% elif consultation.suggestion == 'R' %}
+    <p>
+      <span class="text-sm leading-5 font-medium text-gray-500">Reffered to:</span>
+      {{consultation.referred_to.name}}
+    </p>
+    {% elif consultation.suggestion == 'DD' %}
+    <p>
+      <span class="text-sm leading-5 font-medium text-gray-500">Cause of death:</span>
+      {{consultation.discharge_notes}}
+    </p>
+    <p>
+      <span class="text-sm leading-5 font-medium text-gray-500">Date and time of death:</span>
+      {{consultation.death_datetime}}
+    </p>
+    <p>
+      <span class="text-sm leading-5 font-medium text-gray-500">Death Confirmed by:</span>
+      {{consultation.death_confirmed_by}}
+    </p>
+    {% endif %}
+    <div class="flex gap-6">
+      <p>
+        <span class="mt-1 text-sm leading-5 text-gray-500">IP No:</span> {{consultation.ip_no}}
       </p>
-        {% if consultation.ip_no %}
-      <p class="mt-1 text-sm leading-5 text-gray-500">
-        IP No:  {{consultation.ip_no}}
+      <p>
+        <span class="text-sm leading-5 font-medium text-gray-500">Weight: </span>
+        {{consultation.weight}} kg
       </p>
-  {% endif %}
+      <p>
+        <span class="text-sm leading-5 font-medium text-gray-500">Height:</span>
+        {{consultation.height}} cm
+      </p>
     </div>
+    {% if consultation.consultation_status != 1 %}
+    <div class="flex gap-6">
+      <p>
+        <span class="text-sm leading-5 font-medium text-gray-500">Symptoms at admission:</span>
+        {{consultation.get_symptoms_display|title}}
+      </p>
+      <p>
+        <span class="text-sm leading-5 font-medium text-gray-500">From:</span>
+        {{consultation.symptoms_onset_date.date}}
+      </p>
+    </div>
+    <p>
+      <span class="text-sm leading-5 font-medium text-gray-500">History of present illness:</span>
+      {{consultation.history_of_present_illness}}
+    </p>
+    {% endif %}
+    <p>
+      <span class="text-sm leading-5 font-medium text-gray-500">Examination details and Clinical conditions:</span>
+      {{consultation.examination_details}}
+    </p>
+
+    {% if hcx %}
+    <h4 class="mt-4 font-medium text-gray-500">
+      Health insurance details:
+    </h4>
+
+    <div class="">
+      <table class="min-w-full">
+        <thead>
+          <tr
+            class="border-b border-gray-200 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+            <th class="p-2">
+              Insurer Name
+            </th>
+            <th class="p-2">
+              Issuer ID
+            </th>
+            <th class="p-2">
+              Member ID
+            </th>
+            <th class="p-2">
+              Policy ID
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for policy in hcx %}
+          <tr class="bg-white">
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 font-medium text-gray-900">
+              {{policy.insurer_name}}
+            </td>
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500">
+              {{policy.insurer_id}}
+            </td>
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500">
+              {{policy.subscriber_id}}
+            </td>
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500">
+              {{policy.policy_id}}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% endif %}
+
+    {% if provisional_diagnosis %}
+    <h4 class="mt-4 font-medium text-gray-500">
+      Provisional Diagnosis (as per ICD-11 recommended by WHO):
+    </h4>
+    <div class="">
+      <table class="min-w-full">
+        <thead>
+          <tr
+            class="border-b border-gray-200 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+            <th class="p-2">
+              ID
+            </th>
+            <th class="p-2">
+              Name
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for disease in provisional_diagnosis %}
+          <tr class="bg-white">
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 font-medium text-gray-900">
+              {{disease.id}}
+            </td>
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500">
+              {{disease.label}}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% endif %}
+
+    {% if diagnosis %}
+    <h4 class="mt-4 font-medium text-gray-500">
+      Diagnosis (as per ICD-11 recommended by WHO):
+    </h4>
+    <div class="">
+      <table class="min-w-full">
+        <thead>
+          <tr
+            class="border-b border-gray-200 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+            <th class="p-2">
+              ID
+            </th>
+            <th class="p-2">
+              Name
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for disease in diagnosis %}
+          <tr class="bg-white">
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 font-medium text-gray-900">
+              {{disease.id}}
+            </td>
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500">
+              {{disease.label}}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% endif %}
+
+
+    {% if medical_history %}
+    <h4 class="mt-4 font-medium text-gray-500">
+      Comorbidities:
+    </h4>
+    <div class="">
+      <table class="min-w-full">
+        <thead>
+          <tr
+            class="border-b border-gray-200 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+            <th class="p-2">
+              Comorbidity
+            </th>
+            <th class="p-2">
+              Details
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for disease in medical_history %}
+          <tr class="bg-white">
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 font-medium text-gray-900">
+              {{disease.get_disease_display}}
+            </td>
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500">
+              {{disease.details}}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% endif %}
   </div>
-   <img class='h-12' src="https://cdn.coronasafe.network/black-logo.svg"/>
-   </div>
-  <div class="px-4 py-5 sm:px-6">
-    <dl class="">
-    <div class="flex flex-wrap justify-between">
-      <div class="w-1/2 mt-4">
-        <dt class="text-sm leading-5 font-medium text-gray-500">
-          Full name
-        </dt>
-        <dd class="mt-1 text-sm leading-5 text-gray-900">
-          {{patient.name}}
-        </dd>
-      </div>
-      <div class="w-1/2 mt-4">
-        <dt class="text-sm leading-5 font-medium text-gray-500">
-          Age
-        </dt>
-        <dd class="mt-1 text-sm leading-5 text-gray-900">
-          {{patient.age}}
-        </dd>
-      </div>
-      <div class="w-1/2 mt-4">
-        <dt class="text-sm leading-5 font-medium text-gray-500">
-          Date of Birth
-        </dt>
-        <dd class="mt-1 text-sm leading-5 text-gray-900">
-          {{patient.date_of_birth}}
-        </dd>
-      </div>
-      <div class="w-1/2 mt-4">
-        <dt class="text-sm leading-5 font-medium text-gray-500">
-          Gender
-        </dt>
-        <dd class="mt-1 text-sm leading-5 text-gray-900">
-          {{patient.get_gender_display}}
-        </dd>
-      </div>
 
-      <div class="w-1/2 mt-4">
-        <dt class="text-sm leading-5 font-medium text-gray-500">
-          Address
-        </dt>
-        <dd class="mt-1 text-sm leading-5 text-gray-900">
-          {{patient.address}}
-        </dd>
-      </div>
-
-      <div class="w-1/2 mt-4">
-        <dt class="text-sm leading-5 font-medium text-gray-500">
-          Phone Number
-        </dt>
-        <dd class="mt-1 text-sm leading-5 text-gray-900">
-          {{patient.phone_number}}
-        </dd>
-      </div>
-
-      <div class="w-1/2 mt-4">
-        <dt class="text-sm leading-5 font-medium text-gray-500">
-          Date of Admission
-        </dt>
-        <dd class="mt-1 text-sm leading-5 text-gray-900">
-          {{consultation.admission_date.date}}
-        </dd>
-      </div>
-      <div class="w-1/2 mt-4">
-        <dt class="text-sm leading-5 font-medium text-gray-500">
-          Date of Discharge
-        </dt>
-        <dd class="mt-1 text-sm leading-5 text-gray-900">
-          {{consultation.discharge_date.date}}
-          </dd>
-          </div>
-          <div class="w-1/2 mt-4">
-            <dt class="text-sm leading-5 font-medium text-gray-500">
-              Date of admission to care
-            </dt>
-            <dd class="mt-1 text-sm leading-5 text-gray-900">
-              {{patient.created_date.date}}
-            </dd>
-          </div>
-          <div class="w-1/2 mt-4">
-            <dt class="text-sm leading-5 font-medium text-gray-500">
-              Date of admission to current facility
-            </dt>
-            <dd class="mt-1 text-sm leading-5 text-gray-900">
-              {{consultation.created_date.date}}
-            </dd>
-          </div>
-          <div class="w-1/2 mt-4">
-            <dt class="text-sm leading-5 font-medium text-gray-500">
-              Disease Status
-            </dt>
-            <dd class="mt-1 text-sm leading-5 text-gray-900">
-              {{ disease_status }}
-            </dd>
-          </div>
-          <div class="w-1/2 mt-4">
-            <dt class="text-sm leading-5 font-medium text-gray-500">
-              SRF ID
-            </dt>
-            <dd class="mt-1 text-sm leading-5 text-gray-900">
-              {{patient.srf_id}}
-            </dd>
-          </div>
-          <div class="w-1/2 mt-4">
-            <dt class="text-sm leading-5 font-medium text-gray-500">
-              Date of result
-            </dt>
-            <dd class="mt-1 text-sm leading-5 text-gray-900">
-              {{patient.date_of_result.date}}
-            </dd>
-          </div>
-          </div>
-          <div class="mt-4">
-            <dt class="text-sm leading-5 font-medium text-gray-500">
-              Prescriptions
-            </dt>
-            <dd class="mt-1 text-sm leading-5 text-gray-900">
-              {{consultation.prescription}}
-        </dd>
-      </div>
-      </div>
-      <div class="mt-4">
-        <dt class="text-sm leading-5 font-medium text-gray-500">
-          Diagnosis
-        </dt>
-        <dd class="mt-1 text-sm leading-5 text-gray-900">
-          {{consultation.diagnosis}}
-        </dd>
-      </div>
-      <div class="mt-4">
-        <dt class="text-sm leading-5 font-medium text-gray-500">
-          Symptoms
-        </dt>
-        <dd class="mt-1 text-sm leading-5 text-gray-900">
-          {{consultation.symptoms}}
-        </dd>
-      </div>
-      <div class="mt-4">
-        <dt class="text-sm leading-5 font-medium text-gray-500">
-          History of Present Illness
-        </dt>
-        <dd class="mt-1 text-sm leading-5 text-gray-900">
-          {{consultation.history_of_present_illness}}
-        </dd>
-      </div>
-      <div class="mt-4">
-        <dt class="text-sm leading-5 font-medium text-gray-500">
-          Clinical Condition on Admission
-        </dt>
-        <dd class="mt-1 text-sm leading-5 text-gray-900">
-          {{consultation.examination_details}}
-        </dd>
-      </div>
-      <div class="mt-4">
-        <dt class="text-sm leading-5 font-medium text-gray-500">
-          Treatment Summary
-        </dt>
-        <dd class="mt-1 text-sm leading-5 text-gray-900">
-          {{consultation.prescribed_medication}}
-        </dd>
-      </div>
-      <div class="mt-4">
-        <dt class="text-sm leading-5 font-medium text-gray-500">
-         Advice
-        </dt>
-        <dd class="mt-1 text-sm leading-5 text-gray-900">
-        {{consultation.consultation_notes}}
-        </dd>
-      </div>
-    </dl>
-  </div>
-  {% if consultation.discharge_advice %}
-  <div class="px-4 py-5 border-b border-t border-gray-200 sm:px-6">
+  {% if consultation.suggestion != 'DD' %}
+  <div class="mt-4 px-4 py-5 border-b border-t border-gray-200">
     <h3 class="text-lg leading-6 font-medium text-gray-900">
-      Medications
+      Treatment Summary
     </h3>
   </div>
-  <div class="mt-4">
-    <div class="flex flex-col">
-      <div class="-my-2 py-2 overflow-x-auto sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
-        <div class="align-middle inline-block min-w-full shadow overflow-hidden sm:rounded-lg border-b border-gray-200">
-          <table class="min-w-full">
-            <thead>
-            <tr>
-              <th
-                class="px-1 py-1 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
-                Medicine
-              </th>
-              <th
-                class="px-1 py-1 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
-                Frequency
-              </th>
-              <th
-                class="px-1 py-1 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
-                Days
-              </th>
-            </tr>
-            </thead>
-            <tbody>
+  <div class="px-4 py-5">
+    {% if consultation.investigation %}
+    <h4 class="mt-2 font-medium text-gray-500">
+      Investigations Suggestions:
+    </h4>
+    <div class="">
+      <table class="min-w-full">
+        <thead>
+          <tr
+            class="border-b border-gray-200 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+            <th class="p-2">
+              Type
+            </th>
+            <th class="p-2">
+              Time
+            </th>
+            <th class="p-2">
+              Notes
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for investigation in consultation.investigation %}
+          <tr class="bg-white">
+            <td class="px-1 py-1 whitespace-normal text-sm leading-5 font-medium text-gray-900">
+              {{investigation.type|join:", "}}
+            </td>
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500">
+              {% if investigation.repetitive %}
+              every {{investigation.frequency}}
+              {% else %}
+              {{investigation.time|parse_datetime}}
+              {% endif %}
+            </td>
+            <td class="px-1 py-1 whitespace-normal text-sm leading-5 text-gray-500">
+              {{investigation.notes}}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% endif %}
+
+    {% if consultation.discharge_advice %}
+    <h4 class="mt-2 font-medium text-gray-500">
+      Prescription Medication:
+    </h4>
+    <div class="">
+      <table class="min-w-full">
+        <thead>
+          <tr
+            class="border-b border-gray-200 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+            <th class="p-2">
+              Medicine
+            </th>
+            <th class="p-2">
+              Dosage
+            </th>
+            <th class="p-2">
+              Route
+            </th>
+            <th class="p-2">
+              Frequency
+            </th>
+            <th class="p-2">
+              Days
+            </th>
+            <th class="p-2">
+              Notes
+            </th>
+          </tr>
+        </thead>
+        <tbody>
           {% for prescription in consultation.discharge_advice %}
-              <tr class="bg-white">
-                <td class="px-1 py-1 border-t text-sm leading-5 font-medium text-gray-900">
-                  {{ prescription.medicine }}
-                </td>
-                <td class="px-1 py-1 border-t text-sm leading-5 text-gray-500">
-                {{ prescription.dosage }}
-                </td>
-                <td class="px-1 py-1 border-t text-sm leading-5 text-gray-500">
-                  {{ prescription.days }}
-                </td>
-              </tr>
-            {% endfor %}
-            </tbody>
-          </table>
-        </div>
-      </div>
+          <tr class="bg-white">
+            <td class="px-1 py-1 text-sm leading-5 font-medium text-gray-900">
+              {{ prescription.medicine }}
+            </td>
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500">
+              {{ prescription.dosage_new }}
+            </td>
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500">
+              {{ prescription.route }}
+            </td>
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500">
+              {{ prescription.dosage }}
+            </td>
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500">
+              {{ prescription.days }}
+            </td>
+            <td class="px-1 py-1 whitespace-normal text-sm leading-5 text-gray-500">
+              {{ prescription.notes }}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
     </div>
-  </div>
-  {% endif %}
-  <div class="px-4 py-5 border-b border-t border-gray-200 sm:px-6">
-    <h3 class="text-lg leading-6 font-medium text-gray-900">
-      Consultation History
-    </h3>
-  </div>
-  <div class="mt-4">
-    <div class="flex flex-col">
-      <div class="-my-2 py-2 overflow-x-auto sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
-        <div class="align-middle inline-block min-w-full shadow overflow-hidden sm:rounded-lg border-b border-gray-200">
-          <table class="min-w-full">
-            <thead>
-              <tr>
-                <th
-                  class="px-1 py-1 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
-                  Facility
-                </th>
-                <th
-                  class="px-1 py-1 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
-                  Updated On
-                </th>
-                <th
-                  class="px-1 py-1 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
-                  Suggestion
-                </th>
-                <th
-                  class="px-1 py-1 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
-                  Admitted
-                </th>
-                <th
-                  class="px-1 py-1 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
-                  Admitted On
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for cons in consultations %}
-              <tr class="bg-white">
-                <td class="px-1 py-1 border-t whitespace-no-wrap text-sm leading-5 font-medium text-gray-900">
-                  {{cons.facility.name}}
-                </td>
-                <td class="px-1 py-1 border-t whitespace-no-wrap text-sm leading-5 text-gray-500">
-                  {{cons.modified_date.date}}
-                </td>
-                <td class="px-1 py-1 border-t whitespace-no-wrap text-sm leading-5 text-gray-500">
-                  {{cons.suggestion|suggestion_string}}
+    {% endif %}
 
-                </td>
-                <td class="px-1 py-1 border-t whitespace-no-wrap text-sm leading-5 text-gray-500">
-                  {% if cons.admitted %}
-                  Yes
-                  {% else %}
-                  No
-                  {% endif %}
-                </td>
-                <td class="px-1 py-1 border-t whitespace-no-wrap text-sm leading-5 text-gray-500">
-                  {% if cons.admitted %}
-                  {{cons.admission_date.date}}
-                  {% else %}
-                  <span class="block w-full text-center">-</span>
-                  {% endif %}
-                </td>
-                </tr>
-                {% endfor %}
-                </tbody>
-                </table>
-                </div>
-                </div>
-                </div>
-                </div>
-                <div class="px-4 py-5 border-b border-t border-gray-200 sm:px-6">
-                  <h3 class="text-lg leading-6 font-medium text-gray-900">
-                    Prescriptions
-                  </h3>
-                </div>
-                <div class="mt-4">
-                  <div class="flex flex-col">
-                    <div class="-my-2 py-2 overflow-x-auto sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
-                      <div class="align-middle inline-block min-w-full shadow overflow-hidden sm:rounded-lg border-b border-gray-200">
-                        <table class="min-w-full">
-                          <thead>
-                            <tr>
-                              <th
-                                class="px-1 py-1 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
-                                Medicine
-                              </th>
-                              <th
-                                class="px-1 py-1 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
-                                Frequency
-                              </th>
-                              <th
-                                class="px-1 py-1 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
-                                Days
-                              </th>
-                            </tr>
-                          </thead>
-                          <tbody>
-                            {% for daily_round in dailyrounds %}
-                            {% for prescription in daily_round.medication_given %}
-                            <tr class="bg-white">
-                              <td class="px-1 py-1 border-t whitespace-no-wrap text-sm leading-5 font-medium text-gray-900">
-                                {{prescription.medicine}}
-                              </td>
-                              <td class="px-1 py-1 border-t whitespace-no-wrap text-sm leading-5 font-medium text-gray-900">
-                                {{prescription.dosage}}
-                              </td>
-                              <td class="px-1 py-1 border-t whitespace-no-wrap text-sm leading-5 font-medium text-gray-900">
-                                {{prescription.days}}
-                              </td>
-                            </tr>
-                            {% endfor %}
-                            {% endfor %}
-                          </tbody>
-                        </table>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-  {% if diseases %}
-  <div class="px-4 py-5 border-b border-t border-gray-200 sm:px-6">
-    <h3 class="text-lg leading-6 font-medium text-gray-900">
-      Comorbidities
-    </h3>
-  </div>
-  <div class="mt-4">
-    <div class="flex flex-col">
-      <div class="-my-2 py-2 overflow-x-auto sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
-        <div class="align-middle inline-block min-w-full shadow overflow-hidden sm:rounded-lg border-b border-gray-200">
-          <table class="min-w-full">
-            <thead>
-            <tr>
-              <th class="px-6 py-3 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
-                Comorbidity
-              </th>
-              <th class="px-6 py-3 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
-                Details
-              </th>
-            </tr>
-            </thead>
-            <tbody>
-          {% for disease in diseases %}
-              <tr class="bg-white">
-                <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 font-medium text-gray-900">
-                  {{disease.get_disease_display}}
-                </td>
-                <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500">
-                  {{disease.details}}
-                </td>
-              </tr>
-            {% endfor %}
-            </tbody>
-          </table>
-        </div>
-      </div>
+    {% if consultation.prn_prescription %}
+    <h4 class="mt-2 font-medium text-gray-500">
+      PRN Prescription:
+    </h4>
+    <div class="">
+      <table class="min-w-full">
+        <thead>
+          <tr
+            class="border-b border-gray-200 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+            <th class="p-2">
+              Medicine
+            </th>
+            <th class="p-2">
+              Dosage
+            </th>
+            <th class="p-2">
+              Max Dosage
+            </th>
+            <th class="p-2">
+              Min Time btwn. 2 doses
+            </th>
+            <th class="p-2">
+              Route
+            </th>
+            <th class="p-2">
+              Indicator
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for prescription in consultation.prn_prescription %}
+          <tr class="bg-white">
+            <td class="px-1 py-1 text-sm leading-5 font-medium text-gray-900">
+              {{ prescription.medicine }}
+            </td>
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500">
+              {{ prescription.dosage }}
+            </td>
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500">
+              {{ prescription.max_dosage }}
+            </td>
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500">
+              {{ prescription.min_time }} Hrs.
+            </td>
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500">
+              {{ prescription.route }}
+            </td>
+            <td class="px-1 py-1 text-sm leading-5 text-gray-500">
+              {{ prescription.indicator }}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
     </div>
-  </div>
-  {% endif %}
+    {% endif %}
 
-  {% if samples %}
-  <div class="px-4 py-5 border-b border-t border-gray-200 sm:px-6">
-    <h3 class="text-lg leading-6 font-medium text-gray-900">
-      LAB REPORT
-    </h3>
-  </div>
-  <div class="px-4 py-5 sm:px-6">
-    <div class="flex flex-col">
-      <div class="-my-2 py-2 overflow-x-auto sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
-        <div class="align-middle inline-block min-w-full">
-          <table class="min-w-full">
-            <thead>
-              <tr>
-                <th class="px-6 py-3 border border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
-                  Requested on
-                </th>
-                <th class="px-6 py-3 border border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
-                  Sample type
-                </th>
-                <th class="px-6 py-3 border border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
-                  Label
-                </th>
-                <th class="px-6 py-3 border border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
-                  Result
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-            {% for sample in samples %}
-              <tr class="bg-white">
-                <td class="px-6 py-4 border border-gray-200  text-sm leading-5 font-medium text-gray-900">
-                  {{sample.created_date}}
-                </td>
-                <td class="px-6 py-4 border border-gray-200  text-sm leading-5 text-gray-500">
-                  {{sample.get_sample_type_display}}
-                </td>
-                <td class="px-6 py-4 border border-gray-200  text-sm leading-5 text-gray-500">
-                  {{sample.icmr_label}}
-                </td>
-                <td class="px-6 py-4 border border-gray-200  text-sm leading-5 text-gray-500">
-                  {{sample.get_result_display}}
-                </td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div>
-      </div>
+    {% if consultation.procedure %}
+    <h4 class="mt-2 font-medium text-gray-500">
+      Procedures:
+    </h4>
+    <div class="">
+      <table class="min-w-full">
+        <thead>
+          <tr
+            class="border-b border-gray-200 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+            <th class="p-2">
+              Procedure
+            </th>
+            <th class="p-2">
+              Time
+            </th>
+            <th class="p-2">
+              Notes
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for procedure in consultation.procedure %}
+          <tr class="bg-white">
+            <td class="px-1 py-1 whitespace-normal text-sm leading-5 font-medium text-gray-900">
+              {{procedure.procedure}}
+            </td>
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500">
+              {% if procedure.repetitive %}
+              every {{procedure.frequency}}
+              {% else %}
+              {{procedure.time|parse_datetime}}
+              {% endif %}
+            </td>
+            <td class="px-1 py-1 whitespace-normal text-sm leading-5 text-gray-500">
+              {{procedure.notes}}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
     </div>
-  </div>
-  {% endif %}
-  {% if dailyrounds %}
-  <div class="px-4 py-5 border-b border-t border-gray-200 sm:px-6">
-    <h3 class="text-lg leading-6 font-medium text-gray-900">
-      Daily Summary
-    </h3>
-  </div>
-  {% for daily_round in dailyrounds %}
+    {% endif %}
+
+    {% if consultation.prescribed_medication %}
+    <h4 class="mt-2 font-medium text-gray-500">
+      prescribed_medication:
+    </h4>
+    <p>
+      consultation.prescribed_medication
+    </p>
+    {% endif %}
+
+    {% if consultation.consultation_notes %}
+    <h4 class="mt-2 font-medium text-gray-500">
+      General Instructions (Advice):
+    </h4>
+    <p>
+      {{consultation.consultation_notes}}
+    </p>
+    {% endif %}
+
+    {% if consultation.special_instruction %}
+    <h4 class="mt-2 font-medium text-gray-500">
+      Special Instructions:
+    </h4>
+    <p>
+      {{consultation.special_instruction}}
+    </p>
+    {% endif %}
+
+
+    {% if samples %}
+    <h4 class="mt-2 font-medium text-gray-500">
+      Lab Reports:
+    </h4>
+    <div class="px-4 py-5 sm:px-6">
+      <table class="min-w-full">
+        <thead>
+          <tr>
+            <th
+              class="px-6 py-3 border border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+              Requested on
+            </th>
+            <th
+              class="px-6 py-3 border border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+              Sample type
+            </th>
+            <th
+              class="px-6 py-3 border border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+              Label
+            </th>
+            <th
+              class="px-6 py-3 border border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+              Result
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for sample in samples %}
+          <tr class="bg-white">
+            <td class="px-6 py-4 border border-gray-200  text-sm leading-5 font-medium text-gray-900">
+              {{sample.created_date}}
+            </td>
+            <td class="px-6 py-4 border border-gray-200  text-sm leading-5 text-gray-500">
+              {{sample.get_sample_type_display}}
+            </td>
+            <td class="px-6 py-4 border border-gray-200  text-sm leading-5 text-gray-500">
+              {{sample.icmr_label}}
+            </td>
+            <td class="px-6 py-4 border border-gray-200  text-sm leading-5 text-gray-500">
+              {{sample.get_result_display}}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% endif %}
+
+    {% if dailyrounds %}
+    <h4 class="mt-2 font-medium text-gray-500">
+      Daily Rounds:
+    </h4>
+    {% for daily_round in dailyrounds %}
     <div class="rounded mt-2 border border-gray-200 rounded-lg">
       <div class="px-2 py-2 sm:p-4">
         <h3 class="text-lg leading-6 font-medium text-gray-900">
@@ -487,14 +594,6 @@
               </dt>
               <dd class="mt-1 text-sm leading-5 text-gray-900">
                 {{daily_round.get_patient_category_display}}
-              </dd>
-            </div>
-            <div class="sm:col-span-1">
-              <dt class="text-sm leading-5 font-medium text-gray-500">
-                Current health
-              </dt>
-              <dd class="mt-1 text-sm leading-5 text-gray-900">
-                {{daily_round.get_current_health_display}}
               </dd>
             </div>
           </div>
@@ -525,87 +624,220 @@
         </div>
       </div>
     </div>
-  {% endfor %}
-  {% endif %}
-  <div class="px-4 py-5 border-b border-t border-gray-200 sm:px-6">
-    <h3 class="text-lg leading-6 font-medium text-gray-900">
-      Investigation History
-    </h3>
-  </div>
-  <div class="mt-4">
-    <div class="flex flex-col">
-      <div class="-my-2 py-2 overflow-x-auto sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
-        <div class="align-middle inline-block min-w-full shadow overflow-hidden sm:rounded-lg border-b border-gray-200">
-          <table class="min-w-full">
-            <thead>
-              <tr>
-                <th
-                  class="px-1 py-1 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
-                  Group
-                  </th>
-                  <th
-                    class="px-1 py-1 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
-                  Name
-                  </th>
-                  <th
-                    class="px-1 py-1 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
-                  Result
-                </th>
-                <th
-                  class="px-1 py-1 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
-                  Range
-                </th>
-                <th
-                  class="px-1 py-1 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
-                  Date
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for investigation in investigations %}
-              <tr class="bg-white">
-                <td class="px-1 py-1 border-t whitespace-no-wrap text-sm leading-5 font-medium text-gray-900">
-                  {{investigation.investigation.groups.first}}
-                </td>
-                <td class="px-1 py-1 border-t whitespace-no-wrap text-sm leading-5 font-medium text-gray-900">
-                  {{investigation.investigation.name}}
-                </td>
-                <td class="px-1 py-1 border-t whitespace-no-wrap text-sm leading-5 font-medium text-gray-900">
-                  {% if investigation.value%}
-                  {{investigation.value}}
-                  {% else %}
-                  {{investigation.notes}}
-                  {% endif %}
-                </td>
-                <td class="px-1 py-1 border-t whitespace-no-wrap text-sm leading-5 font-medium text-gray-900">
-                  {% if investigation.investigation.min_value and investigation.investigation.max_value%}
-                  {{investigation.investigation.min_value}} - {{investigation.investigation.max_value}}
-                  {% else %}
-                  -
-                  {% endif %}
-                  {% if investigation.investigation.unit %}
-                  {{investigation.investigation.unit}}
-                  {% endif %}
-                </td>
-                <td class="px-1 py-1 border-t whitespace-no-wrap text-sm leading-5 font-medium text-gray-900">
-                  {{investigation.created_date.date}}
-                </td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div>
-      </div>
+    {% endfor %}
+    {% endif %}
+    <div class="px-4 py-5 border-b border-t border-gray-200 sm:px-6">
+      <h3 class="text-lg leading-6 font-medium text-gray-900">
+        Investigation History
+      </h3>
+    </div>
+    <div class="mt-4">
+      <table class="min-w-full">
+        <thead>
+          <tr>
+            <th
+              class="px-1 py-1 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+              Group
+            </th>
+            <th
+              class="px-1 py-1 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+              Name
+            </th>
+            <th
+              class="px-1 py-1 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+              Result
+            </th>
+            <th
+              class="px-1 py-1 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+              Range
+            </th>
+            <th
+              class="px-1 py-1 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+              Date
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for investigation in investigations %}
+          <tr class="bg-white">
+            <td class="px-1 py-1 border-t whitespace-no-wrap text-sm leading-5 font-medium text-gray-900">
+              {{investigation.investigation.groups.first}}
+            </td>
+            <td class="px-1 py-1 border-t whitespace-no-wrap text-sm leading-5 font-medium text-gray-900">
+              {{investigation.investigation.name}}
+            </td>
+            <td class="px-1 py-1 border-t whitespace-no-wrap text-sm leading-5 font-medium text-gray-900">
+              {% if investigation.value%}
+              {{investigation.value}}
+              {% else %}
+              {{investigation.notes}}
+              {% endif %}
+            </td>
+            <td class="px-1 py-1 border-t whitespace-no-wrap text-sm leading-5 font-medium text-gray-900">
+              {% if investigation.investigation.min_value and investigation.investigation.max_value%}
+              {{investigation.investigation.min_value}} - {{investigation.investigation.max_value}}
+              {% else %}
+              -
+              {% endif %}
+              {% if investigation.investigation.unit %}
+              {{investigation.investigation.unit}}
+              {% endif %}
+            </td>
+            <td class="px-1 py-1 border-t whitespace-no-wrap text-sm leading-5 font-medium text-gray-900">
+              {{investigation.created_date.date}}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
     </div>
   </div>
-</div>
-      <div class="m-4">
-        <div class="text-sm leading-5 font-bold text-gray-500">
-          Verified By
-        </div>
-        <div class="mt-1 text-sm leading-5 text-gray-900">
-          {{consultation.verified_by|linebreaks}}
-        </div>
-      </div>
-  </body>
+  {% endif %}
+
+  <div class="mt-4 px-4 py-5 border-b border-t border-gray-200">
+    <h3 class="text-lg leading-6 font-medium text-gray-900">
+      Discharge Summary
+    </h3>
+  </div>
+  <div class="px-4 py-5">
+    <div class="flex gap-4">
+      <p>
+        <span class="text-sm text-gray-500">Discharge Date:</span> {{consultation.discharge_date}}
+      </p>
+      <p>
+        <span class="text-sm text-gray-500">Discharge Reason:</span> {{consultation.get_discharge_reason_display}}
+      </p>
+    </div>
+    <p>
+      <span class="text-sm text-gray-500">Discharge Notes:</span> {{consultation.discharge_notes}}
+    </p>
+    {% if consultation.discharge_reason == 'REC' %}
+    {% if consultation.discharge_prescription %}
+    <h4 class="mt-2 font-medium text-gray-500">
+      Discharge Prescription Medication:
+    </h4>
+    <div class="">
+      <table class="min-w-full">
+        <thead>
+          <tr
+            class="border-b border-gray-200 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+            <th class="p-2">
+              Medicine
+            </th>
+            <th class="p-2">
+              Dosage
+            </th>
+            <th class="p-2">
+              Route
+            </th>
+            <th class="p-2">
+              Frequency
+            </th>
+            <th class="p-2">
+              Days
+            </th>
+            <th class="p-2">
+              Notes
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for prescription in consultation.discharge_prescription %}
+          <tr class="bg-white">
+            <td class="px-1 py-1 text-sm leading-5 font-medium text-gray-900">
+              {{ prescription.medicine }}
+            </td>
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500">
+              {{ prescription.dosage_new }}
+            </td>
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500">
+              {{ prescription.route }}
+            </td>
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500">
+              {{ prescription.dosage }}
+            </td>
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500">
+              {{ prescription.days }}
+            </td>
+            <td class="px-1 py-1 whitespace-normal text-sm leading-5 text-gray-500">
+              {{ prescription.notes }}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% endif %}
+    {% if consultation.discharge_prn_prescription %}
+    <h4 class="mt-2 font-medium text-gray-500">
+      Discharge PRN Prescription:
+    </h4>
+    <div class="">
+      <table class="min-w-full">
+        <thead>
+          <tr
+            class="border-b border-gray-200 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+            <th class="p-2">
+              Medicine
+            </th>
+            <th class="p-2">
+              Dosage
+            </th>
+            <th class="p-2">
+              Max Dosage
+            </th>
+            <th class="p-2">
+              Min Time btwn. 2 doses
+            </th>
+            <th class="p-2">
+              Route
+            </th>
+            <th class="p-2">
+              Indicator
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for prescription in consultation.discharge_prn_prescription %}
+          <tr class="bg-white">
+            <td class="px-1 py-1 text-sm leading-5 font-medium text-gray-900">
+              {{ prescription.medicine }}
+            </td>
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500">
+              {{ prescription.dosage }}
+            </td>
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500">
+              {{ prescription.max_dosage }}
+            </td>
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500">
+              {{ prescription.min_time }} Hrs.
+            </td>
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500">
+              {{ prescription.route }}
+            </td>
+            <td class="px-1 py-1 whitespace-no-wrap text-sm leading-5 text-gray-500">
+              {{ prescription.indicator }}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% endif %}
+    {% elif consultation.discharge_reason == 'REF' %}
+    {% elif consultation.discharge_reason == 'EXP' %}
+    {% elif consultation.discharge_reason == 'LAMA' %}
+    {% endif %}
+  </div>
+
+  <div class="m-4 mb-12">
+    <div class="text-sm leading-5 font-bold text-gray-500">
+      Verified By
+    </div>
+    <div class="mt-1 text-sm leading-5 text-gray-900">
+      {{consultation.verified_by|linebreaks}}
+    </div>
+  </div>
+</body>
+
 </html>


### PR DESCRIPTION
## Proposed Changes

- update patient discharge summary
- move discharge routes to consultation viewset as it is more related to consultation
- discharge and discharge summary now require consultation id
- discharge summary is now generated and stored on s3 as soon as the patient is discharged, and is fetched from s3 for email and preview

@coronasafe/code-reviewers

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
