### PR TITLE
fix: districtadmin can't set shifting patient status as completed

### DIFF
--- a/care/facility/api/serializers/shifting.py
+++ b/care/facility/api/serializers/shifting.py
@@ -105,7 +105,7 @@ class ShiftingSerializer(serializers.ModelSerializer):
             "TRANSPORTATION TO BE ARRANGED",
             "PATIENT TO BE PICKED UP",
             "TRANSFER IN PROGRESS",
-            # "COMPLETED",
+            "COMPLETED",
             "PATIENT EXPIRED",
         ]
     ]
@@ -142,7 +142,9 @@ class ShiftingSerializer(serializers.ModelSerializer):
     id = serializers.UUIDField(source="external_id", read_only=True)
 
     patient = ExternalIdSerializerField(
-        queryset=PatientRegistration.objects.all(), allow_null=False, required=True
+        queryset=PatientRegistration.objects.all(),
+        allow_null=False,
+        required=True,
     )
     patient_object = PatientListSerializer(source="patient", read_only=True)
 
@@ -383,4 +385,8 @@ class ShiftingRequestCommentSerializer(serializers.ModelSerializer):
     class Meta:
         model = ShiftingRequestComment
         exclude = ("deleted", "request")
-        read_only_fields = TIMESTAMP_FIELDS + ("created_by", "external_id", "id")
+        read_only_fields = TIMESTAMP_FIELDS + (
+            "created_by",
+            "external_id",
+            "id",
+        )


### PR DESCRIPTION
# Bug Request

## Proposed Changes

- Adds `COMPLETED` as an option in the `PEACETIME_SHIFTING_STATUS` list

## Reason

Currently, when updating the shifting status of the patient during peacetime mode, districtadmin even though has `facility_permission` but he/she is not able to set the status to `COMPLETED` because this is not an option in `PEACETIME_SHIFTING_STATUS`

## Associated Issue

- Fixes coronasafe/care_fe#5373

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete

@coronasafe/code-reviewers
