### PR TITLE
Fix issues with Shifting

### DIFF
--- a/care/facility/api/serializers/shifting.py
+++ b/care/facility/api/serializers/shifting.py
@@ -244,7 +244,7 @@ class ShiftingSerializer(serializers.ModelSerializer):
             status = validated_data["status"]
             if status == REVERSE_SHIFTING_STATUS_CHOICES[
                 "CANCELLED"
-            ] and not has_facility_permission(user, instance.origin_facility):
+            ] and not has_facility_permission(user, instance.orgin_facility):
                 raise ValidationError({"status": ["Permission Denied"]})
 
             if settings.PEACETIME_MODE:

--- a/care/facility/api/serializers/shifting.py
+++ b/care/facility/api/serializers/shifting.py
@@ -347,7 +347,7 @@ class ShiftingSerializer(serializers.ModelSerializer):
 
         patient = validated_data["patient"]
         if ShiftingRequest.objects.filter(
-            ~Q(status__in=[30, 50, 80]), patient=patient
+            ~Q(status__in=[30, 50, 80, 100]), patient=patient
         ).exists():
             raise ValidationError(
                 {"request": ["Shifting Request for Patient already exists"]}

--- a/care/utils/notification_handler.py
+++ b/care/utils/notification_handler.py
@@ -92,13 +92,14 @@ class NotificationGenerator:
                 "caused_object_pk": caused_object.id,
                 "message": message,
                 "defer_notifications": defer_notifications,
-                "facility": facility.id,
                 "generate_for_facility": generate_for_facility,
                 "extra_users": extra_users,
                 "extra_data": self.serialize_extra_data(extra_data),
                 "notification_mediums": mediums,
                 "worker_initated": True,
             }
+            if facility:
+                data["facility"] = facility.id
             notification_task_generator.apply_async(kwargs=data, countdown=2)
             self.worker_initiated = False
             return


### PR DESCRIPTION
## Proposed Changes

- Fixes typo `origin_facility` to `orgin_facility`
- Adds Canceled shifting status to be ignored when checking for existing shifting records during creation of a new record.
- Fixes an edge case where notification handler was crashing when no facility object was given.

@coronasafe/code-reviewers