### PR TITLE
fix: removed patient_category from the shifting model

### DIFF
--- a/care/facility/api/serializers/shifting.py
+++ b/care/facility/api/serializers/shifting.py
@@ -329,7 +329,6 @@ class ShiftingSerializer(serializers.ModelSerializer):
             discharge_patient(instance.patient)
 
         old_status = instance.status
-        print(validated_data, self.initial_data)
         new_instance = super().update(instance, validated_data)
 
         patient = new_instance.patient

--- a/care/facility/migrations/0352_auto_20230428_1539.py
+++ b/care/facility/migrations/0352_auto_20230428_1539.py
@@ -1,0 +1,14 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("facility", "0351_auto_20230424_1227"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="shiftingrequest",
+            name="patient_category",
+        ),
+    ]

--- a/care/facility/models/shifting.py
+++ b/care/facility/models/shifting.py
@@ -7,7 +7,6 @@ from care.facility.models import (
     pretty_boolean,
     reverse_choices,
 )
-from care.facility.models.patient_base import CATEGORY_CHOICES
 from care.users.models import User, phone_number_regex
 
 SHIFTING_STATUS_CHOICES = (
@@ -45,9 +44,10 @@ REVERSE_SHIFTING_STATUS_CHOICES = reverse_choices(SHIFTING_STATUS_CHOICES)
 
 
 class ShiftingRequest(FacilityBaseModel):
-
     orgin_facility = models.ForeignKey(
-        "Facility", on_delete=models.PROTECT, related_name="requesting_facility"
+        "Facility",
+        on_delete=models.PROTECT,
+        related_name="requesting_facility",
     )
     shifting_approving_facility = models.ForeignKey(
         "Facility",
@@ -95,9 +95,6 @@ class ShiftingRequest(FacilityBaseModel):
         on_delete=models.SET_NULL,
         null=True,
         related_name="shifting_assigned_to",
-    )
-    patient_category = models.CharField(
-        choices=CATEGORY_CHOICES, max_length=8, blank=False, null=True
     )
     ambulance_driver_name = models.TextField(default="", blank=True)
     ambulance_phone_number = models.CharField(


### PR DESCRIPTION
# Feature Request

## Proposed Changes

- Removes `patient_category` from the shifting model

## Associated PR

- Required by coronasafe/care_fe#5392

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete

@coronasafe/code-reviewers
