### PR TITLE
Fix shifting permission check for destination

### DIFF
--- a/care/facility/api/serializers/shifting.py
+++ b/care/facility/api/serializers/shifting.py
@@ -283,7 +283,7 @@ class ShiftingSerializer(serializers.ModelSerializer):
                     pass
                 elif (
                     status in self.PEACETIME_RECIEVING_STATUS
-                    and not has_facility_permission(user, instance.assigned_facility)
+                    and has_facility_permission(user, instance.assigned_facility)
                 ):
                     pass
                 else:


### PR DESCRIPTION
Related Issue: https://github.com/coronasafe/care_fe/issues/5418

- Fixes a permission check issue where the destination facility's users would not have access to update the shifting status. 

@coronasafe/code-reviewers

CC: @khavinshankar for helping me troubleshoot this.