### PR TITLE
Enforce constraint on current bed count being lesser than the total bed count

### DIFF
--- a/care/facility/api/serializers/facility_capacity.py
+++ b/care/facility/api/serializers/facility_capacity.py
@@ -9,6 +9,19 @@ class FacilityCapacitySerializer(serializers.ModelSerializer):
     room_type_text = ChoiceField(choices=ROOM_TYPES, read_only=True, source="room_type")
     id = serializers.UUIDField(source="external_id", read_only=True)
 
+    def validate(self, data):
+        if (
+            data.get("current_capacity")
+            and data.get("total_capacity")
+            and data["current_capacity"] > data["total_capacity"]
+        ):
+            raise serializers.ValidationError(
+                {
+                    "current_capacity": "Current capacity cannot be greater than total capacity."
+                }
+            )
+        return data
+
     class Meta:
         model = FacilityCapacity
         read_only_fields = (


### PR DESCRIPTION
Fixes #1283

This PR adds validation to prevent current capacity from being greater than total capacity in the "FacilityCapacitySerializer" module. 

The "FacilityCapacitySerializer" module now checks for the validation of data before processing it. With this added validation, whenever the "current_capacity" attribute is greater than the "total_capacity" attribute, the user will receive an error message that says, "Current capacity cannot be greater than total capacity."

This update will improve data validation and prevent unwanted results from being stored as data.

```
{"current_capacity":["Current capacity cannot be greater than total capacity."]}
```