### PR TITLE
bump `isort` as pre-commit initialize fails with older version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         args: [--markdown-linebreak-ext=md]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: 5.11.5
     hooks:
       - id: isort
         additional_dependencies: ["isort[pyproject]"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         args: [--markdown-linebreak-ext=md]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         additional_dependencies: ["isort[pyproject]"]

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -5,7 +5,7 @@ ipdb==0.13.2  # https://github.com/gotcha/ipdb
 psycopg2-binary==2.8.4  # https://github.com/psycopg/psycopg2
 # Code quality
 # ------------------------------------------------------------------------------
-isort==5.10.1  # https://github.com/PyCQA/isort
+isort==5.12.0  # https://github.com/PyCQA/isort
 flake8==4.0.1  # https://github.com/PyCQA/flake8
 flake8-isort==4.1.1  # https://github.com/gforcada/flake8-isort
 black==22.3.0  # https://github.com/ambv/black

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -5,7 +5,7 @@ ipdb==0.13.2  # https://github.com/gotcha/ipdb
 psycopg2-binary==2.8.4  # https://github.com/psycopg/psycopg2
 # Code quality
 # ------------------------------------------------------------------------------
-isort==5.12.0  # https://github.com/PyCQA/isort
+isort==5.11.5  # https://github.com/PyCQA/isort
 flake8==4.0.1  # https://github.com/PyCQA/flake8
 flake8-isort==4.1.1  # https://github.com/gforcada/flake8-isort
 black==22.3.0  # https://github.com/ambv/black


### PR DESCRIPTION
## Proposed Changes

- Bump `isort` as pre-commit initialize fails with older version of `isort`.
![image](https://user-images.githubusercontent.com/25143503/236654264-c83aa72d-1829-476b-8e30-6714eb159eb9.png)



### Associated Issue
  -

### Architecture changes
  -
 
@coronasafe/code-reviewers

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
