### PR TITLE
Adds API for `PatientAssetBed`

### DIFF
--- a/care/facility/api/viewsets/bed.py
+++ b/care/facility/api/viewsets/bed.py
@@ -16,6 +16,7 @@ from rest_framework.viewsets import GenericViewSet
 
 from care.facility.api.serializers.bed import (
     AssetBedSerializer,
+    PatientAssetBedSerializer,
     BedSerializer,
     ConsultationBedSerializer,
 )
@@ -114,6 +115,47 @@ class AssetBedViewSet(
             allowed_facilities = get_accessible_facilities(user)
             queryset = queryset.filter(bed__facility__id__in=allowed_facilities)
         return queryset
+
+
+class PatientAssetBedFilter(filters.FilterSet):
+    location = filters.UUIDFilter(field_name="bed__location__external_id")
+    asset_class = filters.CharFilter(field_name="asset__asset_class")
+    bed_is_occupied = filters.BooleanFilter(method="filter_bed_is_occupied")
+
+    def filter_bed_is_occupied(self, queryset, name, value):
+        return queryset.exclude(
+            bed__consultationbed__consultation__current_bed__isnull=value
+        )
+
+
+class PatientAssetBedViewSet(ListModelMixin, GenericViewSet):
+    queryset = AssetBed.objects.all().select_related("asset", "bed")
+    serializer_class = PatientAssetBedSerializer
+    filter_backends = (
+        filters.DjangoFilterBackend,
+        drf_filters.OrderingFilter,
+    )
+    filterset_class = PatientAssetBedFilter
+    ordering_fields = [
+        "bed__name",
+        "created_date",
+    ]
+
+    def get_queryset(self):
+        user = self.request.user
+        queryset = self.queryset
+        if user.is_superuser:
+            pass
+        elif user.user_type >= User.TYPE_VALUE_MAP["StateLabAdmin"]:
+            queryset = queryset.filter(bed__facility__state=user.state)
+        elif user.user_type >= User.TYPE_VALUE_MAP["DistrictLabAdmin"]:
+            queryset = queryset.filter(bed__facility__district=user.district)
+        else:
+            allowed_facilities = get_accessible_facilities(user)
+            queryset = queryset.filter(bed__facility__id__in=allowed_facilities)
+        return queryset.filter(
+            bed__facility__external_id=self.kwargs["facility_external_id"]
+        )
 
 
 class ConsultationBedFilter(filters.FilterSet):

--- a/config/api_router.py
+++ b/config/api_router.py
@@ -15,6 +15,7 @@ from care.facility.api.viewsets.asset import (
 )
 from care.facility.api.viewsets.bed import (
     AssetBedViewSet,
+    PatientAssetBedViewSet,
     BedViewSet,
     ConsultationBedViewSet,
 )
@@ -177,6 +178,7 @@ facility_nested_router.register(r"inventory", FacilityInventoryLogViewSet)
 facility_nested_router.register(r"inventorysummary", FacilityInventorySummaryViewSet)
 facility_nested_router.register(r"min_quantity", FacilityInventoryMinQuantityViewSet)
 facility_nested_router.register(r"asset_location", AssetLocationViewSet)
+facility_nested_router.register(r"patient_asset_beds", PatientAssetBedViewSet)
 # facility_nested_router.register("burn_rate", FacilityInventoryBurnRateViewSet)
 
 router.register("asset", AssetViewSet)


### PR DESCRIPTION
## Proposed Changes

- Adds `GET /api/v1/facility/{facility_external_id}/patient_asset_beds/` to list all patient asset beds. Can be used for both CNS and Monitoring Hub.

![image](https://github.com/coronasafe/care/assets/25143503/508c1c08-d298-4677-bbcd-f2306d5a71f3)
![image](https://github.com/coronasafe/care/assets/25143503/01f4d30f-3305-4aa5-b69c-8f3cf4f4e238)


 
@coronasafe/code-reviewers

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
