### PR TITLE
merge and update staging deployment job

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -239,13 +239,13 @@ jobs:
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-  deploy-staging-egov-api:
+  deploy-staging-egov:
     needs: build-staging
     name: Deploy to ECS API Egov
     runs-on: ubuntu-latest
     environment:
       name: Staging-egov
-      url: https://careapi.coronasafe.in
+      url: https://careapi.ohc.network
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -278,29 +278,6 @@ jobs:
           service: ${{ env.ECS_SERVICE_BACKEND }}
           cluster: ${{ env.ECS_CLUSTER }}
           wait-for-service-stability: true
-
-  deploy-staging-egov-celery:
-    needs: build-staging
-    name: Deploy to Egov CELERY ECS
-    runs-on: ubuntu-latest
-    environment:
-      name: Staging-egov
-      url: https://careapi.coronasafe.in
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_DEFAULT_REGION }}
-
-      - name: IMAGE Tagging
-        env:
-          IMAGE_TAG: latest-${{ github.run_number }}
-        run: echo "IMAGE_VALUE=`echo ghcr.io/${{ github.repository }}:$IMAGE_TAG`" >> $GITHUB_ENV
 
       - name: Fill Celery Cron definition
         id: task-def-celery-cron


### PR DESCRIPTION
## Proposed Changes

- merge staging api and celery deployment into one job to avoid creating duplicate deployment status on github
- update name and domain of staging deployment

### Associated Issue
  - 

### Architecture changes
  -
 
@coronasafe/code-reviewers

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
