### PR TITLE
set default auth to jwt for production deployments

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -1,7 +1,8 @@
 from .deployment import *  # noqa
 
-# Your stuff...
-# ------------------------------------------------------------------------------
+REST_FRAMEWORK["DEFAULT_AUTHENTICATION_CLASSES"] = (  # noqa F405
+    "config.authentication.CustomJWTAuthentication",
+)
 
 IS_PRODUCTION = True
 USE_SMS = True


### PR DESCRIPTION
## Proposed Changes

- set default auth to jwt for production deployments

### Associated Issue
  -

### Architecture changes
  -

@coronasafe/code-reviewers

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
