### PR TITLE
Fix: Add get_object_or_404 to resolve 500 DoesNotExist Error and added tests

### DIFF
--- a/care/facility/models/daily_round.py
+++ b/care/facility/models/daily_round.py
@@ -3,6 +3,7 @@ import enum
 from django.contrib.postgres.fields import JSONField
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
+from django.shortcuts import get_object_or_404
 from multiselectfield import MultiSelectField
 
 from care.facility.models import (
@@ -503,9 +504,10 @@ class DailyRound(PatientBaseModel):
 
     @staticmethod
     def has_read_permission(request):
-        consultation = PatientConsultation.objects.get(
-            external_id=request.parser_context["kwargs"]["consultation_external_id"]
-        )
+        consultation = get_object_or_404(
+                        PatientConsultation,
+                        external_id=request.parser_context["kwargs"]["consultation_external_id"]
+                    )
         return request.user.is_superuser or (
             (request.user in consultation.patient.facility.users.all())
             or (

--- a/care/facility/models/daily_round.py
+++ b/care/facility/models/daily_round.py
@@ -505,9 +505,9 @@ class DailyRound(PatientBaseModel):
     @staticmethod
     def has_read_permission(request):
         consultation = get_object_or_404(
-                        PatientConsultation,
-                        external_id=request.parser_context["kwargs"]["consultation_external_id"]
-                    )
+            PatientConsultation,
+            external_id=request.parser_context["kwargs"]["consultation_external_id"],
+        )
         return request.user.is_superuser or (
             (request.user in consultation.patient.facility.users.all())
             or (

--- a/care/facility/models/daily_round.py
+++ b/care/facility/models/daily_round.py
@@ -21,8 +21,8 @@ from care.facility.models.json_schema.daily_round import (
     META,
     NURSING_PROCEDURE,
     OUTPUT,
-    PRESSURE_SORE,
     PAIN_SCALE_ENHANCED,
+    PRESSURE_SORE,
 )
 from care.facility.models.patient_base import CURRENT_HEALTH_CHOICES, SYMPTOM_CHOICES
 from care.facility.models.patient_consultation import PatientConsultation

--- a/care/facility/tests/test_patient_daily_rounds_api.py
+++ b/care/facility/tests/test_patient_daily_rounds_api.py
@@ -1,0 +1,15 @@
+from care.utils.tests.test_base import TestBase
+from care.facility.models.daily_round import DailyRound
+from rest_framework import status
+
+class TestDailyRoundApi(TestBase):
+
+    def get_url(self, external_consultation_id=None):
+        return F"/api/v1/consultation/{external_consultation_id}/daily_rounds/analyse/"
+
+    def test_external_consultation_does_not_exists_returns_404(self):
+        sample_uuid = "e4a3d84a-d678-4992-9287-114f029046d8"
+        response = self.client.get(self.get_url(sample_uuid))
+        self.assertEquals(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    

--- a/care/facility/tests/test_patient_daily_rounds_api.py
+++ b/care/facility/tests/test_patient_daily_rounds_api.py
@@ -1,5 +1,6 @@
-from care.utils.tests.test_base import TestBase
 from rest_framework import status
+
+from care.utils.tests.test_base import TestBase
 
 
 class TestDailyRoundApi(TestBase):

--- a/care/facility/tests/test_patient_daily_rounds_api.py
+++ b/care/facility/tests/test_patient_daily_rounds_api.py
@@ -1,15 +1,12 @@
 from care.utils.tests.test_base import TestBase
-from care.facility.models.daily_round import DailyRound
 from rest_framework import status
 
-class TestDailyRoundApi(TestBase):
 
+class TestDailyRoundApi(TestBase):
     def get_url(self, external_consultation_id=None):
-        return F"/api/v1/consultation/{external_consultation_id}/daily_rounds/analyse/"
+        return f"/api/v1/consultation/{external_consultation_id}/daily_rounds/analyse/"
 
     def test_external_consultation_does_not_exists_returns_404(self):
         sample_uuid = "e4a3d84a-d678-4992-9287-114f029046d8"
         response = self.client.get(self.get_url(sample_uuid))
         self.assertEquals(response.status_code, status.HTTP_404_NOT_FOUND)
-
-    


### PR DESCRIPTION
## Proposed Changes

- Changed .get to get_object_or_404 to fetch PatientConsultation from external consultation id.
- Added tests to verify the behaviour

Kindly review the linting as I have not done that.

### Associated Issue
 Fixes #1348 
@coronasafe/code-reviewers

## Merge Checklist

- [x] Tests added/fixed
- [x] Update docs in `/docs`
- [x] Linting Complete
