### PR TITLE
give preference to static fixtures first while loading dummy data

### DIFF
--- a/care/facility/management/commands/load_dummy_data.py
+++ b/care/facility/management/commands/load_dummy_data.py
@@ -22,9 +22,9 @@ class Command(BaseCommand):
             )
 
         try:
+            management.call_command("loaddata", self.BASE_URL + "users.json")
             management.call_command("load_data", "kerala")
             management.call_command("seed_data")
-            management.call_command("loaddata", self.BASE_URL + "users.json")
             management.call_command("loaddata", self.BASE_URL + "facility.json")
             management.call_command("loaddata", self.BASE_URL + "cypress_users.json")
             management.call_command("loaddata", self.BASE_URL + "facility_users.json")


### PR DESCRIPTION
## Proposed Changes

- load_data for kereal would load districts in random order which caused user_district relations to break

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
