### PR TITLE
Remove PII from Patient CSV export

### DIFF
--- a/care/facility/models/patient.py
+++ b/care/facility/models/patient.py
@@ -478,13 +478,9 @@ class PatientRegistration(PatientBaseModel, PatientPermissionMixin):
 
     CSV_MAPPING = {
         # Patient Details
-        "external_id": "Patient ID",
-        "name": "Patient Name",
         "facility__name": "Facility Name",
         "gender": "Gender",
         "age": "Age",
-        # Policy Details
-        "policy__policy_id": "Policy ID/Name",
         "created_date": "Date of Registration",
         "created_date__time": "Time of Registration",
         # Last Consultation Details
@@ -495,7 +491,6 @@ class PatientRegistration(PatientBaseModel, PatientPermissionMixin):
         "last_consultation__icd11_provisional_diagnoses": "Provisional Diagnoses",
         "last_consultation__suggestion": "Decision after consultation",
         "last_consultation__category": "Category",
-        "last_consultation__discharge_reason": "Discharge reason",
         "last_consultation__discharge_date": "Date of discharge",
         "last_consultation__discharge_date__time": "Time of discharge",
     }


### PR DESCRIPTION
## Proposed Changes

- Remove Personal Identifiable Information (PII) from the Patient list CSV export.
- Fields Removed:
1. external_id (Patient ID)
2. Name
3. Policy ID
4. Discharge reason

### Associated Issue

- Fixes https://github.com/coronasafe/care_fe/issues/5795

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
