### PR TITLE
hotfix: pin to pydantic v1 for fhir.resources

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -54,6 +54,7 @@ pywebpush==1.11.0
 # HCX
 # ------------------------------------------------------------------------------
 fhir.resources==6.5.0
+pydantic==1.*
 jwcrypto==1.5.0 # https://github.com/latchset/jwcrypto/releases
 pycryptodome==3.16.0
 pycryptodomex==3.16.0


### PR DESCRIPTION
## Proposed Changes

- fhir.resources is incompatible with pydantic v2, so pinned it to v1

### Associated Issue

- closes #1417

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
