### PR TITLE
hotfix: revert removing patient_id fo fix values collapsing

### DIFF
--- a/care/facility/models/patient.py
+++ b/care/facility/models/patient.py
@@ -478,6 +478,7 @@ class PatientRegistration(PatientBaseModel, PatientPermissionMixin):
 
     CSV_MAPPING = {
         # Patient Details
+        "external_id": "Patient ID",
         "facility__name": "Facility Name",
         "gender": "Gender",
         "age": "Age",


### PR DESCRIPTION
## Proposed Changes

- djqcsv is collapsing duplicate values in the first column

### Associated Issue

- Fixes coronasafe/care_fe#5823

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
