### PR TITLE
Load medicines to in-memory on django start

### DIFF
--- a/care/facility/api/viewsets/prescription.py
+++ b/care/facility/api/viewsets/prescription.py
@@ -19,6 +19,7 @@ from care.facility.models import (
     PrescriptionType,
     generate_choices,
 )
+from care.facility.static_data.medibase import MedibaseMedicineTable
 from care.utils.filters.choicefilter import CareChoiceFilter
 from care.utils.queryset.consultation import get_consultation_queryset
 
@@ -174,8 +175,6 @@ class MedibaseViewSet(ViewSet):
         return exact_matches + partial_matches
 
     def list(self, request):
-        from care.facility.static_data.medibase import MedibaseMedicineTable
-
         queryset = MedibaseMedicineTable
 
         if request.GET.get("query", False):


### PR DESCRIPTION
## Proposed Changes

- Moved import outside list action, so that little table is loaded with medicines on django start.

## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
