### PR TITLE
Revert "Load medicines to in-memory on django start (#1432)"

### DIFF
--- a/config/wsgi.py
+++ b/config/wsgi.py
@@ -36,5 +36,3 @@ application = get_wsgi_application()
 # Apply WSGI middleware here.
 # from helloworld.wsgi import HelloWorldApplication
 # application = HelloWorldApplication(application)
-
-from care.facility.static_data.medibase import MedibaseMedicineTable  # noqa


### PR DESCRIPTION
This reverts commit 44fb40210ab332ef205589d3b8bdef4d2a89000d.

## Proposed Changes

- Reverted as all workers are populating to in-memory db at the same time, so crashes.

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
