### PR TITLE
Add discharge_reason filter for patient

### DIFF
--- a/care/facility/api/viewsets/patient.py
+++ b/care/facility/api/viewsets/patient.py
@@ -153,6 +153,10 @@ class PatientFilterSet(filters.FilterSet):
         field_name="last_consultation__current_bed__bed__bed_type",
         choice_dict=REVERSE_BED_TYPES,
     )
+    last_consultation_discharge_reason = filters.ChoiceFilter(
+        field_name="last_consultation__discharge_reason",
+        choices=DISCHARGE_REASON_CHOICES,
+    )
     last_consultation_assigned_to = filters.NumberFilter(
         field_name="last_consultation__assigned_to"
     )


### PR DESCRIPTION
## Proposed Changes

- Allow patient list to be filtered with `last_consultation__discharge_reason`

### Associated Issue

- https://github.com/coronasafe/care_fe/issues/5474
- https://github.com/coronasafe/care_fe/pull/5843

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
