### PR TITLE
Medibase: Drop littletable; instead store as list from ORM's `values_list`

### DIFF
--- a/care/facility/api/viewsets/prescription.py
+++ b/care/facility/api/viewsets/prescription.py
@@ -140,7 +140,7 @@ class MedibaseViewSet(ViewSet):
     def serailize_data(self, objects):
         return [
             {
-                "external_id": x[0],
+                "id": x[0],
                 "name": x[1],
                 "type": x[2],
                 "generic": x[3],
@@ -172,5 +172,5 @@ class MedibaseViewSet(ViewSet):
         if request.GET.get("query", False):
             query = request.GET.get("query").strip().lower()
             queryset = [x for x in queryset if query in f"{x[1]} {x[3]} {x[4]}".lower()]
-            queryset = self.sort(query, queryset, limit=15)
+            queryset = self.sort(query, queryset)
         return Response(self.serailize_data(queryset[:15]))

--- a/care/facility/api/viewsets/prescription.py
+++ b/care/facility/api/viewsets/prescription.py
@@ -138,32 +138,29 @@ class MedibaseViewSet(ViewSet):
     permission_classes = (IsAuthenticated,)
 
     def serailize_data(self, objects):
-        result = []
-        for object in objects:
-            if type(object) == tuple:
-                object = object[0]
-            result.append(
-                {
-                    **object,
-                    "id": object["external_id"],
-                }
-            )
-        return result
+        return [
+            {
+                "external_id": x[0],
+                "name": x[1],
+                "type": x[2],
+                "generic": x[3],
+                "company": x[4],
+                "contents": x[5],
+                "cims_class": x[6],
+                "atc_classification": x[7],
+            }
+            for x in objects
+        ]
 
-    def sort(self, query, results, limit=15):
+    def sort(self, query, results):
         exact_matches = []
         partial_matches = []
 
-        for result in results:
-            words = result["searchable"].split()
-            if query in words:
-                exact_matches.append(result)
-                if len(exact_matches) + len(partial_matches) >= limit:
-                    break
+        for x in results:
+            if query in f"{x[1]} {x[3]} {x[4]}".lower().split():
+                exact_matches.append(x)
             else:
-                partial_matches.append(result)
-                if len(exact_matches) + len(partial_matches) >= limit:
-                    break
+                partial_matches.append(x)
 
         return exact_matches + partial_matches
 
@@ -174,6 +171,6 @@ class MedibaseViewSet(ViewSet):
 
         if request.GET.get("query", False):
             query = request.GET.get("query").strip().lower()
-            queryset = [x for x in queryset if query in x["searchable"]]
+            queryset = [x for x in queryset if query in f"{x[1]} {x[3]} {x[4]}".lower()]
             queryset = self.sort(query, queryset, limit=15)
         return Response(self.serailize_data(queryset[:15]))

--- a/care/facility/api/viewsets/prescription.py
+++ b/care/facility/api/viewsets/prescription.py
@@ -170,8 +170,8 @@ class MedibaseViewSet(ViewSet):
 
         queryset = MedibaseMedicineTable
 
-        if request.GET.get("query", False):
-            query = request.GET.get("query").strip().lower()
+        if query := request.query_params.get("query"):
+            query = query.strip().lower()
             queryset = [x for x in queryset if query in f"{x[1]} {x[3]} {x[4]}".lower()]
             queryset = self.sort(query, queryset)
         return Response(self.serailize_data(queryset[:15]))

--- a/care/facility/api/viewsets/prescription.py
+++ b/care/facility/api/viewsets/prescription.py
@@ -157,7 +157,8 @@ class MedibaseViewSet(ViewSet):
         partial_matches = []
 
         for x in results:
-            if query in f"{x[1]} {x[3]} {x[4]}".lower().split():
+            words = f"{x[1]} {x[3]} {x[4]}".lower().split()
+            if query in words:
                 exact_matches.append(x)
             else:
                 partial_matches.append(x)

--- a/care/facility/static_data/medibase.py
+++ b/care/facility/static_data/medibase.py
@@ -1,13 +1,11 @@
-from littletable import Table
-
 from care.facility.models.prescription import MedibaseMedicine
 
-MedibaseMedicineTable = Table("MedibaseMedicine")
+MedibaseMedicineTable = []
 
 medibase_objects = MedibaseMedicine.objects.all()
 
 for obj in medibase_objects:
-    MedibaseMedicineTable.insert(
+    MedibaseMedicineTable.append(
         {
             "id": obj.id,
             "external_id": obj.external_id,
@@ -18,9 +16,6 @@ for obj in medibase_objects:
             "contents": obj.contents or "",
             "cims_class": obj.cims_class or "",
             "atc_classification": obj.atc_classification or "",
-            "searchable": f"{obj.name} {obj.generic} {obj.company}",
+            "searchable": f"{obj.name} {obj.generic} {obj.company}".lower(),
         }
     )
-
-MedibaseMedicineTable.create_index("id", unique=True)
-MedibaseMedicineTable.create_search_index("searchable")

--- a/care/facility/static_data/medibase.py
+++ b/care/facility/static_data/medibase.py
@@ -19,18 +19,3 @@ def load_medibase_in_memory():
 
 
 MedibaseMedicineTable = load_medibase_in_memory()
-
-
-# for obj in medibase_objects:
-# MedibaseMedicineTable.append(
-#     {
-#         "external_id": obj.external_id,
-#         "name": obj.name,
-#         "type": obj.type,
-#         "generic": obj.generic or "",
-#         "company": obj.company or "",
-#         "contents": obj.contents or "",
-#         "cims_class": obj.cims_class or "",
-#         "atc_classification": obj.atc_classification or "",
-#     }
-# )

--- a/care/facility/static_data/medibase.py
+++ b/care/facility/static_data/medibase.py
@@ -1,20 +1,24 @@
 from care.facility.models.prescription import MedibaseMedicine
 
-medibase_objects = MedibaseMedicine.objects.all()
 
-MedibaseMedicineTable = tuple(
-    (
-        obj.external_id,
-        obj.name,
-        obj.type,
-        obj.generic or "",
-        obj.company or "",
-        obj.contents or "",
-        obj.cims_class or "",
-        obj.atc_classification or "",
+def load_medibase_in_memory():
+    medibase_objects = MedibaseMedicine.objects.all()
+    return tuple(
+        (
+            obj.external_id,
+            obj.name,
+            obj.type,
+            obj.generic or "",
+            obj.company or "",
+            obj.contents or "",
+            obj.cims_class or "",
+            obj.atc_classification or "",
+        )
+        for obj in medibase_objects
     )
-    for obj in medibase_objects
-)
+
+
+MedibaseMedicineTable = load_medibase_in_memory()
 
 
 # for obj in medibase_objects:

--- a/care/facility/static_data/medibase.py
+++ b/care/facility/static_data/medibase.py
@@ -1,20 +1,33 @@
+from django.db.models import CharField, TextField, Value
+from django.db.models.functions import Coalesce
+
 from care.facility.models.prescription import MedibaseMedicine
 
 
 def load_medibase_in_memory():
-    medibase_objects = MedibaseMedicine.objects.all()
-    return tuple(
-        (
-            obj.external_id,
-            obj.name,
-            obj.type,
-            obj.generic or "",
-            obj.company or "",
-            obj.contents or "",
-            obj.cims_class or "",
-            obj.atc_classification or "",
+    return (
+        MedibaseMedicine.objects.all()
+        .annotate(
+            generic_pretty=Coalesce("generic", Value(""), output_field=CharField()),
+            company_pretty=Coalesce("company", Value(""), output_field=CharField()),
+            contents_pretty=Coalesce("contents", Value(""), output_field=TextField()),
+            cims_class_pretty=Coalesce(
+                "cims_class", Value(""), output_field=CharField()
+            ),
+            atc_classification_pretty=Coalesce(
+                "atc_classification", Value(""), output_field=TextField()
+            ),
         )
-        for obj in medibase_objects
+        .values_list(
+            "external_id",
+            "name",
+            "type",
+            "generic_pretty",
+            "company_pretty",
+            "contents_pretty",
+            "cims_class_pretty",
+            "atc_classification_pretty",
+        )
     )
 
 

--- a/care/facility/static_data/medibase.py
+++ b/care/facility/static_data/medibase.py
@@ -1,21 +1,32 @@
 from care.facility.models.prescription import MedibaseMedicine
 
-MedibaseMedicineTable = []
-
 medibase_objects = MedibaseMedicine.objects.all()
 
-for obj in medibase_objects:
-    MedibaseMedicineTable.append(
-        {
-            "id": obj.id,
-            "external_id": obj.external_id,
-            "name": obj.name,
-            "type": obj.type,
-            "generic": obj.generic or "",
-            "company": obj.company or "",
-            "contents": obj.contents or "",
-            "cims_class": obj.cims_class or "",
-            "atc_classification": obj.atc_classification or "",
-            "searchable": f"{obj.name} {obj.generic} {obj.company}".lower(),
-        }
+MedibaseMedicineTable = tuple(
+    (
+        obj.external_id,
+        obj.name,
+        obj.type,
+        obj.generic or "",
+        obj.company or "",
+        obj.contents or "",
+        obj.cims_class or "",
+        obj.atc_classification or "",
     )
+    for obj in medibase_objects
+)
+
+
+# for obj in medibase_objects:
+# MedibaseMedicineTable.append(
+#     {
+#         "external_id": obj.external_id,
+#         "name": obj.name,
+#         "type": obj.type,
+#         "generic": obj.generic or "",
+#         "company": obj.company or "",
+#         "contents": obj.contents or "",
+#         "cims_class": obj.cims_class or "",
+#         "atc_classification": obj.atc_classification or "",
+#     }
+# )

--- a/config/wsgi.py
+++ b/config/wsgi.py
@@ -36,3 +36,5 @@ application = get_wsgi_application()
 # Apply WSGI middleware here.
 # from helloworld.wsgi import HelloWorldApplication
 # application = HelloWorldApplication(application)
+
+from care.facility.static_data.medibase import MedibaseMedicineTable  # noqa


### PR DESCRIPTION
## Proposed Changes

- MedibaseMedicineTable no longer uses `littletable` and is now simply a `list` fetched ORM's `values_list`


## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
