### PR TITLE
Update branding from CoronaSafe Network to Open Healthcare Network

### DIFF
--- a/care/facility/api/serializers/patient_otp.py
+++ b/care/facility/api/serializers/patient_otp.py
@@ -26,7 +26,7 @@ def send_sms(otp, phone_number):
         sendSMS(
             phone_number,
             (
-                f"CoronaSafe Network Patient Management System Login, OTP is {otp} . "
+                f"Open Healthcare Network Patient Management System Login, OTP is {otp} . "
                 "Please do not share this Confidential Login Token with anyone else"
             ),
         )

--- a/care/templates/base.html
+++ b/care/templates/base.html
@@ -104,7 +104,7 @@
             alt="Digital Public Goods logo" />
         </a>
         <a href="https://coronasafe.network/">
-          CoronaSafe Network is an open-source digital public good designed by
+          Open Healthcare Network is an open-source digital public good designed by
           a multi-disciplinary team of innovators and volunteers who are working on a model to support
           Government efforts.</a>&nbsp;
         <a href="https://github.com/coronasafe" class="care-secondary-color">(Github)</a>

--- a/care/templates/email/user_reset_password.html
+++ b/care/templates/email/user_reset_password.html
@@ -1,5 +1,5 @@
 Hi,
-Greetings from Coronasafe Network,
+Greetings from Open Healthcare Network,
 Please click the following link to reset your password for your account with username {{username}}
  <a href="{{reset_password_url}}" > Click Here</a>
 

--- a/care/templates/email/user_reset_password.txt
+++ b/care/templates/email/user_reset_password.txt
@@ -1,5 +1,5 @@
 Hi,
-Greetings from Coronasafe Network,
+Greetings from Open Healthcare Network,
 Please click the following link to reset your password
 {{reset_password_url}}
 


### PR DESCRIPTION
This PR updates the branding in various parts of the application from "CoronaSafe Network" to "Open Healthcare Network". The changes include modifications in SMS messages, HTML templates, and email templates.

- Updated the SMS message for the patient OTP login
- Changed the branding in the base.html template
- Updated the reset password email templates (both HTML and plain text versions)

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
