### PR TITLE
Adds `REDIS_URL` to `.local.env`

### DIFF
--- a/docker/.local.env
+++ b/docker/.local.env
@@ -4,6 +4,7 @@ POSTGRES_HOST=db
 POSTGRES_DB=care
 POSTGRES_PORT=5432
 DATABASE_URL=postgres://postgres:postgres@db:5432/care
+REDIS_URL=redis://redis:6379
 CELERY_BROKER_URL=redis://redis:6379/0
 
 DJANGO_DEBUG=False


### PR DESCRIPTION
## Proposed Changes

- Adds missing `REDIS_URL` to `docker/.local.env` (as it was using `localhost:6379` so far).

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
