### PR TITLE
Ignore admission date during discharge process if not provided

### DIFF
--- a/care/facility/api/serializers/patient_consultation.py
+++ b/care/facility/api/serializers/patient_consultation.py
@@ -437,7 +437,10 @@ class PatientConsultationDischargeSerializer(serializers.ModelSerializer):
                 raise ValidationError(
                     {"death_datetime": "This field value cannot be in the future."}
                 )
-            if attrs.get("death_datetime") < self.instance.admission_date:
+            if (
+                self.instance.admission_date
+                and attrs.get("death_datetime") < self.instance.admission_date
+            ):
                 raise ValidationError(
                     {
                         "death_datetime": "This field value cannot be before the admission date."

--- a/care/facility/api/serializers/patient_consultation.py
+++ b/care/facility/api/serializers/patient_consultation.py
@@ -457,7 +457,10 @@ class PatientConsultationDischargeSerializer(serializers.ModelSerializer):
             raise ValidationError(
                 {"discharge_date": "This field value cannot be in the future."}
             )
-        elif attrs.get("discharge_date") < self.instance.admission_date:
+        elif (
+            self.instance.admission_date
+            and attrs.get("discharge_date") < self.instance.admission_date
+        ):
             raise ValidationError(
                 {
                     "discharge_date": "This field value cannot be before the admission date."


### PR DESCRIPTION
## Proposed Changes

This pull request introduces a change that allows the discharge process to ignore the admission date if it's not provided. This avoids potential validation errors and exceptions during the discharge process when the admission date is absent.

- Modified the validation logic in patient_consultation.py to check if the admission date exists before comparing it with the death date.

Fixes https://github.com/coronasafe/care_fe/issues/5916

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
