### PR TITLE
Set Minimum Value to 0 for Respiratory Rate Field in DailyRound Model

### DIFF
--- a/care/facility/models/daily_round.py
+++ b/care/facility/models/daily_round.py
@@ -260,7 +260,7 @@ class DailyRound(PatientBaseModel):
     resp = models.IntegerField(
         default=None,
         null=True,
-        validators=[MinValueValidator(10), MaxValueValidator(70)],
+        validators=[MinValueValidator(0), MaxValueValidator(70)],
     )
     rhythm = models.IntegerField(choices=RythmnChoice, default=RythmnType.UNKNOWN.value)
     rhythm_detail = models.TextField(default=None, null=True, blank=True)

--- a/care/facility/models/daily_round.py
+++ b/care/facility/models/daily_round.py
@@ -260,7 +260,7 @@ class DailyRound(PatientBaseModel):
     resp = models.IntegerField(
         default=None,
         null=True,
-        validators=[MinValueValidator(1), MaxValueValidator(70)],
+        validators=[MinValueValidator(0), MaxValueValidator(70)],
     )
     rhythm = models.IntegerField(choices=RythmnChoice, default=RythmnType.UNKNOWN.value)
     rhythm_detail = models.TextField(default=None, null=True, blank=True)

--- a/care/facility/models/daily_round.py
+++ b/care/facility/models/daily_round.py
@@ -260,7 +260,7 @@ class DailyRound(PatientBaseModel):
     resp = models.IntegerField(
         default=None,
         null=True,
-        validators=[MinValueValidator(0), MaxValueValidator(70)],
+        validators=[MinValueValidator(1), MaxValueValidator(70)],
     )
     rhythm = models.IntegerField(choices=RythmnChoice, default=RythmnType.UNKNOWN.value)
     rhythm_detail = models.TextField(default=None, null=True, blank=True)


### PR DESCRIPTION
Required for: https://github.com/coronasafe/care_fe/pull/5931

## Proposed Changes

This PR modifies the validators for the `resp` field in the `daily_round.py` model. Previously, the `resp` field had a minimum valid value of 10, which may not have accommodated all possible real-world values for respiratory rates.

- The `MinValueValidator` for the `resp` field has been changed from 10 to 1.

The `MaxValueValidator` remains unchanged at 70. This change allows for a wider range of valid inputs, increasing the flexibility of our data collection.

This change does not affect any other part of the `daily_round.py` model, or any other models in the application.

### Associated Issue

- https://github.com/coronasafe/care_fe/issues/5926

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
