### PR TITLE
Shifting: Skip changing `last_consultation.category` if `patient_category` is not present in `validated_data`

### DIFF
--- a/care/facility/api/serializers/shifting.py
+++ b/care/facility/api/serializers/shifting.py
@@ -329,7 +329,7 @@ class ShiftingSerializer(serializers.ModelSerializer):
         new_instance = super().update(instance, validated_data)
 
         patient = new_instance.patient
-        patient_category = validated_data.pop("patient_category")
+        patient_category = validated_data.pop("patient_category", None)
         if patient.last_consultation and patient_category is not None:
             patient.last_consultation.category = patient_category
             patient.last_consultation.save(update_fields=["category"])
@@ -394,7 +394,7 @@ class ShiftingSerializer(serializers.ModelSerializer):
             patient.allow_transfer = True
             patient.save()
 
-        patient_category = validated_data.pop("patient_category")
+        patient_category = validated_data.pop("patient_category", None)
         if patient.last_consultation and patient_category is not None:
             patient.last_consultation.category = patient_category
             patient.last_consultation.save(update_fields=["category"])


### PR DESCRIPTION
## Proposed Changes

- Skip changing `last_consultation.category` if `patient_category` is not present in `validated_data`

### Associated Issue and PR

- Fixes #1478
- Required by https://github.com/coronasafe/care_fe/pull/5947

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
