### PR TITLE
Added `op_no` and `ip_OR_op` Filters for Patients

### DIFF
--- a/care/facility/api/viewsets/patient.py
+++ b/care/facility/api/viewsets/patient.py
@@ -81,6 +81,10 @@ class PatientFilterSet(filters.FilterSet):
     ip_no = filters.CharFilter(
         field_name="last_consultation__ip_no", lookup_expr="icontains"
     )
+    op_no = filters.CharFilter(
+        field_name="last_consultation__op_no", lookup_expr="icontains"
+    )
+    ip_or_op_no = filters.CharFilter(method="filter_by_ip_or_op_no")
     gender = filters.NumberFilter(field_name="gender")
     age = filters.NumberFilter(field_name="age")
     age_min = filters.NumberFilter(field_name="age", lookup_expr="gte")
@@ -93,6 +97,14 @@ class PatientFilterSet(filters.FilterSet):
         method="filter_by_category",
         choices=CATEGORY_CHOICES,
     )
+
+    def filter_by_ip_or_op_no(self, queryset, name, value):
+        if value:
+            queryset = queryset.filter(
+                Q(last_consultation__ip_no__icontains=value)
+                | Q(last_consultation__op_no__icontains=value)
+            )
+        return queryset
 
     def filter_by_category(self, queryset, name, value):
         if value:

--- a/care/facility/tests/test_patient_api.py
+++ b/care/facility/tests/test_patient_api.py
@@ -1,5 +1,7 @@
+from datetime import datetime
 from enum import Enum
 
+from django.utils.timezone import make_aware
 from rest_framework import status
 from rest_framework.test import APIRequestFactory, APITestCase
 from rest_framework_simplejwt.tokens import RefreshToken
@@ -186,3 +188,55 @@ class PatientNotesTestCase(TestBase, TestClassMixin, APITestCase):
                 created_by_object_content.keys(),
                 [item.value for item in ExpectedCreatedByObjectKeys],
             )
+
+
+class PatientFilterTestCase(TestBase, TestClassMixin, APITestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        state = self.create_state()
+        district = self.create_district(state=state)
+
+        self.user = self.create_super_user(district=district, username="test user")
+        facility = self.create_facility(district=district, user=self.user)
+        self.user.home_facility = facility
+        self.user.save()
+
+        self.patient = self.create_patient(district=district.id, created_by=self.user)
+        self.consultation = self.create_consultation(
+            op_no="OP1234",
+            ip_no="IP5678",
+            patient=self.patient,
+            facility=facility,
+            created_by=self.user,
+            suggestion="A",
+            admission_date=make_aware(datetime(2020, 4, 1, 15, 30, 00)),
+        )
+        self.patient.last_consultation = self.consultation
+        self.patient.save()
+        refresh_token = RefreshToken.for_user(self.user)
+        self.client.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {refresh_token.access_token}"
+        )
+
+    def test_filter_by_op_no(self):
+        response = self.client.get("/api/v1/patient/?op_no=OP1234")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(
+            response.data["results"][0]["id"], str(self.patient.external_id)
+        )
+
+    def test_filter_by_ip_OR_op_no(self):
+        response = self.client.get("/api/v1/patient/?ip_or_op_no=IP5678")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(
+            response.data["results"][0]["id"], str(self.patient.external_id)
+        )
+
+        response = self.client.get("/api/v1/patient/?ip_or_op_no=OP1234")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(
+            response.data["results"][0]["id"], str(self.patient.external_id)
+        )


### PR DESCRIPTION
## Proposed Changes

This pull request introduces two new filters for the `Patient` model:

1. Filter based on `op_no`: This filter allows users to search patients based on the `op_no` field of the `last_consultation` related model. The filter uses the `icontains` lookup expression which is case-insensitive.

2. Filter based on `ip_OR_op_no`: This filter allows users to search patients based on either `ip_no` or `op_no` fields of the `last_consultation` related model. This filter uses a custom method that applies a `Q` object to perform an OR operation between `ip_no` and `op_no` filters.

### Associated Issue

- https://github.com/coronasafe/care_fe/issues/5918

## Files Updated

1. `care/facility/api/viewsets/patient.py`: Added the new filters and their implementations.

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
