### PR TITLE
fix bed allocation overlap

### DIFF
--- a/care/facility/api/serializers/bed.py
+++ b/care/facility/api/serializers/bed.py
@@ -224,7 +224,9 @@ class ConsultationBedSerializer(ModelSerializer):
                     )
 
             # Conflict checking logic
-            existing_qs = ConsultationBed.objects.filter(consultation=consultation)
+            existing_qs = ConsultationBed.objects.filter(bed=bed).exclude(
+                consultation=consultation
+            )
             if existing_qs.filter(start_date__gt=start_date).exists():
                 raise ValidationError({"start_date": "Cannot create conflicting entry"})
             if end_date:


### PR DESCRIPTION

### Associated Issue

- overlapping bed record were not being validated properly

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
