### PR TITLE
Check bed name before making new multiple beds with same name

### DIFF
--- a/care/facility/api/viewsets/bed.py
+++ b/care/facility/api/viewsets/bed.py
@@ -66,11 +66,21 @@ class BedViewSet(
         # Bulk creating n number of beds
         if number_of_beds > 1:
             data = serializer.validated_data.copy()
+            start = 1
+            while True:
+                if not Bed.objects.filter(
+                    name=f"{serializer.validated_data['name']} {start}",
+                    facility=serializer.validated_data['facility'],
+                    location=serializer.validated_data["location"]
+                ).exists():
+                    break
+                start += 1
+
             data.pop("name")
             beds = [
                 Bed(
                     **data,
-                    name=f"{serializer.validated_data['name']} {i+1}",
+                    name=f"{serializer.validated_data['name']} {start+i}",
                 )
                 for i in range(number_of_beds)
             ]


### PR DESCRIPTION
## Proposed Changes

- Instead of straight away adding the number `1` behind each bed name, we first check the number from which the bed names are available and then start adding the beds. For example if the user is adding 2 beds with name `Bed` and there is already a bed with name `Bed 1`, then the new beds created will be `Bed 2` & `Bed 3` instead of `Bed 1` & `Bed 2`.

### Associated Issue

Fixes [#1529](https://github.com/coronasafe/care/issues/1529)

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
