### PR TITLE
feat: add dev only endpoint to preview discharge summary

### DIFF
--- a/care/facility/api/viewsets/patient_consultation.py
+++ b/care/facility/api/viewsets/patient_consultation.py
@@ -1,5 +1,6 @@
 from django.db.models import Prefetch
 from django.db.models.query_utils import Q
+from django.shortcuts import render
 from django_filters import rest_framework as filters
 from drf_spectacular.utils import extend_schema
 from dry_rest_permissions.generics import DRYPermissions
@@ -237,3 +238,19 @@ class PatientConsultationViewSet(
         if not consultation:
             raise NotFound({"detail": "No consultation found for this asset"})
         return Response(PatientConsultationIDSerializer(consultation).data)
+
+
+def dev_preview_discharge_summary(request, consultation_id):
+    """
+    This is a dev only view to preview the discharge summary template
+    """
+    consultation = (
+        PatientConsultation.objects.select_related("patient")
+        .order_by("-id")
+        .filter(external_id=consultation_id)
+        .first()
+    )
+    if not consultation:
+        raise NotFound({"detail": "No consultation found for this asset"})
+    data = discharge_summary.get_discharge_summary_data(consultation)
+    return render(request, "reports/patient_discharge_summary_pdf.html", data)

--- a/config/urls.py
+++ b/config/urls.py
@@ -11,6 +11,9 @@ from drf_spectacular.views import (
 
 from care.abdm.urls import abdm_urlpatterns
 from care.facility.api.viewsets.open_id import OpenIdConfigView
+from care.facility.api.viewsets.patient_consultation import (
+    dev_preview_discharge_summary,
+)
 from care.hcx.api.viewsets.listener import (
     ClaimOnSubmitView,
     CommunicationRequestView,
@@ -118,6 +121,10 @@ if settings.DEBUG:
             kwargs={"exception": Exception("Page not Found")},
         ),
         path("500/", default_views.server_error),
+        path(
+            "preview_discharge_summary/<str:consultation_id>/",
+            dev_preview_discharge_summary,
+        ),
     ]
     if "debug_toolbar" in settings.INSTALLED_APPS:
         urlpatterns += [path("__debug__/", include("debug_toolbar.urls"))]


### PR DESCRIPTION
## Proposed Changes

- this adds a dev view to preview rendered discharge summary

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
