### PR TITLE
Sorts medicine name exact matches first

### DIFF
--- a/care/facility/tests/test_medibase_api.py
+++ b/care/facility/tests/test_medibase_api.py
@@ -12,10 +12,10 @@ class TestMedibaseApi(TestBase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data[0]["name"], "DOLO")
 
-    def test_search_by_generic_exact_word(self):
+    def test_search_by_generic_exact(self):
         response = self.client.get(self.get_url(query="pAraCetAmoL"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data[0]["generic"], "paracetamol")
+        self.assertEqual(response.data[0]["name"], "paracetamol")
 
     def test_search_by_name_and_generic_exact_word(self):
         response = self.client.get(self.get_url(query="panadol paracetamol"))


### PR DESCRIPTION
## Proposed Changes

- Sort by medicine name exact match first before word match.
- Increase limit to 30

### Associated Issue

- Fixes #1556

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [x] Update docs in `/docs`
- [x] Linting Complete
- [x] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
