### PR TITLE
Set edits as read_only, exclude asset from Service

### DIFF
--- a/care/facility/api/serializers/asset.py
+++ b/care/facility/api/serializers/asset.py
@@ -119,7 +119,7 @@ class AssetSerializer(ModelSerializer):
     location = UUIDField(write_only=True, required=True)
     last_service = AssetServiceSerializer(read_only=True)
     last_serviced_on = serializers.DateField(write_only=True, required=False)
-    note = serializers.CharField(write_only=True, required=False)
+    note = serializers.CharField(write_only=True, required=False, allow_blank=True)
 
     class Meta:
         model = Asset

--- a/care/facility/api/serializers/asset.py
+++ b/care/facility/api/serializers/asset.py
@@ -83,11 +83,11 @@ class AssetServiceEditSerializer(ModelSerializer):
 
 class AssetServiceSerializer(ModelSerializer):
     id = UUIDField(source="external_id", read_only=True)
-    edits = AssetServiceEditSerializer(many=True)
+    edits = AssetServiceEditSerializer(many=True, read_only=True)
 
     class Meta:
         model = AssetService
-        exclude = ("deleted",)
+        exclude = ("deleted", "asset")
 
     def update(self, instance, validated_data):
         user = self.context["request"].user


### PR DESCRIPTION
## Proposed Changes

The `edits` field in `AssetServiceSerializer` has been updated to be read-only. This change ensures that the edits field cannot be updated directly through the serializer, providing an additional layer of data integrity.

The asset field has been added to the exclude option in the Meta class of `AssetServiceSerializer`

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
