### PR TITLE
Fix asset dummy data

### DIFF
--- a/data/dummy/facility.json
+++ b/data/dummy/facility.json
@@ -760,9 +760,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -790,9 +788,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -820,9 +816,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -850,9 +844,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -880,9 +872,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -910,9 +900,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -940,9 +928,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -970,9 +956,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -1000,9 +984,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -1030,9 +1012,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -1060,9 +1040,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -1090,9 +1068,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -1120,9 +1096,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -1150,9 +1124,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -1180,9 +1152,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -1210,9 +1180,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -1240,9 +1208,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -1270,9 +1236,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -1300,9 +1264,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -1330,9 +1292,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -1360,9 +1320,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -1390,9 +1348,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -1420,9 +1376,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -1450,9 +1404,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -1480,9 +1432,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -1510,9 +1460,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -1540,9 +1488,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -1570,9 +1516,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -1600,9 +1544,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {
@@ -1630,9 +1572,7 @@
       "support_email": "",
       "qr_code_id": null,
       "manufacturer": null,
-      "warranty_amc_end_of_validity": null,
-      "last_serviced_on": null,
-      "notes": ""
+      "warranty_amc_end_of_validity": null
     }
   },
   {


### PR DESCRIPTION
## Proposed Changes

- Fix `load_dummy_data` management command.

Side note: We should have a required passing check for important management commands just like we have for migrations.

![image](https://github.com/coronasafe/care/assets/3626859/ac8fb03e-0bb4-4fc0-b318-76100e10ceb8)

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
