### PR TITLE
Reject Prescription Creation if Medicine already Prescribed and is active

### DIFF
--- a/care/facility/api/serializers/prescription.py
+++ b/care/facility/api/serializers/prescription.py
@@ -63,7 +63,6 @@ class PrescriptionSerializer(serializers.ModelSerializer):
             )
 
         if not self.instance:
-            # consultation_obj can be retrieved from the request context's path parameter: 'consultation_external_id'
             consultation_obj = get_object_or_404(
                 PatientConsultation,
                 external_id=self.context["request"].parser_context["kwargs"][

--- a/care/facility/api/serializers/prescription.py
+++ b/care/facility/api/serializers/prescription.py
@@ -70,7 +70,7 @@ class PrescriptionSerializer(serializers.ModelSerializer):
                         "medicine": (
                             "This medicine is already prescribed to this patient. "
                             "Please discontinue the existing prescription to prescribe again."
-                            )
+                        )
                     }
                 )
 

--- a/care/facility/api/serializers/prescription.py
+++ b/care/facility/api/serializers/prescription.py
@@ -1,12 +1,7 @@
 from django.shortcuts import get_object_or_404
 from rest_framework import serializers
 
-from care.facility.models import (
-    MedibaseMedicine,
-    MedicineAdministration,
-    PatientConsultation,
-    Prescription,
-)
+from care.facility.models import MedibaseMedicine, MedicineAdministration, Prescription
 from care.users.api.serializers.user import UserBaseMinimumSerializer
 
 
@@ -63,15 +58,10 @@ class PrescriptionSerializer(serializers.ModelSerializer):
             )
 
         if not self.instance:
-            consultation_obj = get_object_or_404(
-                PatientConsultation,
-                external_id=self.context["request"].parser_context["kwargs"][
-                    "consultation_external_id"
-                ],
-            )
-
             if Prescription.objects.filter(
-                consultation=consultation_obj,
+                consultation__external_id=self.context["request"].parser_context[
+                    "kwargs"
+                ]["consultation_external_id"],
                 medicine=attrs["medicine"],
                 discontinued=False,
             ).exists():

--- a/care/facility/api/serializers/prescription.py
+++ b/care/facility/api/serializers/prescription.py
@@ -67,7 +67,10 @@ class PrescriptionSerializer(serializers.ModelSerializer):
             ).exists():
                 raise serializers.ValidationError(
                     {
-                        "medicine": "This medicine is already prescribed to this patient. Please discontinue the existing prescription to prescribe again."
+                        "medicine": (
+                            "This medicine is already prescribed to this patient. "
+                            "Please discontinue the existing prescription to prescribe again."
+                            )
                     }
                 )
 

--- a/care/facility/api/viewsets/prescription.py
+++ b/care/facility/api/viewsets/prescription.py
@@ -103,7 +103,7 @@ class ConsultationPrescriptionViewSet(
             "discontinued_reason", None
         )
         prescription_obj.save()
-        return Response({}, status=status.HTTP_201_CREATED)
+        return Response({}, status=status.HTTP_200_OK)
 
     @extend_schema(tags=["prescriptions"])
     @action(

--- a/care/facility/tests/test_prescriptions_api.py
+++ b/care/facility/tests/test_prescriptions_api.py
@@ -1,0 +1,61 @@
+from rest_framework import status
+
+from care.facility.models import MedibaseMedicine
+from care.utils.tests.test_base import TestBase
+
+
+class PrescriptionsApiTestCase(TestBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.medicine = MedibaseMedicine.objects.first()
+
+        self.normal_prescription_data = {
+            "medicine": self.medicine.external_id,
+            "prescription_type": "REGULAR",
+            "dosage": "1 mg",
+            "frequency": "OD",
+            "is_prn": False,
+        }
+
+    def test_create_normal_prescription(self):
+        consultation = self.create_consultation()
+        response = self.client.post(
+            f"/api/v1/consultation/{consultation.external_id}/prescriptions/",
+            self.normal_prescription_data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_prescribe_duplicate_active_medicine_and_discontinue(self):
+        """
+        1. Creates a prescription with Medicine A
+        2. Attempts to create another prescription with Medicine A (expecting failure)
+        3. Discontinues the first prescription
+        4. Re-attempts to create another prescription with Medicine A (expecting success)
+        """
+        consultation = self.create_consultation()
+        res = self.client.post(
+            f"/api/v1/consultation/{consultation.external_id}/prescriptions/",
+            self.normal_prescription_data,
+        )
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)
+        discontinue_prescription_id = res.data["id"]
+
+        res = self.client.post(
+            f"/api/v1/consultation/{consultation.external_id}/prescriptions/",
+            self.normal_prescription_data,
+        )
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+
+        res = self.client.post(
+            f"/api/v1/consultation/{consultation.external_id}/prescriptions/{discontinue_prescription_id}/discontinue/",
+            {
+                "discontinued_reason": "Test Reason",
+            },
+        )
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+
+        res = self.client.post(
+            f"/api/v1/consultation/{consultation.external_id}/prescriptions/",
+            self.normal_prescription_data,
+        )
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)


### PR DESCRIPTION
## Proposed Changes

- RReject Prescription Creation if Medicine already Prescribed and is active

### Associated Issue

- Required by coronasafe/care_fe#6085

<img width="1710" alt="image" src="https://github.com/coronasafe/care/assets/25143503/ed738f18-3f69-4d8f-8881-df2e8333806b">


## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
