### PR TITLE
Medicine Administrations: Add validations to `administered_date`

### DIFF
--- a/care/facility/api/serializers/prescription.py
+++ b/care/facility/api/serializers/prescription.py
@@ -1,4 +1,5 @@
 from django.shortcuts import get_object_or_404
+from django.utils import timezone
 from rest_framework import serializers
 
 from care.facility.models import MedibaseMedicine, MedicineAdministration, Prescription
@@ -76,6 +77,24 @@ class MedicineAdministrationSerializer(serializers.ModelSerializer):
 
     administered_by = UserBaseMinimumSerializer(read_only=True)
     prescription = PrescriptionSerializer(read_only=True)
+
+    def validate_administered_date(self, value):
+        if value > timezone.now():
+            raise serializers.ValidationError(
+                "Administered Date cannot be in the future."
+            )
+
+        prescription = self.context["prescription"]
+        if prescription.discontinued and value > prescription.discontinued_date:
+            raise serializers.ValidationError(
+                "Administered Date cannot be after Discontinued Date."
+            )
+
+        if prescription.created_date > value:
+            raise serializers.ValidationError(
+                "Administered Date cannot be before Prescription Date."
+            )
+        return value
 
     class Meta:
         model = MedicineAdministration

--- a/care/facility/api/serializers/prescription.py
+++ b/care/facility/api/serializers/prescription.py
@@ -83,14 +83,7 @@ class MedicineAdministrationSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(
                 "Administered Date cannot be in the future."
             )
-
-        prescription = self.context["prescription"]
-        if prescription.discontinued and value > prescription.discontinued_date:
-            raise serializers.ValidationError(
-                "Administered Date cannot be after Discontinued Date."
-            )
-
-        if prescription.created_date > value:
+        if self.context["prescription"].created_date > value:
             raise serializers.ValidationError(
                 "Administered Date cannot be before Prescription Date."
             )

--- a/care/facility/api/viewsets/prescription.py
+++ b/care/facility/api/viewsets/prescription.py
@@ -113,6 +113,11 @@ class ConsultationPrescriptionViewSet(
     )
     def administer(self, request, *args, **kwargs):
         prescription_obj = self.get_object()
+        if prescription_obj.discontinued:
+            return Response(
+                {"error": "Administering discontinued prescriptions is not allowed"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         serializer = MedicineAdministrationSerializer(
             data=request.data, context={"prescription": prescription_obj}
         )

--- a/care/facility/api/viewsets/prescription.py
+++ b/care/facility/api/viewsets/prescription.py
@@ -113,7 +113,9 @@ class ConsultationPrescriptionViewSet(
     )
     def administer(self, request, *args, **kwargs):
         prescription_obj = self.get_object()
-        serializer = MedicineAdministrationSerializer(data=request.data)
+        serializer = MedicineAdministrationSerializer(
+            data=request.data, context={"prescription": prescription_obj}
+        )
         serializer.is_valid(raise_exception=True)
         serializer.save(prescription=prescription_obj, administered_by=request.user)
         return Response(serializer.data, status=status.HTTP_201_CREATED)

--- a/care/facility/tests/test_medicine_administrations_api.py
+++ b/care/facility/tests/test_medicine_administrations_api.py
@@ -1,0 +1,58 @@
+from django.utils import timezone
+from rest_framework import status
+
+from care.facility.models import MedibaseMedicine, Prescription
+from care.utils.tests.test_base import TestBase
+
+
+class MedicineAdministrationsApiTestCase(TestBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.normal_prescription = self.create_prescription()
+
+    def create_prescription(self, **kwargs):
+        data = {
+            "consultation": self.create_consultation(),
+            "medicine": MedibaseMedicine.objects.first(),
+            "prescription_type": "REGULAR",
+            "dosage": "1 mg",
+            "frequency": "OD",
+            "is_prn": False,
+        }
+        return Prescription.objects.create(
+            **{**data, **kwargs, "prescribed_by": self.user}
+        )
+
+    def test_administer(self):
+        prescription = self.normal_prescription
+        res = self.client.post(
+            f"/api/v1/consultation/{prescription.consultation.external_id}/prescriptions/{prescription.external_id}/administer/",
+            {"notes": "Test Notes"},
+        )
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)
+
+    def test_administer_in_future(self):
+        prescription = self.normal_prescription
+        res = self.client.post(
+            f"/api/v1/consultation/{prescription.consultation.external_id}/prescriptions/{prescription.external_id}/administer/",
+            {"notes": "Test Notes", "administered_date": "2300-09-01T16:34"},
+        )
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_administer_in_past(self):
+        prescription = self.normal_prescription
+        res = self.client.post(
+            f"/api/v1/consultation/{prescription.consultation.external_id}/prescriptions/{prescription.external_id}/administer/",
+            {"notes": "Test Notes", "administered_date": "2019-09-01T16:34"},
+        )
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_administer_discontinued(self):
+        prescription = self.create_prescription(
+            discontinued=True, discontinued_date=timezone.now()
+        )
+        res = self.client.post(
+            f"/api/v1/consultation/{prescription.consultation.external_id}/prescriptions/{prescription.external_id}/administer/",
+            {"notes": "Test Notes"},
+        )
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Proposed Changes

- Added validations for `administered_date` in Medicine Administrations

### Associated Issue

- https://github.com/coronasafe/care_fe/issues/6178
- Front-end: https://github.com/coronasafe/care_fe/pull/6206

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
