### PR TITLE
CSV export for Assets

### DIFF
--- a/care/facility/api/serializers/asset.py
+++ b/care/facility/api/serializers/asset.py
@@ -24,6 +24,8 @@ from care.facility.models.asset import (
     AssetService,
     AssetServiceEdit,
     AssetTransaction,
+    AssetTypeChoices,
+    StatusChoices,
     UserDefaultAssetLocation,
 )
 from care.users.api.serializers.user import UserBaseMinimumSerializer
@@ -113,8 +115,8 @@ class AssetServiceSerializer(ModelSerializer):
 
 class AssetSerializer(ModelSerializer):
     id = UUIDField(source="external_id", read_only=True)
-    status = ChoiceField(choices=Asset.StatusChoices, read_only=True)
-    asset_type = ChoiceField(choices=Asset.AssetTypeChoices)
+    status = ChoiceField(choices=StatusChoices, read_only=True)
+    asset_type = ChoiceField(choices=AssetTypeChoices)
     location_object = AssetLocationSerializer(source="current_location", read_only=True)
     location = UUIDField(write_only=True, required=True)
     last_service = AssetServiceSerializer(read_only=True)

--- a/care/facility/models/asset.py
+++ b/care/facility/models/asset.py
@@ -4,6 +4,7 @@ import uuid
 from django.db import models
 from django.db.models import JSONField, Q
 
+from care.facility.models import reverse_choices
 from care.facility.models.facility import Facility
 from care.facility.models.json_schema.asset import ASSET_META
 from care.facility.models.mixins.permissions.asset import AssetsPermissionMixin
@@ -46,21 +47,28 @@ class AssetLocation(BaseModel, AssetsPermissionMixin):
     )
 
 
+class AssetType(enum.Enum):
+    INTERNAL = 50
+    EXTERNAL = 100
+
+
+AssetTypeChoices = [(e.value, e.name) for e in AssetType]
+
+AssetClassChoices = [(e.name, e.value._name) for e in AssetClasses]
+
+
+class Status(enum.Enum):
+    ACTIVE = 50
+    TRANSFER_IN_PROGRESS = 100
+
+
+StatusChoices = [(e.value, e.name) for e in Status]
+
+REVERSE_ASSET_TYPE = reverse_choices(AssetTypeChoices)
+REVERSE_STATUS = reverse_choices(StatusChoices)
+
+
 class Asset(BaseModel):
-    class AssetType(enum.Enum):
-        INTERNAL = 50
-        EXTERNAL = 100
-
-    AssetTypeChoices = [(e.value, e.name) for e in AssetType]
-
-    AssetClassChoices = [(e.name, e.value._name) for e in AssetClasses]
-
-    class Status(enum.Enum):
-        ACTIVE = 50
-        TRANSFER_IN_PROGRESS = 100
-
-    StatusChoices = [(e.value, e.name) for e in Status]
-
     name = models.CharField(max_length=1024, blank=False, null=False)
     description = models.TextField(default="", null=True, blank=True)
     asset_type = models.IntegerField(
@@ -99,6 +107,35 @@ class Asset(BaseModel):
         default=None,
         related_name="last_service",
     )
+
+    CSV_MAPPING = {
+        "name": "Name",
+        "description": "Description",
+        "asset_type": "Type",
+        "asset_class": "Class",
+        "status": "Working Status",
+        "current_location": "Current Location",
+        "is_working": "Is Working",
+        "not_working_reason": "Not Working Reason",
+        "serial_number": "Serial Number",
+        "warranty_details": "Warranty Details",
+        "vendor_name": "Vendor Name",
+        "support_name": "Support Name",
+        "support_phone": "Support Phone Number",
+        "support_email": "Support Email",
+        "qr_code_id": "QR Code ID",
+        "manufacturer": "Manufacturer",
+        "warranty_amc_end_of_validity": "Warrenty End Date",
+        "last_service__serviced_on": "Last Service Date",
+        "last_service__note": "Notes",
+        "meta__local_ip_address": "Config - IP Address",
+        "meta__camera_access_key": "Config: Camera Access Key",
+    }
+
+    CSV_MAKE_PRETTY = {
+        "asset_type": (lambda x: REVERSE_ASSET_TYPE[x]),
+        "status": (lambda x: REVERSE_STATUS[x]),
+    }
 
     class Meta:
         constraints = [


### PR DESCRIPTION
Frontend PR: https://github.com/coronasafe/care_fe/pull/6262

# Summary

This PR introduces several changes to the `Asset` model and its related serializers and viewsets in the `care/facility` app. The primary goal is to improve the handling of asset types and statuses, and to support CSV export of asset data.

# Changes

## Asset Model

- The `AssetType` and `Status` enums are now defined outside the `Asset` model, and their choices are generated separately as `AssetTypeChoices` and `StatusChoices`.
- Reversed mappings for asset types and statuses are created for use in CSV exports.
- A `CSV_MAPPING` dictionary is added to map model fields to human-readable CSV headers.
- A `CSV_MAKE_PRETTY` dictionary is added to provide functions for converting database values to human-readable strings for CSV exports.

## Asset Serializer

- The `status` and `asset_type` fields now use the `StatusChoices` and `AssetTypeChoices` generated outside the `Asset` model.

## Asset ViewSet

- The `list` method is overridden to support CSV export of asset data. If the `CSV_REQUEST_PARAMETER` is present in the request, the method generates a CSV file with headers and values based on the `CSV_MAPPING` and `CSV_MAKE_PRETTY` dictionaries in the `Asset` model.

# Testing

Please ensure that these changes do not break existing functionality, particularly around the handling of asset types and statuses. Also, please test the new CSV export functionality and ensure that the exported data matches the specified mappings and transformations.

# Closing

These changes should improve the flexibility and usability of the asset management features in the `care/facility` app. Please review and provide any feedback.