### PR TITLE
fix: failing deploy due to outdated lock file

### DIFF
--- a/docker/prod.Dockerfile
+++ b/docker/prod.Dockerfile
@@ -21,7 +21,7 @@ RUN python -m venv /venv
 RUN pip install pipenv
 
 COPY Pipfile Pipfile.lock ./
-RUN pipenv install --system --deploy
+RUN pipenv sync --system --categories "packages"
 
 
 # ---


### PR DESCRIPTION
## Proposed Changes

- dependabot removes extra categories from pipfile.lock
- unenforcing lockfile checks for extra categories fixes the issue

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
