### PR TITLE
add workflow triggers for merge queues

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -3,6 +3,7 @@ name: Lint Code Base
 on:
   pull_request:
     branches: [master]
+  merge_group:
 
 jobs:
   build:

--- a/.github/workflows/test-merge-queue.yml
+++ b/.github/workflows/test-merge-queue.yml
@@ -1,0 +1,8 @@
+name: Test Pull Request
+
+on:
+  merge_group:
+
+jobs:
+  test:
+    uses: ./.github/workflows/test-base.yml


### PR DESCRIPTION
ref: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#configuring-continuous-integration-ci-workflows-for-merge-queues

I created a separate test workflow for merge queue as the current one will cause issues due to same ref concurrency

closes #1627 

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
