### PR TITLE
Prescription: fixes `last_administered_on`

### DIFF
--- a/care/facility/api/serializers/prescription.py
+++ b/care/facility/api/serializers/prescription.py
@@ -29,11 +29,11 @@ class PrescriptionSerializer(serializers.ModelSerializer):
     def get_last_administered_on(self, obj):
         last_administration = (
             MedicineAdministration.objects.filter(prescription=obj)
-            .order_by("-created_date")
+            .order_by("-administered_date")
             .first()
         )
         if last_administration:
-            return last_administration.created_date
+            return last_administration.administered_date
         return None
 
     class Meta:


### PR DESCRIPTION
## Proposed Changes

- Fixes `last_administered_on` from returning `created_date` instead of `administered_date`

### Associated Issue

- Part of: https://github.com/coronasafe/care_fe/issues/6323
- Related FE: https://github.com/coronasafe/care_fe/pull/6345

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
