### PR TITLE
Refactor AssetPublicQRViewSet to Prefer qr_code_id Over Primary Key

### DIFF
--- a/care/facility/api/viewsets/asset.py
+++ b/care/facility/api/viewsets/asset.py
@@ -190,16 +190,15 @@ class AssetPublicQRViewSet(GenericViewSet):
     lookup_field = "qr_code_id"
 
     def retrieve(self, request, *args, **kwargs):
-        key = "asset:qr:" + kwargs["qr_code_id"]
+        qr_code_id = kwargs["qr_code_id"]
+        key = "asset:qr:" + qr_code_id
         hit = cache.get(key)
         if not hit:
-            instance = (
-                self.get_queryset().filter(qr_code_id=kwargs["qr_code_id"]).first()
-            )
+            instance = self.get_queryset().filter(qr_code_id=qr_code_id).first()
             if not instance:  # If the asset is not found, try to find it by pk
-                instance = get_object_or_404(
-                    self.get_queryset(), pk=kwargs["qr_code_id"]
-                )
+                if not qr_code_id.isnumeric():
+                    return Response(status=status.HTTP_404_NOT_FOUND)
+                instance = get_object_or_404(self.get_queryset(), pk=qr_code_id)
             serializer = self.get_serializer(instance)
             cache.set(key, serializer.data, 60 * 60 * 24)
             return Response(serializer.data)

--- a/care/facility/api/viewsets/asset.py
+++ b/care/facility/api/viewsets/asset.py
@@ -1,5 +1,3 @@
-import uuid
-
 from django.conf import settings
 from django.core.cache import cache
 from django.db.models import Exists, OuterRef, Q
@@ -192,21 +190,13 @@ class AssetPublicQRViewSet(GenericViewSet):
     lookup_field = "qr_code_id"
 
     def retrieve(self, request, *args, **kwargs):
-        is_uuid = True
-        try:
-            uuid.UUID(kwargs["qr_code_id"])
-        except ValueError:
-            # If the qr_code_id is not a UUID, then it is the pk of the asset
-            is_uuid = False
-            if not kwargs["qr_code_id"].isnumeric():
-                return Response(status=status.HTTP_404_NOT_FOUND)
-
         key = "asset:qr:" + kwargs["qr_code_id"]
         hit = cache.get(key)
         if not hit:
-            if is_uuid:
-                instance = self.get_object()
-            else:
+            instance = (
+                self.get_queryset().filter(qr_code_id=kwargs["qr_code_id"]).first()
+            )
+            if not instance:  # If the asset is not found, try to find it by pk
                 instance = get_object_or_404(
                     self.get_queryset(), pk=kwargs["qr_code_id"]
                 )


### PR DESCRIPTION
Previously, the retrieve method in AssetPublicQRViewSet would check whether the qr_code_id was a UUID or not and then retrieve the asset accordingly.

Previously, we encountered a problem when the `qr_code_id` was a numerical integer. This caused a conflict in our retrieval system as the numerical `qr_code_id` was incorrectly interpreted as the primary key (pk) of the asset, thereby preventing the correct retrieval of the asset using its `qr_code_id`

This refactor involves the following changes:

- Removed the block of code that checks whether the qr_code_id is a UUID.
- Directly used the qr_code_id to retrieve the asset from the queryset.
- Kept the fallback mechanism which retrieves the asset by its primary key (pk) if it's not found using the qr_code_id.

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
