### PR TITLE
Exclude `external_id` from resources serializers

### DIFF
--- a/care/facility/api/serializers/resources.py
+++ b/care/facility/api/serializers/resources.py
@@ -174,8 +174,8 @@ class ResourceRequestSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = ResourceRequest
-        exclude = ("deleted",)
-        read_only_fields = TIMESTAMP_FIELDS + ("external_id",)
+        exclude = ("deleted", "external_id")
+        read_only_fields = TIMESTAMP_FIELDS
 
 
 class ResourceRequestCommentSerializer(serializers.ModelSerializer):
@@ -195,9 +195,5 @@ class ResourceRequestCommentSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = ResourceRequestComment
-        exclude = ("deleted", "request")
-        read_only_fields = TIMESTAMP_FIELDS + (
-            "created_by",
-            "external_id",
-            "id",
-        )
+        exclude = ("deleted", "request", "external_id")
+        read_only_fields = TIMESTAMP_FIELDS + ("created_by")


### PR DESCRIPTION
## Proposed Changes

- Exclude `external_id` from resources serializers as a duplicate of the serialized `id` field.

### Associated Issue

- Fixes #1687

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
