### PR TITLE
offload migrations to beat service

### DIFF
--- a/scripts/celery_beat-ecs.sh
+++ b/scripts/celery_beat-ecs.sh
@@ -3,4 +3,28 @@
 if [ -z "${DATABASE_URL}" ]; then
     export DATABASE_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"
 fi
+
+postgres_ready() {
+python << END
+import sys
+
+import psycopg
+
+try:
+    psycopg.connect(conninfo="${DATABASE_URL}")
+except psycopg.OperationalError:
+    sys.exit(-1)
+sys.exit(0)
+
+END
+}
+
+until postgres_ready; do
+  >&2 echo 'Waiting for PostgreSQL to become available...'
+  sleep 1
+done
+>&2 echo 'PostgreSQL is available'
+
+python manage.py migrate --noinput
+
 celery --app=config.celery_app beat --loglevel=info

--- a/scripts/celery_beat.sh
+++ b/scripts/celery_beat.sh
@@ -3,5 +3,29 @@
 if [ -z "${DATABASE_URL}" ]; then
     export DATABASE_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"
 fi
+
+postgres_ready() {
+python << END
+import sys
+
+import psycopg
+
+try:
+    psycopg.connect(conninfo="${DATABASE_URL}")
+except psycopg.OperationalError:
+    sys.exit(-1)
+sys.exit(0)
+
+END
+}
+
+until postgres_ready; do
+  >&2 echo 'Waiting for PostgreSQL to become available...'
+  sleep 1
+done
+>&2 echo 'PostgreSQL is available'
+
+python manage.py migrate --noinput
+
 export NEW_RELIC_CONFIG_FILE=/etc/newrelic.ini
 newrelic-admin run-program celery --app=config.celery_app beat --loglevel=info

--- a/scripts/start-ecs.sh
+++ b/scripts/start-ecs.sh
@@ -30,5 +30,4 @@ done
 >&2 echo 'PostgreSQL is available'
 
 python manage.py collectstatic --noinput
-python manage.py migrate --noinput
 gunicorn config.wsgi:application --bind 0.0.0.0:9000 --chdir=/app --workers 2

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -28,8 +28,7 @@ until postgres_ready; do
 done
 >&2 echo 'PostgreSQL is available'
 
+python manage.py collectstatic --noinput
 
 export NEW_RELIC_CONFIG_FILE=/etc/newrelic.ini
-python manage.py collectstatic --noinput
-python manage.py migrate
 newrelic-admin run-program gunicorn config.wsgi:application --bind 0.0.0.0:9000 --chdir=/app


### PR DESCRIPTION
## Proposed Changes

- offload migrations to beat service

### Architecture changes

- let celery beat service take care of the migrations to avoid race conditons in the case of multiple backed replicas

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
