### PR TITLE
Display just the date in the CSV output of facility capacity for the updated date column

### DIFF
--- a/care/facility/models/facility.py
+++ b/care/facility/models/facility.py
@@ -318,7 +318,10 @@ class FacilityCapacity(FacilityBaseModel, FacilityRelatedPermissionMixin):
         "facilitycapacity__modified_date": "Updated Date",
     }
 
-    CSV_MAKE_PRETTY = {"facilitycapacity__room_type": (lambda x: REVERSE_ROOM_TYPES[x])}
+    CSV_MAKE_PRETTY = {
+        "facilitycapacity__room_type": (lambda x: REVERSE_ROOM_TYPES[x]),
+        "facilitycapacity__modified_date": (lambda x: x.strftime("%d-%m-%Y")),
+    }
 
     def __str__(self):
         return (


### PR DESCRIPTION
## Proposed Changes

- Add modified date formatting to CSV output in FacilityCapacity model

### Associated Issue

- coronasafe/care_fe#6603

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
