### PR TITLE
Support filtering daily rounds by `taken_at` range

### DIFF
--- a/care/facility/api/viewsets/daily_round.py
+++ b/care/facility/api/viewsets/daily_round.py
@@ -20,6 +20,7 @@ DailyRoundAttributes = [f.name for f in DailyRound._meta.get_fields()]
 
 class DailyRoundFilterSet(filters.FilterSet):
     rounds_type = filters.CharFilter(method="filter_rounds_type")
+    taken_at = filters.DateTimeFromToRangeFilter()
 
     def filter_rounds_type(self, queryset, name, value):
         rounds_type = set()


### PR DESCRIPTION
## Proposed Changes

- Support filtering daily rounds by `taken_at` date time range

### Associated Issue

- https://github.com/coronasafe/care_fe/issues/6690

<img width="1486" alt="image" src="https://github.com/coronasafe/care/assets/25143503/6efae2c3-8cb7-45e7-aaea-243c63e4af84">


## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
