### PR TITLE
Resolved Display Issues for Oxygen Cylinder Capacity in Facility Exports

### DIFF
--- a/care/facility/models/facility.py
+++ b/care/facility/models/facility.py
@@ -208,11 +208,7 @@ class Facility(FacilityBaseModel, FacilityPermissionMixin):
         "local_body__name": "Local Body",
         "district__name": "District",
         "state__name": "State",
-        "oxygen_capacity": "Oxygen Capacity",
         "phone_number": "Phone Number",
-        "type_b_cylinders": "B Type Oxygen Cylinder",
-        "type_c_cylinders": "C Type Oxygen Cylinder",
-        "type_d_cylinders": "Jumbo D Type Oxygen Cylinder",
     }
 
     CSV_MAKE_PRETTY = {"facility_type": (lambda x: REVERSE_FACILITY_TYPES[x])}
@@ -316,6 +312,10 @@ class FacilityCapacity(FacilityBaseModel, FacilityRelatedPermissionMixin):
         "facilitycapacity__total_capacity": "Total Capacity",
         "facilitycapacity__current_capacity": "Current Capacity",
         "facilitycapacity__modified_date": "Updated Date",
+        "oxygen_capacity": "Oxygen Capacity",
+        "type_b_cylinders": "B Type Oxygen Cylinder",
+        "type_c_cylinders": "C Type Oxygen Cylinder",
+        "type_d_cylinders": "Jumbo D Type Oxygen Cylinder",
     }
 
     CSV_MAKE_PRETTY = {


### PR DESCRIPTION
## Proposed Changes

In this pull request, we fix an issue related to the display of the "oxygen_capacity" along with "type_b_cylinders", "type_c_cylinders", and "type_d_cylinders" fields in the facility exports.

Previously, these fields were showing up in all four exports options (Facility, Capacity, Doctor, Triage). However, as per the expected behavior, these fields should only be displayed in the capacity export.

We have addressed this bug by reorganizing the position of these fields in the 'facility.py' model. They are now set to only appear in the "capacity export", thereby aligning their appearance with the expected behavior.

This fix ensures improved readability and accurate data display while exporting different facility data categories. We believe this change will contribute to the overall effectiveness and usability of the facility exports feature.

### Associated Issue

- Fixes https://github.com/coronasafe/care_fe/issues/6604

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
