### PR TITLE
Fix edge case for middleware hostname override in asset.py

### DIFF
--- a/care/facility/api/viewsets/asset.py
+++ b/care/facility/api/viewsets/asset.py
@@ -324,8 +324,8 @@ class AssetViewSet(
             middleware_hostname = (
                 asset.meta.get(
                     "middleware_hostname",
-                    asset.current_location.middleware_address,
                 )
+                or asset.current_location.middleware_address
                 or asset.current_location.facility.middleware_address
             )
             asset_class: BaseAssetIntegration = AssetClasses[asset.asset_class].value(

--- a/care/facility/tasks/asset_monitor.py
+++ b/care/facility/tasks/asset_monitor.py
@@ -34,8 +34,8 @@ def check_asset_status():
             hostname = (
                 asset.meta.get(
                     "middleware_hostname",
-                    asset.current_location.middleware_address,
                 )
+                or asset.current_location.middleware_address
                 or asset.current_location.facility.middleware_address
             )
             if not hostname:


### PR DESCRIPTION
This pull request addresses a subtle yet important issue in the asset management API, specifically in the `operate_assets` method of `care/facility/api/viewsets/asset.py` and the `check_asset_status` function in `care/facility/tasks/asset_monitor.py`. The modification ensures a more reliable fallback mechanism for retrieving the middleware hostname associated with assets.

Previously, the code utilized the `asset.meta.get("middleware_hostname", asset.current_location.middleware_address)` pattern. This approach, however, did not account for scenarios where `asset.meta['middleware_hostname']` could be an empty string. In such cases, the intended fallback to `asset.current_location.middleware_address` was bypassed, inadvertently defaulting to `asset.current_location.facility.middleware_address` due to the outer `or` condition.

The current update addresses this issue by repositioning the fallback logic. Instead of relying on the `get` method's default value, the code now explicitly checks for the truthiness of the `middleware_hostname` retrieved from `asset.meta`. This change ensures that if `middleware_hostname` is an empty string, the code will correctly fall back to `asset.current_location.middleware_address`, and subsequently to `asset.current_location.facility.middleware_address` if needed.


@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
