### PR TITLE
Allow district admin to delete users

### DIFF
--- a/care/users/api/viewsets/users.py
+++ b/care/users/api/viewsets/users.py
@@ -151,6 +151,12 @@ class UserViewSet(
                 user_type__lt=User.TYPE_VALUE_MAP["StateAdmin"],
                 is_superuser=False,
             )
+        elif request.user.user_type == User.TYPE_VALUE_MAP["DistrictAdmin"]:
+            queryset = queryset.filter(
+                district=request.user.district,
+                user_type__lt=User.TYPE_VALUE_MAP["DistrictAdmin"],
+                is_superuser=False,
+            )
         else:
             return Response(
                 status=status.HTTP_403_FORBIDDEN, data={"permission": "Denied"}


### PR DESCRIPTION
Frontend PR: https://github.com/coronasafe/care_fe/pull/6781

## Proposed Changes

In this commit, a new filter condition has been added specifically for the `DistrictAdmin` user type in the users API viewsets. More specifically, in the `destroy` function. Previously, if a user had a request that passed through this function, it would only check if the user's type is less than `StateAdmin` and hence not a superuser.

Now, besides the pre-existing conditions (user type is less than `StateAdmin` and not a superuser), if the user type is `DistrictAdmin`, an additional filter is applied. The filter checks if the `district` field of the user matches the district of the `request.user` and also verifies if the user type is less than `DistrictAdmin` and not a superuser.

Thus, this commit essentially grants a finer degree of control to the District Administrators in managing users under their jurisdiction i.e., the same district. It is important to note that this patch restricts the `DistrictAdmin` from deleting users of the same type or higher and the superusers, thus putting checks on their privileges.

### Associated Issue

- https://github.com/coronasafe/care_fe/issues/6716

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
