### PR TITLE
Add `resolved_middleware` JSON field to Asset Serializer.

### DIFF
--- a/care/facility/api/serializers/asset.py
+++ b/care/facility/api/serializers/asset.py
@@ -147,21 +147,7 @@ class AssetSerializer(ModelSerializer):
         }
     )
     def get_resolved_middleware(self, instance):
-        if hostname := instance.meta.get("middleware_hostname"):
-            return {
-                "hostname": hostname,
-                "source": "asset",
-            }
-        if hostname := instance.current_location.middleware_address:
-            return {
-                "hostname": hostname,
-                "source": "location",
-            }
-        if hostname := instance.current_location.facility.middleware_address:
-            return {
-                "hostname": hostname,
-                "source": "facility",
-            }
+        return instance.resolved_middleware
 
     class Meta:
         model = Asset

--- a/care/facility/api/serializers/asset.py
+++ b/care/facility/api/serializers/asset.py
@@ -134,7 +134,7 @@ class AssetSerializer(ModelSerializer):
     last_serviced_on = serializers.DateField(write_only=True, required=False)
     note = serializers.CharField(write_only=True, required=False, allow_blank=True)
 
-    resolved_middleware = serializers.SerializerMethodField()
+    resolved_middleware = serializers.SerializerMethodField(required=False)
 
     @extend_schema_field(
         {
@@ -143,6 +143,7 @@ class AssetSerializer(ModelSerializer):
                 "hostname": {"type": "string"},
                 "source": {"type": "string", "enum": ["asset", "location", "facility"]},
             },
+            "nullable": True,
         }
     )
     def get_resolved_middleware(self, instance):

--- a/care/facility/models/asset.py
+++ b/care/facility/models/asset.py
@@ -141,6 +141,24 @@ class Asset(BaseModel):
         "is_working": (lambda x: "WORKING" if x else "NOT WORKING"),
     }
 
+    @property
+    def resolved_middleware(self):
+        if hostname := self.meta.get("middleware_hostname"):
+            return {
+                "hostname": hostname,
+                "source": "asset",
+            }
+        if hostname := self.current_location.middleware_address:
+            return {
+                "hostname": hostname,
+                "source": "location",
+            }
+        if hostname := self.current_location.facility.middleware_address:
+            return {
+                "hostname": hostname,
+                "source": "facility",
+            }
+
     class Meta:
         constraints = [
             models.UniqueConstraint(


### PR DESCRIPTION


## Proposed Changes

- Adds a serializer method field: `resolved_middleware` that returns a JSON of the resolved middleware.

<img width="681" alt="image" src="https://github.com/coronasafe/care/assets/25143503/1c41c63e-eeb7-4f96-b149-dc91a3821cd0">

### Examples

<img width="390" alt="image" src="https://github.com/coronasafe/care/assets/25143503/e1e0e291-e7e7-4922-b2cd-dadf71a5501b">

<img width="424" alt="image" src="https://github.com/coronasafe/care/assets/25143503/e6370cfa-4f3d-43ec-ae60-b14ebf276ab0">

<img width="394" alt="image" src="https://github.com/coronasafe/care/assets/25143503/f77af860-4296-4d56-b4a3-7d2b96151e08">


### Associated Issue

- Fixes #1740

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
