### PR TITLE
Check if user uploading External results is from same district

### DIFF
--- a/care/facility/api/viewsets/patient_external_test.py
+++ b/care/facility/api/viewsets/patient_external_test.py
@@ -140,16 +140,17 @@ class PatientExternalTestViewSet(
         # csv_file.seek(0)
         # reader = csv.DictReader(io.StringIO(csv_file.read().decode("utf-8-sig")))
 
+        if "sample_tests" not in request.data:
+            raise ValidationError({"sample_tests": "No Data was provided"})
+        if not isinstance(request.data["sample_tests"], list):
+            raise ValidationError({"sample_tests": "Data should be provided as a list"})
+
         # check if the user is from same district
         user = User.objects.filter(username=request.user).first()
         for data in request.data["sample_tests"]:
             if user.district != data["district"]:
                 raise ValidationError({"Error": "User must belong to same district"})
 
-        if "sample_tests" not in request.data:
-            raise ValidationError({"sample_tests": "No Data was provided"})
-        if not isinstance(request.data["sample_tests"], list):
-            raise ValidationError({"sample_tests": "Data should be provided as a list"})
         errors = []
         counter = 0
         ser_objects = []

--- a/care/facility/api/viewsets/patient_external_test.py
+++ b/care/facility/api/viewsets/patient_external_test.py
@@ -139,6 +139,13 @@ class PatientExternalTestViewSet(
         # csv_file = request.FILES[list(request.FILES.keys())[0]]
         # csv_file.seek(0)
         # reader = csv.DictReader(io.StringIO(csv_file.read().decode("utf-8-sig")))
+
+        # check if the user is from same district
+        user = User.objects.filter(username=request.user).first()
+        for data in request.data["sample_tests"]:
+            if user.district != data["district"]:
+                raise ValidationError({"Error": "User must belong to same district"})
+
         if "sample_tests" not in request.data:
             raise ValidationError({"sample_tests": "No Data was provided"})
         if not isinstance(request.data["sample_tests"], list):

--- a/care/facility/api/viewsets/patient_external_test.py
+++ b/care/facility/api/viewsets/patient_external_test.py
@@ -139,7 +139,6 @@ class PatientExternalTestViewSet(
         # csv_file = request.FILES[list(request.FILES.keys())[0]]
         # csv_file.seek(0)
         # reader = csv.DictReader(io.StringIO(csv_file.read().decode("utf-8-sig")))
-
         if "sample_tests" not in request.data:
             raise ValidationError({"sample_tests": "No Data was provided"})
         if not isinstance(request.data["sample_tests"], list):

--- a/care/facility/api/viewsets/patient_external_test.py
+++ b/care/facility/api/viewsets/patient_external_test.py
@@ -145,9 +145,8 @@ class PatientExternalTestViewSet(
             raise ValidationError({"sample_tests": "Data should be provided as a list"})
 
         # check if the user is from same district
-        user = User.objects.filter(username=request.user).first()
         for data in request.data["sample_tests"]:
-            if user.district != data["district"]:
+            if request.user.district != data["district"]:
                 raise ValidationError({"Error": "User must belong to same district"})
 
         errors = []


### PR DESCRIPTION
## Proposed Changes

Before importing the External results from the CSV file, check whether each of those results belong to the same district as that of the uploading user

### Associated Issue
Fixes [#6650](https://github.com/coronasafe/care_fe/issues/6650)

![Screenshot from 2023-12-05 15-40-13](https://github.com/coronasafe/care/assets/70687348/e96d0342-ade4-4daa-ae7a-dc2ba41a85f5)

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
