### PR TITLE
Send asset downtime status along with asset details

### DIFF
--- a/care/facility/api/serializers/asset.py
+++ b/care/facility/api/serializers/asset.py
@@ -149,7 +149,6 @@ class AssetSerializer(ModelSerializer):
     last_serviced_on = serializers.DateField(write_only=True, required=False)
     note = serializers.CharField(write_only=True, required=False, allow_blank=True)
     resolved_middleware = ResolvedMiddlewareField(read_only=True)
-
     down = serializers.BooleanField(read_only=True)
 
     class Meta:

--- a/care/facility/api/serializers/asset.py
+++ b/care/facility/api/serializers/asset.py
@@ -150,10 +150,15 @@ class AssetSerializer(ModelSerializer):
     note = serializers.CharField(write_only=True, required=False, allow_blank=True)
     resolved_middleware = ResolvedMiddlewareField(read_only=True)
 
+    down = serializers.BooleanField(read_only=True)
+
     class Meta:
         model = Asset
         exclude = ("deleted", "external_id", "current_location")
-        read_only_fields = TIMESTAMP_FIELDS + ("resolved_middleware",)
+        read_only_fields = TIMESTAMP_FIELDS + (
+            "resolved_middleware",
+            "down",
+        )
 
     def validate_qr_code_id(self, value):
         value = value or None  # treat empty string as null

--- a/care/facility/api/serializers/asset.py
+++ b/care/facility/api/serializers/asset.py
@@ -149,14 +149,14 @@ class AssetSerializer(ModelSerializer):
     last_serviced_on = serializers.DateField(write_only=True, required=False)
     note = serializers.CharField(write_only=True, required=False, allow_blank=True)
     resolved_middleware = ResolvedMiddlewareField(read_only=True)
-    down = serializers.BooleanField(read_only=True)
+    latest_status = serializers.CharField(read_only=True)
 
     class Meta:
         model = Asset
         exclude = ("deleted", "external_id", "current_location")
         read_only_fields = TIMESTAMP_FIELDS + (
             "resolved_middleware",
-            "down",
+            "latest_status",
         )
 
     def validate_qr_code_id(self, value):

--- a/care/facility/api/viewsets/asset.py
+++ b/care/facility/api/viewsets/asset.py
@@ -215,17 +215,6 @@ class AssetAvailabilityViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSe
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = AssetAvailabilityFilter
 
-    # filter queryset to get all assets accessible by a user
-    def get_queryset(self):
-        queryset = AssetAvailabilityRecord.objects.all().select_related("asset")
-
-        # Check if the requesting user belongs to the related Facility
-        queryset = queryset.filter(
-            Q(asset__current_location__facility__users=self.request.user)
-            | Q(asset__current_location__facility__users__isnull=True)
-        )
-        return queryset
-
 
 class AssetViewSet(
     ListModelMixin,

--- a/care/facility/api/viewsets/asset.py
+++ b/care/facility/api/viewsets/asset.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.core.cache import cache
 from django.db.models import Exists, OuterRef, Q, Subquery
-from django.db.models.query import QuerySet
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.http import Http404
@@ -253,11 +252,6 @@ class AssetViewSet(
             queryset = queryset.filter(
                 current_location__facility__id__in=allowed_facilities
             )
-
-        return queryset
-
-    def filter_queryset(self, queryset: QuerySet) -> QuerySet:
-        queryset = super().filter_queryset(queryset)
         queryset = queryset.annotate(
             latest_status=Subquery(
                 AssetAvailabilityRecord.objects.filter(asset=OuterRef("pk"))

--- a/care/facility/api/viewsets/asset.py
+++ b/care/facility/api/viewsets/asset.py
@@ -215,6 +215,17 @@ class AssetAvailabilityViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSe
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = AssetAvailabilityFilter
 
+    # filter queryset to get all assets accessible by a user
+    def get_queryset(self):
+        queryset = AssetAvailabilityRecord.objects.all().select_related("asset")
+
+        # Check if the requesting user belongs to the related Facility
+        queryset = queryset.filter(
+            Q(asset__current_location__facility__users=self.request.user)
+            | Q(asset__current_location__facility__users__isnull=True)
+        )
+        return queryset
+
 
 class AssetViewSet(
     ListModelMixin,

--- a/care/facility/tests/test_asset_api.py
+++ b/care/facility/tests/test_asset_api.py
@@ -52,6 +52,7 @@ class AssetViewSetTestCase(TestUtils, APITestCase):
     def test_retrieve_asset(self):
         response = self.client.get(f"/api/v1/asset/{self.asset.external_id}/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("latest_status", response.data)
 
     def test_update_asset(self):
         sample_data = {


### PR DESCRIPTION
## Proposed Changes

Modify the `AssetAvailabilityViewSet` query set to send the asset uptime status of all assets related to the user
![image](https://github.com/coronasafe/care/assets/70687348/833d40f5-346c-40d4-b399-f38e0b5f0e69)

### Associated Issue
Partially Fixes [#6819](https://github.com/coronasafe/care_fe/issues/6819)

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
