### PR TITLE
Copy consciousness_level when cloning last daily round

### DIFF
--- a/care/facility/api/serializers/daily_round.py
+++ b/care/facility/api/serializers/daily_round.py
@@ -232,6 +232,7 @@ class DailyRoundSerializer(serializers.ModelSerializer):
                             "rhythm",
                             "rhythm_detail",
                             "ventilator_spo2",
+                            "consciousness_level",
                         ]
                         cloned_daily_round_obj = DailyRound()
                         for field in fields_to_clone:


### PR DESCRIPTION
Related issue: https://github.com/coronasafe/care_fe/issues/6839

We're recently added consciousness_level to normal round type, hence it should be copied when cloning the last daily round record.

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
