### PR TITLE
added error handling for get_hip_id_by_health_id

### DIFF
--- a/care/abdm/api/viewsets/auth.py
+++ b/care/abdm/api/viewsets/auth.py
@@ -348,7 +348,7 @@ class RequestDataView(GenericAPIView):
         except Exception as e:
             return Response(
                 {
-                    "message": "Failed to notify (health-information/notify)",
+                    "detail": "Failed to notify (health-information/notify)",
                     "error": str(e),
                 },
                 status=status.HTTP_400_BAD_REQUEST,

--- a/care/abdm/api/viewsets/auth.py
+++ b/care/abdm/api/viewsets/auth.py
@@ -22,7 +22,10 @@ class OnFetchView(GenericAPIView):
     def post(self, request, *args, **kwargs):
         data = request.data
 
-        AbdmGateway().init(data["resp"]["requestId"])
+        try:
+            AbdmGateway().init(data["resp"]["requestId"])
+        except Exception as e:
+            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
         return Response({}, status=status.HTTP_202_ACCEPTED)
 
@@ -324,20 +327,31 @@ class RequestDataView(GenericAPIView):
             }
         )
 
-        AbdmGateway().data_notify(
-            {
-                "health_id": consent["notification"]["consentDetail"]["patient"]["id"],
-                "consent_id": data["hiRequest"]["consent"]["id"],
-                "transaction_id": data["transactionId"],
-                "care_contexts": list(
-                    map(
-                        lambda context: {"id": context["careContextReference"]},
-                        consent["notification"]["consentDetail"]["careContexts"][
-                            :-2:-1
-                        ],
-                    )
-                ),
-            }
-        )
+        try:
+            AbdmGateway().data_notify(
+                {
+                    "health_id": consent["notification"]["consentDetail"]["patient"][
+                        "id"
+                    ],
+                    "consent_id": data["hiRequest"]["consent"]["id"],
+                    "transaction_id": data["transactionId"],
+                    "care_contexts": list(
+                        map(
+                            lambda context: {"id": context["careContextReference"]},
+                            consent["notification"]["consentDetail"]["careContexts"][
+                                :-2:-1
+                            ],
+                        )
+                    ),
+                }
+            )
+        except Exception as e:
+            return Response(
+                {
+                    "message": "Failed to notify (health-information/notify)",
+                    "error": str(e),
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         return Response({}, status=status.HTTP_202_ACCEPTED)

--- a/care/abdm/api/viewsets/healthid.py
+++ b/care/abdm/api/viewsets/healthid.py
@@ -474,6 +474,12 @@ class ABDMHealthIDViewSet(GenericViewSet, CreateModelMixin):
             {"phone": patient.phone_number, "healthId": patient.abha_number.health_id}
         )
 
+        if not response:
+            return Response(
+                {"message": "Failed to send SMS"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         return Response(response, status=status.HTTP_202_ACCEPTED)
 
     # auth/init

--- a/care/abdm/api/viewsets/healthid.py
+++ b/care/abdm/api/viewsets/healthid.py
@@ -364,7 +364,7 @@ class ABDMHealthIDViewSet(GenericViewSet, CreateModelMixin):
                 )
             except Exception as e:
                 return Response(
-                    {"message": "Failed to fetch modes", "reason": str(e)},
+                    {"detail": "Failed to fetch modes", "error": str(e)},
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
@@ -420,7 +420,7 @@ class ABDMHealthIDViewSet(GenericViewSet, CreateModelMixin):
             )
         except Exception as e:
             return Response(
-                {"message": "Failed to fetch modes", "reason": str(e)},
+                {"detail": "Failed to fetch modes", "error": str(e)},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -464,7 +464,7 @@ class ABDMHealthIDViewSet(GenericViewSet, CreateModelMixin):
             )
         except Exception as e:
             return Response(
-                {"message": "Failed to add care context", "reason": str(e)},
+                {"detail": "Failed to add care context", "error": str(e)},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -497,7 +497,7 @@ class ABDMHealthIDViewSet(GenericViewSet, CreateModelMixin):
             )
         except Exception as e:
             return Response(
-                {"message": "Failed to send SMS", "reason": str(e)},
+                {"detail": "Failed to send SMS", "error": str(e)},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 

--- a/care/abdm/api/viewsets/hip.py
+++ b/care/abdm/api/viewsets/hip.py
@@ -87,24 +87,34 @@ class HipViewSet(GenericViewSet):
                     pincode=patient_data["address"]["pincode"],
                 )
 
+                try:
+                    self.get_linking_token(
+                        {
+                            "healthId": patient_data["healthId"]
+                            or patient_data["healthIdNumber"],
+                            "name": patient_data["name"],
+                            "gender": patient_data["gender"],
+                            "dateOfBirth": str(
+                                datetime.strptime(
+                                    f"{patient_data['yearOfBirth']}-{patient_data['monthOfBirth']}-{patient_data['dayOfBirth']}",
+                                    "%Y-%m-%d",
+                                )
+                            )[0:10],
+                        }
+                    )
+                except Exception:
+                    return Response(
+                        {
+                            "status": "FAILED",
+                            "healthId": patient_data["healthId"]
+                            or patient_data["healthIdNumber"],
+                        },
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
+
                 abha_number.save()
                 patient.abha_number = abha_number
                 patient.save()
-
-                self.get_linking_token(
-                    {
-                        "healthId": patient_data["healthId"]
-                        or patient_data["healthIdNumber"],
-                        "name": patient_data["name"],
-                        "gender": patient_data["gender"],
-                        "dateOfBirth": str(
-                            datetime.strptime(
-                                f"{patient_data['yearOfBirth']}-{patient_data['monthOfBirth']}-{patient_data['dayOfBirth']}",
-                                "%Y-%m-%d",
-                            )
-                        )[0:10],
-                    }
-                )
 
             payload = {
                 "requestId": str(uuid.uuid4()),

--- a/care/facility/api/serializers/patient_consultation.py
+++ b/care/facility/api/serializers/patient_consultation.py
@@ -668,16 +668,19 @@ class PatientConsultationDischargeSerializer(serializers.ModelSerializer):
             ).update(end_date=now())
             if patient.abha_number:
                 abha_number = patient.abha_number
-                AbdmGateway().fetch_modes(
-                    {
-                        "healthId": abha_number.abha_number,
-                        "name": abha_number.name,
-                        "gender": abha_number.gender,
-                        "dateOfBirth": str(abha_number.date_of_birth),
-                        "consultationId": abha_number.external_id,
-                        "purpose": "LINK",
-                    }
-                )
+                try:
+                    AbdmGateway().fetch_modes(
+                        {
+                            "healthId": abha_number.abha_number,
+                            "name": abha_number.name,
+                            "gender": abha_number.gender,
+                            "dateOfBirth": str(abha_number.date_of_birth),
+                            "consultationId": abha_number.external_id,
+                            "purpose": "LINK",
+                        }
+                    )
+                except Exception:
+                    pass
             return instance
 
     def create(self, validated_data):


### PR DESCRIPTION
## Proposed Changes

- added error handling for get_hip_id_by_health_id

### Associated Issue

Errors are out when hf_id is not present for a facility. This interferes with discharging a patient when he has an ABHA number but the facility doesn't have hf_id.

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
