### PR TITLE
Allows diagnoses starting with disease code to be available in ICD11 Search

### DIFF
--- a/care/facility/api/viewsets/icd.py
+++ b/care/facility/api/viewsets/icd.py
@@ -22,11 +22,10 @@ class ICDViewSet(ViewSet):
     def list(self, request):
         from care.facility.static_data.icd11 import ICDDiseases
 
-        queryset = ICDDiseases
+        queryset = ICDDiseases.where(has_code=True)
         if request.GET.get("query", False):
             query = request.GET.get("query")
             queryset = queryset.where(
-                label=queryset.re_match(r".*" + query + r".*", IGNORECASE),
-                is_leaf=True,
+                label=queryset.re_match(r".*" + query + r".*", IGNORECASE)
             )  # can accept regex from FE if needed.
         return Response(serailize_data(queryset[0:100]))

--- a/care/facility/static_data/icd11.py
+++ b/care/facility/static_data/icd11.py
@@ -1,4 +1,5 @@
 import contextlib
+import re
 
 from django.db import connection
 from littletable import Table
@@ -14,11 +15,11 @@ def fetch_from_db():
             {
                 "id": str(diagnosis["id"]),
                 "label": diagnosis["label"],
-                "is_leaf": diagnosis["is_leaf"],
+                "has_code": bool(re.match(r"^[A-Z][A-Z0-9.]+\s", diagnosis["label"])),
                 "chapter": diagnosis["meta_chapter_short"],
             }
-            for diagnosis in ICD11Diagnosis.objects.filter().values(
-                "id", "label", "is_leaf", "meta_chapter_short"
+            for diagnosis in ICD11Diagnosis.objects.values(
+                "id", "label", "meta_chapter_short"
             )
         ]
     return []


### PR DESCRIPTION
## Proposed Changes

- Allows diagnoses starting with disease code to be available in ICD11 searched regardless of whether it's a chapter/category/leaf entity or not

### Associated Issue

- Fixes https://github.com/coronasafe/care_fe/issues/7042

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
