### PR TITLE
Fix celery beat healthchecks

### DIFF
--- a/docker-compose.pre-built.yaml
+++ b/docker-compose.pre-built.yaml
@@ -29,4 +29,3 @@ services:
     depends_on:
       - db
       - redis
-      - celery-beat

--- a/scripts/celery_beat-ecs.sh
+++ b/scripts/celery_beat-ecs.sh
@@ -30,5 +30,6 @@ done
 python manage.py migrate --noinput
 python manage.py load_redis_index
 
+touch /tmp/healthy
 
 celery --app=config.celery_app beat --loglevel=info

--- a/scripts/celery_beat.sh
+++ b/scripts/celery_beat.sh
@@ -30,6 +30,7 @@ done
 python manage.py migrate --noinput
 python manage.py load_redis_index
 
+touch /tmp/healthy
 
 export NEW_RELIC_CONFIG_FILE=/etc/newrelic.ini
 newrelic-admin run-program celery --app=config.celery_app beat --loglevel=info

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -3,6 +3,11 @@
 CONTAINER_ROLE=$(cat /tmp/container-role)
 if [[ "$CONTAINER_ROLE" = "api" ]]; then
     curl -fsS http://localhost:9000/ping/ || exit 1
-elif [[ "$CONTAINER_ROLE" == celery* ]]; then
+elif [[ "$CONTAINER_ROLE" == "celery-worker" ]]; then
     celery -A config.celery_app inspect ping -d celery@$HOSTNAME || exit 1
+elif [[ "$CONTAINER_ROLE" == "celery-beat" ]]; then
+    ls /tmp/healthy || exit 1
+else
+    echo "Unknown container role: $CONTAINER_ROLE"
+    exit 1
 fi


### PR DESCRIPTION
This pull request fixes the healthchecks for the celery beat service. Previously, the healthchecks were failing due to a missing file. This PR adds the necessary file and updates the healthcheck logic to check for its presence.