### PR TITLE
Add custom prefix and suffix to hip name

### DIFF
--- a/care/abdm/api/viewsets/health_facility.py
+++ b/care/abdm/api/viewsets/health_facility.py
@@ -34,9 +34,7 @@ def register_health_facility_as_service(facility_external_id):
 
     clean_facility_name = re.sub(r"[^A-Za-z0-9 ]+", " ", health_facility.facility.name)
     clean_facility_name = re.sub(r"\s+", " ", clean_facility_name).strip()
-    hip_name = (
-        settings.HIP_NAME_PREFIX + clean_facility_name + settings.HIP_NAME_POSTFIX
-    )
+    hip_name = settings.HIP_NAME_PREFIX + clean_facility_name + settings.HIP_NAME_SUFFIX
     response = Facility().add_update_service(
         {
             "facilityId": health_facility.hf_id,

--- a/care/abdm/api/viewsets/health_facility.py
+++ b/care/abdm/api/viewsets/health_facility.py
@@ -57,7 +57,19 @@ def register_health_facility_as_service(facility_external_id):
         data = response.json()[0]
 
         if "error" in data:
-            return [False, data["error"]["message"]]
+            if (
+                data["error"].get("code") == "2500"
+                and settings.ABDM_CLIENT_ID in data["error"].get("message")
+                and "already associated" in data["error"].get("message")
+            ):
+                health_facility.registered = True
+                health_facility.save()
+                return [True, None]
+
+            return [
+                False,
+                data["error"].get("message", "Error while registering HIP as service"),
+            ]
 
         if "servicesLinked" in data:
             health_facility.registered = True

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -591,6 +591,8 @@ HEALTH_SERVICE_API_URL = env(
     "HEALTH_SERVICE_API_URL", default="https://healthidsbx.abdm.gov.in/api"
 )
 ABDM_FACILITY_URL = env("ABDM_FACILITY_URL", default="https://facilitysbx.abdm.gov.in")
+HIP_NAME_PREFIX = env("HIP_NAME_PREFIX", default="")
+HIP_NAME_POSTFIX = env("HIP_NAME_POSTFIX", default="")
 ABDM_USERNAME = env("ABDM_USERNAME", default="abdm_user_internal")
 X_CM_ID = env("X_CM_ID", default="sbx")
 FIDELIUS_URL = env("FIDELIUS_URL", default="http://fidelius:8090")

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -592,7 +592,7 @@ HEALTH_SERVICE_API_URL = env(
 )
 ABDM_FACILITY_URL = env("ABDM_FACILITY_URL", default="https://facilitysbx.abdm.gov.in")
 HIP_NAME_PREFIX = env("HIP_NAME_PREFIX", default="")
-HIP_NAME_POSTFIX = env("HIP_NAME_POSTFIX", default="")
+HIP_NAME_SUFFIX = env("HIP_NAME_SUFFIX", default="")
 ABDM_USERNAME = env("ABDM_USERNAME", default="abdm_user_internal")
 X_CM_ID = env("X_CM_ID", default="sbx")
 FIDELIUS_URL = env("FIDELIUS_URL", default="http://fidelius:8090")


### PR DESCRIPTION
## Proposed Changes

- add postfix and prefix and clean hip name before service registration
- set register to true if the facility is already associated with the bridge ID

### Associated Issue

- Fixes #1849 

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
