### PR TITLE
Limit minimum encounter date to 2020-01-01

### DIFF
--- a/care/facility/api/serializers/patient_consultation.py
+++ b/care/facility/api/serializers/patient_consultation.py
@@ -1,7 +1,8 @@
 from datetime import timedelta
 
+from django.conf import settings
 from django.db import transaction
-from django.utils.timezone import localtime, now
+from django.utils.timezone import localtime, make_aware, now
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
@@ -46,6 +47,8 @@ from care.utils.notification_handler import NotificationGenerator
 from care.utils.queryset.facility import get_home_facility_queryset
 from care.utils.serializer.external_id_field import ExternalIdSerializerField
 from config.serializers import ChoiceField
+
+MIN_ENCOUNTER_DATE = make_aware(settings.MIN_ENCOUNTER_DATE)
 
 
 class PatientConsultationSerializer(serializers.ModelSerializer):
@@ -474,6 +477,14 @@ class PatientConsultationSerializer(serializers.ModelSerializer):
         return value
 
     def validate_encounter_date(self, value):
+        if value < MIN_ENCOUNTER_DATE:
+            raise ValidationError(
+                {
+                    "encounter_date": [
+                        f"This field value must be greater than {MIN_ENCOUNTER_DATE.strftime('%Y-%m-%d')}"
+                    ]
+                }
+            )
         if value > now():
             raise ValidationError(
                 {"encounter_date": "This field value cannot be in the future."}

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -4,7 +4,7 @@ Base settings to build other settings files upon.
 
 import base64
 import json
-from datetime import timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import environ
@@ -570,6 +570,12 @@ FACILITY_S3_BUCKET_EXTERNAL_ENDPOINT = env(
 
 # for setting the shifting mode
 PEACETIME_MODE = env.bool("PEACETIME_MODE", default=True)
+
+MIN_ENCOUNTER_DATE = env(
+    "MIN_ENCOUNTER_DATE",
+    cast=lambda d: datetime.strptime(d, "%Y-%m-%d"),
+    default=datetime(2020, 1, 1),
+)
 
 # for exporting csv
 CSV_REQUEST_PARAMETER = "csv"

--- a/docs/django-configuration/configuration.rst
+++ b/docs/django-configuration/configuration.rst
@@ -1,6 +1,11 @@
 Environment Variables
 ===============
 
+``MIN_ENCOUNTER_DATE``
+---------------------
+Default value is `2020-01-01`. This is the minimum date for a possible consultation encounter.
+Example: `MIN_ENCOUNTER_DATE=2000-01-01`
+
 ``TASK_SUMMARIZE_TRIAGE``
 ---------------------
 Default value is `True`. If set to `False`, the celery task to summarize triage data will not be executed.


### PR DESCRIPTION
This pull request adds a validation to ensure that the encounter date cannot be set to a date earlier than January 1, 2020. It also includes a test case to verify this validation.