### PR TITLE
Add consultation serializer for Investigation

### DIFF
--- a/care/facility/api/serializers/patient_investigation.py
+++ b/care/facility/api/serializers/patient_investigation.py
@@ -1,6 +1,9 @@
 from rest_framework import serializers
 
 from care.facility.api.serializers import TIMESTAMP_FIELDS
+from care.facility.api.serializers.patient_consultation import (
+    PatientConsultationSerializer,
+)
 from care.facility.models.patient_investigation import (
     InvestigationSession,
     InvestigationValue,
@@ -40,6 +43,10 @@ class PatientInvestigationSessionSerializer(serializers.ModelSerializer):
 
 class InvestigationValueSerializer(serializers.ModelSerializer):
     id = serializers.CharField(source="external_id", read_only=True)
+
+    consultation_object = PatientConsultationSerializer(
+        source="consultation", read_only=True
+    )
 
     group_object = PatientInvestigationGroupSerializer(source="group", read_only=True)
     investigation_object = MinimalPatientInvestigationSerializer(

--- a/care/facility/api/viewsets/patient_investigation.py
+++ b/care/facility/api/viewsets/patient_investigation.py
@@ -99,7 +99,7 @@ class PatientInvestigationSummaryViewSet(
     mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet
 ):
     serializer_class = InvestigationValueSerializer
-    queryset = InvestigationValue.objects.all()
+    queryset = InvestigationValue.objects.select_related("consultation").all()
     lookup_field = "external_id"
     permission_classes = (IsAuthenticated,)
     filterset_class = PatientInvestigationFilter
@@ -155,7 +155,7 @@ class InvestigationValueViewSet(
     viewsets.GenericViewSet,
 ):
     serializer_class = InvestigationValueSerializer
-    queryset = InvestigationValue.objects.all()
+    queryset = InvestigationValue.objects.select_related("consultation").all()
     lookup_field = "external_id"
     permission_classes = (IsAuthenticated,)
     filterset_class = PatientInvestigationFilter


### PR DESCRIPTION
This pull request adds a consultation serializer for the Investigation model. It includes changes to the `patient_investigation.py` file in the `care/facility/api/serializers` directory.