### PR TITLE
Fix queryset filters for asset daily rounds

### DIFF
--- a/care/facility/api/serializers/daily_round.py
+++ b/care/facility/api/serializers/daily_round.py
@@ -6,7 +6,6 @@ from django.utils import timezone
 from django.utils.timezone import localtime, now
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
-from rest_framework.generics import get_object_or_404
 
 # from care.facility.api.serializers.bed import BedSerializer
 from care.facility.models import (
@@ -22,9 +21,9 @@ from care.facility.models.patient_base import (
     SYMPTOM_CHOICES,
     SuggestionChoices,
 )
+from care.facility.models.patient_consultation import PatientConsultation
 from care.users.api.serializers.user import UserBaseMinimumSerializer
 from care.utils.notification_handler import NotificationGenerator
-from care.utils.queryset.consultation import get_consultation_queryset
 from care.utils.queryset.facility import get_home_facility_queryset
 from config.serializers import ChoiceField
 
@@ -105,6 +104,7 @@ class DailyRoundSerializer(serializers.ModelSerializer):
             "glasgow_total_calculated",
             "total_intake_calculated",
             "total_output_calculated",
+            "consultation",
         )
         exclude = ("deleted",)
 
@@ -165,30 +165,19 @@ class DailyRoundSerializer(serializers.ModelSerializer):
         ).generate()
 
     def create(self, validated_data):
+        consultation: PatientConsultation = validated_data["consultation"]
         # Authorisation Checks
-
-        # Skip check for asset user
-        if self.context["request"].user.asset_id is None:
-            allowed_facilities = get_home_facility_queryset(
-                self.context["request"].user
+        if (
+            not get_home_facility_queryset(self.context["request"].user)
+            .filter(id=consultation.facility_id)
+            .exists()
+        ):
+            raise ValidationError(
+                {"facility": "Daily Round creates are only allowed in home facility"}
             )
-            if not allowed_facilities.filter(
-                id=self.validated_data["consultation"].facility.id
-            ).exists():
-                raise ValidationError(
-                    {
-                        "facility": "Daily Round creates are only allowed in home facility"
-                    }
-                )
-
         # Authorisation Checks End
 
         with transaction.atomic():
-            consultation = get_object_or_404(
-                get_consultation_queryset(self.context["request"].user).filter(
-                    id=validated_data["consultation"].id
-                )
-            )
             if (
                 validated_data.get("rounds_type")
                 == DailyRound.RoundsType.TELEMEDICINE.value
@@ -307,6 +296,7 @@ class DailyRoundSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs):
         validated = super().validate(attrs)
+        validated["consultation"] = self.context["consultation"]
 
         if validated["consultation"].discharge_date:
             raise ValidationError(

--- a/care/facility/api/viewsets/daily_round.py
+++ b/care/facility/api/viewsets/daily_round.py
@@ -12,7 +12,6 @@ from rest_framework.viewsets import GenericViewSet
 from care.facility.api.serializers.daily_round import DailyRoundSerializer
 from care.facility.api.viewsets.mixins.access import AssetUserAccessMixin
 from care.facility.models.daily_round import DailyRound
-from care.facility.models.patient_consultation import PatientConsultation
 from care.utils.queryset.consultation import get_consultation_queryset
 
 DailyRoundAttributes = [f.name for f in DailyRound._meta.get_fields()]
@@ -57,16 +56,21 @@ class DailyRoundsViewSet(
     PAGE_SIZE = 36  # One Round Per Hour
 
     def get_queryset(self):
-        return self.queryset.filter(
-            consultation__external_id=self.kwargs["consultation_external_id"]
-        ).order_by("-taken_at")
-
-    def get_serializer(self, *args, **kwargs):
-        if "data" in kwargs:
-            kwargs["data"]["consultation"] = PatientConsultation.objects.get(
+        consultation = get_object_or_404(
+            get_consultation_queryset(self.request.user).filter(
                 external_id=self.kwargs["consultation_external_id"]
-            ).id
-        return super().get_serializer(*args, **kwargs)
+            )
+        )
+        return self.queryset.filter(consultation=consultation).order_by("-taken_at")
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context["consultation"] = get_object_or_404(
+            get_consultation_queryset(self.request.user).filter(
+                external_id=self.kwargs["consultation_external_id"]
+            )
+        )
+        return context
 
     @extend_schema(tags=["daily_rounds"])
     @action(methods=["POST"], detail=False)

--- a/care/utils/queryset/consultation.py
+++ b/care/utils/queryset/consultation.py
@@ -8,8 +8,10 @@ from care.utils.cache.cache_allowed_facilities import get_accessible_facilities
 def get_consultation_queryset(user):
     queryset = PatientConsultation.objects.all()
     if user.is_superuser:
-        return queryset
-    if user.user_type >= User.TYPE_VALUE_MAP["StateLabAdmin"]:
+        pass
+    elif hasattr(user, "asset") and user.asset is not None:
+        queryset = queryset.filter(facility=user.asset.current_location.facility_id)
+    elif user.user_type >= User.TYPE_VALUE_MAP["StateLabAdmin"]:
         q_filters = Q(facility__state=user.state)
         q_filters |= Q(patient__facility__state=user.state)
         queryset = queryset.filter(q_filters)

--- a/care/utils/queryset/facility.py
+++ b/care/utils/queryset/facility.py
@@ -7,6 +7,8 @@ def get_facility_queryset(user):
     queryset = Facility.objects.all()
     if user.is_superuser:
         pass
+    elif hasattr(user, "asset") and user.asset is not None:
+        queryset = queryset.filter(id=user.asset.current_location.facility_id)
     elif user.user_type >= User.TYPE_VALUE_MAP["StateLabAdmin"]:
         queryset = queryset.filter(state=user.state)
     elif user.user_type >= User.TYPE_VALUE_MAP["DistrictLabAdmin"]:
@@ -21,6 +23,8 @@ def get_home_facility_queryset(user):
     queryset = Facility.objects.all()
     if user.is_superuser:
         pass
+    elif hasattr(user, "asset") and user.asset is not None:
+        queryset = queryset.filter(id=user.asset.current_location.facility_id)
     elif user.user_type >= User.TYPE_VALUE_MAP["StateLabAdmin"]:
         queryset = queryset.filter(state=user.state)
     elif user.user_type >= User.TYPE_VALUE_MAP["DistrictLabAdmin"]:


### PR DESCRIPTION
This pull request fixes the queryset filters for asset daily rounds. It ensures that the filters are correctly applied to the queryset, allowing asset users to access and filter daily rounds based on their current location.

regression from #1760