### PR TITLE
Fixed N+1 queries issue in /api/v1/bed/

### DIFF
--- a/care/facility/api/serializers/bed.py
+++ b/care/facility/api/serializers/bed.py
@@ -83,8 +83,6 @@ class BedSerializer(ModelSerializer):
         return super().validate(attrs)
 
     def get_is_occupied(self, instance):
-        if hasattr(instance, "_is_occupied"):
-            return instance._is_occupied
         return instance.is_occupied
 
 

--- a/care/facility/api/serializers/bed.py
+++ b/care/facility/api/serializers/bed.py
@@ -4,6 +4,7 @@ from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import (
+    BooleanField,
     CharField,
     DateTimeField,
     IntegerField,
@@ -39,7 +40,7 @@ class BedSerializer(ModelSerializer):
     bed_type = ChoiceField(choices=BedTypeChoices)
 
     location_object = AssetLocationSerializer(source="location", read_only=True)
-    is_occupied = SerializerMethodField()
+    is_occupied = BooleanField(default=False, read_only=True)
 
     location = UUIDField(write_only=True, required=True)
     facility = UUIDField(write_only=True, required=True)
@@ -81,9 +82,6 @@ class BedSerializer(ModelSerializer):
                 {"location": "Field is Required", "facility": "Field is Required"}
             )
         return super().validate(attrs)
-
-    def get_is_occupied(self, instance):
-        return instance.is_occupied
 
 
 class AssetBedSerializer(ModelSerializer):

--- a/care/facility/api/serializers/bed.py
+++ b/care/facility/api/serializers/bed.py
@@ -4,7 +4,6 @@ from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import (
-    BooleanField,
     CharField,
     DateTimeField,
     IntegerField,
@@ -40,7 +39,7 @@ class BedSerializer(ModelSerializer):
     bed_type = ChoiceField(choices=BedTypeChoices)
 
     location_object = AssetLocationSerializer(source="location", read_only=True)
-    is_occupied = BooleanField(default=False, read_only=True)
+    is_occupied = SerializerMethodField()
 
     location = UUIDField(write_only=True, required=True)
     facility = UUIDField(write_only=True, required=True)
@@ -82,6 +81,11 @@ class BedSerializer(ModelSerializer):
                 {"location": "Field is Required", "facility": "Field is Required"}
             )
         return super().validate(attrs)
+
+    def get_is_occupied(self, instance):
+        if hasattr(instance, "_is_occupied"):
+            return instance._is_occupied
+        return instance.is_occupied
 
 
 class AssetBedSerializer(ModelSerializer):

--- a/care/facility/api/viewsets/bed.py
+++ b/care/facility/api/viewsets/bed.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import IntegrityError, transaction
-from django.db.models import OuterRef, Subquery
+from django.db.models import Exists, OuterRef, Subquery
 from django_filters import rest_framework as filters
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import filters as drf_filters
@@ -50,7 +50,7 @@ class BedViewSet(
 ):
     queryset = (
         Bed.objects.all()
-        .select_related("facility", "location")
+        .select_related("facility", "location", "location__facility")
         .order_by("-created_date")
     )
     serializer_class = BedSerializer
@@ -63,6 +63,16 @@ class BedViewSet(
     def get_queryset(self):
         user = self.request.user
         queryset = self.queryset
+
+        if self.action == "list":
+            queryset = queryset.annotate(
+                _is_occupied=Exists(
+                    ConsultationBed.objects.filter(
+                        bed__id=OuterRef("id"), end_date__isnull=True
+                    )
+                )
+            )
+
         if user.is_superuser:
             pass
         elif user.user_type >= User.TYPE_VALUE_MAP["StateLabAdmin"]:

--- a/care/facility/api/viewsets/bed.py
+++ b/care/facility/api/viewsets/bed.py
@@ -66,7 +66,7 @@ class BedViewSet(
 
         if self.action == "list":
             queryset = queryset.annotate(
-                _is_occupied=Exists(
+                is_occupied=Exists(
                     ConsultationBed.objects.filter(
                         bed__id=OuterRef("id"), end_date__isnull=True
                     )

--- a/care/facility/api/viewsets/bed.py
+++ b/care/facility/api/viewsets/bed.py
@@ -64,14 +64,13 @@ class BedViewSet(
         user = self.request.user
         queryset = self.queryset
 
-        if self.action == "list":
-            queryset = queryset.annotate(
-                is_occupied=Exists(
-                    ConsultationBed.objects.filter(
-                        bed__id=OuterRef("id"), end_date__isnull=True
-                    )
+        queryset = queryset.annotate(
+            is_occupied=Exists(
+                ConsultationBed.objects.filter(
+                    bed__id=OuterRef("id"), end_date__isnull=True
                 )
             )
+        )
 
         if user.is_superuser:
             pass

--- a/care/facility/models/bed.py
+++ b/care/facility/models/bed.py
@@ -40,10 +40,6 @@ class Bed(BaseModel):
             )
         ]
 
-    @property
-    def is_occupied(self) -> bool:
-        return ConsultationBed.objects.filter(bed=self, end_date__isnull=True).exists()
-
     def __str__(self):
         return self.name
 

--- a/care/facility/tests/test_bed_api.py
+++ b/care/facility/tests/test_bed_api.py
@@ -1,0 +1,37 @@
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from care.facility.models import Bed
+from care.utils.tests.test_utils import TestUtils
+
+
+class BedViewSetTestCase(TestUtils, APITestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.state = cls.create_state()
+        cls.district = cls.create_district(cls.state)
+        cls.local_body = cls.create_local_body(cls.district)
+        cls.super_user = cls.create_super_user("su", cls.district)
+        cls.facility = cls.create_facility(cls.super_user, cls.district, cls.local_body)
+        cls.asset_location = cls.create_asset_location(cls.facility)
+        cls.user = cls.create_user("staff", cls.district, home_facility=cls.facility)
+        cls.patient = cls.create_patient(
+            cls.district, cls.facility, local_body=cls.local_body
+        )
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.bed1 = Bed.objects.create(
+            name="bed1", location=self.asset_location, facility=self.facility
+        )
+        self.bed2 = Bed.objects.create(
+            name="bed2", location=self.asset_location, facility=self.facility
+        )
+        self.bed3 = Bed.objects.create(
+            name="bed3", location=self.asset_location, facility=self.facility
+        )
+
+    def test_list_beds(self):
+        with self.assertNumQueries(5):
+            response = self.client.get("/api/v1/bed/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/care/facility/tests/test_bed_api.py
+++ b/care/facility/tests/test_bed_api.py
@@ -32,6 +32,7 @@ class BedViewSetTestCase(TestUtils, APITestCase):
         )
 
     def test_list_beds(self):
+        # includes 3 queries for auth and 1 for pagination count
         with self.assertNumQueries(5):
             response = self.client.get("/api/v1/bed/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
## Proposed Changes

- **is_occupied** is the property defined in the **Bed Model**, which was contributing to N + 1 queries issue, and I have annotated the attribute **_is_occupied** in the queryset, which basically corresponds to the same value as the **is_occupied property** in Bed Model. I have handled the various attribute cases, in **BedSerializer**, by defining **is_occupied** field as **SerializerMethodField**, hence there will be no change in API response.

- Have added **location__facility** in the select_related field, as this was also contributing to the N + 1 queries issue.

### Associated Issue

- Solves #1338


## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
