### PR TITLE
Fixed N+1 queries issue in /api/v1/consultationbed/

### DIFF
--- a/care/facility/api/serializers/bed.py
+++ b/care/facility/api/serializers/bed.py
@@ -4,7 +4,6 @@ from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import (
-    BooleanField,
     CharField,
     DateTimeField,
     IntegerField,
@@ -40,7 +39,7 @@ class BedSerializer(ModelSerializer):
     bed_type = ChoiceField(choices=BedTypeChoices)
 
     location_object = AssetLocationSerializer(source="location", read_only=True)
-    is_occupied = BooleanField(default=False, read_only=True)
+    is_occupied = SerializerMethodField()
 
     location = UUIDField(write_only=True, required=True)
     facility = UUIDField(write_only=True, required=True)
@@ -54,6 +53,11 @@ class BedSerializer(ModelSerializer):
         if value > 100:
             raise ValidationError("Cannot create more than 100 beds at once.")
         return value
+
+    def get_is_occupied(self, instance):
+        if hasattr(instance, "_is_occupied"):
+            return instance._is_occupied
+        return instance.is_occupied
 
     class Meta:
         model = Bed
@@ -348,3 +352,11 @@ class ConsultationBedSerializer(ModelSerializer):
         validated_data.pop("assets", None)
 
         return super().update(instance, validated_data)
+
+    def to_representation(self, instance: ConsultationBed):
+        if hasattr(instance, "bed"):
+            if instance.end_date is None:
+                instance.bed._is_occupied = True
+            else:
+                instance.bed._is_occupied = False
+        return super().to_representation(instance)


### PR DESCRIPTION
## Proposed Changes

- The related fields of **Bed** like **"bed__facility", "bed__location", "bed__location__facility"** were causing the N + 1 queries issue, hence added them in select_related.

- The related fields of prefetched_model **asset** was also causing the N + 1 queries issue, hence added the related fields of it in select_related, while using **Prefetch() object**.

- To solve the N + 1 query issue related to **is_occupied** property of **Bed Model**, I have made necessary changes in 
**PatientConsultationSerializer**, to set the **_is_occupied** property of Bed instance, whose value is equal to the **is_occupied** property of **Bed Model**.

### Associated Issue

- Fixes #1339 

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
