### PR TITLE
Fix facility delete method

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
   },
   "[python]": {
     "editor.codeActionsOnSave": {
-      "source.organizeImports": true
+      "source.organizeImports": "explicit"
     },
     "editor.formatOnSave": true
   },

--- a/care/facility/api/viewsets/facility.py
+++ b/care/facility/api/viewsets/facility.py
@@ -128,8 +128,6 @@ class FacilityViewSet(
         self.perform_destroy(instance)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
-    # return Response({"permission": "denied"}, status=status.HTTP_403_FORBIDDEN)
-
     def list(self, request, *args, **kwargs):
         if settings.CSV_REQUEST_PARAMETER in request.GET:
             mapping = Facility.CSV_MAPPING.copy()

--- a/care/facility/api/viewsets/facility.py
+++ b/care/facility/api/viewsets/facility.py
@@ -20,8 +20,8 @@ from care.facility.models import (
     FacilityCapacity,
     FacilityPatientStatsHistory,
     HospitalDoctors,
-    PatientRegistration,
 )
+from care.facility.models.facility import FacilityUser
 from care.users.models import User
 
 
@@ -111,20 +111,24 @@ class FacilityViewSet(
             return FacilitySerializer
 
     def destroy(self, request, *args, **kwargs):
-        if (
-            request.user.is_superuser
-            or request.user.user_type >= User.TYPE_VALUE_MAP["DistrictLabAdmin"]
-        ):
-            if not PatientRegistration.objects.filter(
-                facility=self.get_object(), is_active=True
-            ).exists():
-                return super().destroy(request, *args, **kwargs)
-            else:
-                return Response(
-                    {"facility": "cannot delete facility with active patients"},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-        return Response({"permission": "denied"}, status=status.HTTP_403_FORBIDDEN)
+        instance = self.get_object()
+        if instance.patientregistration_set.filter(is_active=True).exists():
+            return Response(
+                {
+                    "facility": (
+                        "You cannot delete a facility with Live patients. "
+                        "Discharge all patients and try again"
+                    )
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        FacilityUser.objects.filter(facility=instance).delete()
+        User.objects.filter(home_facility=instance).update(home_facility=None)
+        self.perform_destroy(instance)
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    # return Response({"permission": "denied"}, status=status.HTTP_403_FORBIDDEN)
 
     def list(self, request, *args, **kwargs):
         if settings.CSV_REQUEST_PARAMETER in request.GET:

--- a/care/facility/tests/test_facility_api.py
+++ b/care/facility/tests/test_facility_api.py
@@ -48,3 +48,46 @@ class FacilityTests(TestUtils, APITestCase):
         sample_data = {}
         create_response = self.client.post("/api/v1/facility/", sample_data)
         self.assertIs(create_response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_delete(self):
+        state_admin = self.create_user("state_admin", self.district, user_type=40)
+        district2 = self.create_district(self.state)
+        facility = self.create_facility(self.super_user, district2, self.local_body)
+        self.client.force_authenticate(user=state_admin)
+        response = self.client.delete(f"/api/v1/facility/{facility.external_id}/")
+        self.assertIs(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        dist_admin = self.create_user("dist_admin", self.district, user_type=30)
+        facility = self.create_facility(self.super_user, self.district, self.local_body)
+        self.client.force_authenticate(user=dist_admin)
+        response = self.client.delete(f"/api/v1/facility/{facility.external_id}/")
+        self.assertIs(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_delete_no_permission(self):
+        facility = self.create_facility(self.super_user, self.district, self.local_body)
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.delete(f"/api/v1/facility/{facility.external_id}/")
+        self.assertIs(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        state2 = self.create_state()
+        district2 = self.create_district(state2)
+
+        state_admin = self.create_user("state_admin", district2, user_type=40)
+        self.client.force_authenticate(user=state_admin)
+        response = self.client.delete(f"/api/v1/facility/{facility.external_id}/")
+        self.assertIs(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        dist_admin = self.create_user("dist_admin", district2, user_type=30)
+        self.client.force_authenticate(user=dist_admin)
+        response = self.client.delete(f"/api/v1/facility/{facility.external_id}/")
+        self.assertIs(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_delete_with_active_patients(self):
+        facility = self.create_facility(self.super_user, self.district, self.local_body)
+        self.create_patient(self.district, facility)
+
+        state_admin = self.create_user("state_admin", self.district, user_type=40)
+        self.client.force_authenticate(user=state_admin)
+        response = self.client.delete(f"/api/v1/facility/{facility.external_id}/")
+        self.assertIs(response.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
This pull request fixes the facility delete permission and fixes the method by ensuring that a facility cannot be deleted if it has active patients. It also deletes related FacilityUser objects and updates the home_facility field of User objects.