### PR TITLE
added validate on ResetPasswordUserSerializer for username 

### DIFF
--- a/care/users/reset_password_views.py
+++ b/care/users/reset_password_views.py
@@ -41,6 +41,16 @@ HTTP_IP_ADDRESS_HEADER = getattr(
 class ResetPasswordUserSerializer(serializers.Serializer):
     username = serializers.CharField()
 
+    def validate(self, attrs):
+        username = attrs.get('username')
+
+        try:
+            user = User.objects.get(username=username)
+        except User.DoesNotExist:
+            raise serializers.ValidationError("User with this username does not exist.")
+
+        return attrs
+
 
 class ResetPasswordCheck(GenericAPIView):
     """


### PR DESCRIPTION

# Before Update
While we were triggering `http://127.0.0.1:9000/api/v1/password_reset/` for password reset it was returning a status `OK` without verifying if the `username` exists in `User` table or not.
![Screenshot from 2024-02-28 21-50-46](https://github.com/coronasafe/care/assets/72642534/94a22838-8ef0-403b-99ed-60b94900bb8e)

# FIX
* I updated the `ResetPasswordUserSerializer` where it validates whether the username exists or not.

# After fix

![Screenshot from 2024-02-28 21-57-34](https://github.com/coronasafe/care/assets/72642534/ddf3c359-c1b3-464c-bc93-88ffd905f1a9)
