### PR TITLE
Fix bed assignment validation for admission

### DIFF
--- a/care/facility/api/serializers/daily_round.py
+++ b/care/facility/api/serializers/daily_round.py
@@ -179,8 +179,11 @@ class DailyRoundSerializer(serializers.ModelSerializer):
             )
         # Authorisation Checks End
 
-        # Patient needs to have a bed assigned
-        if not consultation.current_bed:
+        # Patient needs to have a bed assigned for admission
+        if (
+            not consultation.current_bed
+            and consultation.suggestion == SuggestionChoices.A
+        ):
             raise ValidationError(
                 {
                     "bed": "Patient does not have a bed assigned. Please assign a bed first"

--- a/care/facility/tests/test_patient_consultation_api.py
+++ b/care/facility/tests/test_patient_consultation_api.py
@@ -39,7 +39,9 @@ class TestPatientConsultation(TestUtils, APITestCase):
             "examination_details": "examination_details",
             "history_of_present_illness": "history_of_present_illness",
             "treatment_plan": "treatment_plan",
-            "suggestion": PatientConsultation.SUGGESTION_CHOICES[0][0],
+            "suggestion": PatientConsultation.SUGGESTION_CHOICES[0][
+                0
+            ],  # HOME ISOLATION
             "treating_physician": self.doctor.id,
             "create_diagnoses": [
                 {

--- a/care/facility/tests/test_patient_daily_rounds_api.py
+++ b/care/facility/tests/test_patient_daily_rounds_api.py
@@ -23,12 +23,12 @@ class TestDailyRoundApi(TestUtils, APITestCase):
         cls.admission_consultation_no_bed = cls.create_consultation(
             facility=cls.facility,
             patient=cls.patient,
-            suggestion=PatientConsultation.SUGGESTION_CHOICES[1][0],
+            suggestion=PatientConsultation.SUGGESTION_CHOICES[1][0],  # ADMISSION
         )
         cls.domiciliary_consultation_no_bed = cls.create_consultation(
             facility=cls.facility,
             patient=cls.patient,
-            suggestion=PatientConsultation.SUGGESTION_CHOICES[4][0],
+            suggestion=PatientConsultation.SUGGESTION_CHOICES[4][0],  # DOMICILIARY CARE
         )
         cls.consultation_with_bed = cls.create_consultation(
             facility=cls.facility, patient=cls.patient

--- a/care/facility/tests/test_patient_daily_rounds_api.py
+++ b/care/facility/tests/test_patient_daily_rounds_api.py
@@ -4,6 +4,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from care.facility.models import PatientRegistration
+from care.facility.models.patient_consultation import PatientConsultation
 from care.utils.tests.test_utils import TestUtils
 
 
@@ -19,8 +20,15 @@ class TestDailyRoundApi(TestUtils, APITestCase):
         cls.patient = cls.create_patient(district=cls.district, facility=cls.facility)
         cls.asset_location = cls.create_asset_location(cls.facility)
         cls.bed = cls.create_bed(facility=cls.facility, location=cls.asset_location)
-        cls.consultation_without_bed = cls.create_consultation(
-            facility=cls.facility, patient=cls.patient
+        cls.admission_consultation_no_bed = cls.create_consultation(
+            facility=cls.facility,
+            patient=cls.patient,
+            suggestion=PatientConsultation.SUGGESTION_CHOICES[1][0],
+        )
+        cls.domiciliary_consultation_no_bed = cls.create_consultation(
+            facility=cls.facility,
+            patient=cls.patient,
+            suggestion=PatientConsultation.SUGGESTION_CHOICES[4][0],
         )
         cls.consultation_with_bed = cls.create_consultation(
             facility=cls.facility, patient=cls.patient
@@ -65,11 +73,11 @@ class TestDailyRoundApi(TestUtils, APITestCase):
             patient.action, PatientRegistration.ActionEnum.DISCHARGE_RECOMMENDED.value
         )
 
-    def test_log_update_without_bed(
+    def test_log_update_without_bed_for_admission(
         self,
     ):
         response = self.client.post(
-            f"/api/v1/consultation/{self.consultation_without_bed.external_id}/daily_rounds/",
+            f"/api/v1/consultation/{self.admission_consultation_no_bed.external_id}/daily_rounds/",
             data=self.log_update,
             format="json",
         )
@@ -78,3 +86,13 @@ class TestDailyRoundApi(TestUtils, APITestCase):
             response.data["bed"],
             "Patient does not have a bed assigned. Please assign a bed first",
         )
+
+    def test_log_update_without_bed_for_domiciliary(
+        self,
+    ):
+        response = self.client.post(
+            f"/api/v1/consultation/{self.domiciliary_consultation_no_bed.external_id}/daily_rounds/",
+            data=self.log_update,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/care/utils/tests/test_utils.py
+++ b/care/utils/tests/test_utils.py
@@ -312,7 +312,9 @@ class TestUtils:
             "examination_details": "examination_details",
             "history_of_present_illness": "history_of_present_illness",
             "treatment_plan": "treatment_plan",
-            "suggestion": PatientConsultation.SUGGESTION_CHOICES[0][0],
+            "suggestion": PatientConsultation.SUGGESTION_CHOICES[0][
+                0
+            ],  # HOME ISOLATION
             "referred_to": None,
             "encounter_date": make_aware(datetime(2020, 4, 7, 15, 30)),
             "discharge_date": None,


### PR DESCRIPTION
Fixes https://github.com/coronasafe/care_fe/issues/7340

This pull request fixes the bed assignment validation for admission. Previously, if a patient did not have a bed assigned and the suggestion was 'A', an error would occur. This PR ensures that the error is raised only when the patient does not have a bed assigned and the suggestion is 'A'.