### PR TITLE
ExternalIDSerializerField to be UUID Field instead of Field

### DIFF
--- a/care/utils/serializer/external_id_field.py
+++ b/care/utils/serializer/external_id_field.py
@@ -13,7 +13,7 @@ class UUIDValidator(object):
             raise serializers.ValidationError("invalid uuid")
 
 
-class ExternalIdSerializerField(serializers.Field):
+class ExternalIdSerializerField(serializers.UUIDField):
     def __init__(self, queryset=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.queryset = queryset


### PR DESCRIPTION
## Proposed Changes

- ExternalIDSerializerField to be UUID Field instead of Field

### Associated Issue

- Fixes #1957

### Before
<img width="884" alt="image" src="https://github.com/coronasafe/care/assets/25143503/0b846af9-25a8-4bde-885c-99237bda9fb5">

### After
<img width="1250" alt="image" src="https://github.com/coronasafe/care/assets/25143503/b9ae760e-73bc-4778-a132-874fda42e450">


## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
