### PR TITLE
[BUG] fix Location/ Bed Management issue ( District Lab Admin Account)

### DIFF
--- a/care/facility/models/mixins/permissions/facility.py
+++ b/care/facility/models/mixins/permissions/facility.py
@@ -71,6 +71,11 @@ class FacilityPermissionMixin(BasePermissionMixin):
             super().has_object_read_permission(request)
             or self.users.contains(request.user)
             or (
+                hasattr(self, "state")
+                and request.user.user_type >= User.TYPE_VALUE_MAP["StateLabAdmin"]
+                and request.user.state == self.state
+            )
+            or (
                 hasattr(self, "district")
                 and request.user.user_type >= User.TYPE_VALUE_MAP["DistrictLabAdmin"]
                 and request.user.district == self.district
@@ -130,7 +135,16 @@ class FacilityRelatedPermissionMixin(BasePermissionMixin):
         return (
             super().has_object_read_permission(request)
             or request.user.is_superuser
-            or request.user.user_type >= User.TYPE_VALUE_MAP["DistrictLabAdmin"]
+            or (
+                hasattr(self.facility, "state")
+                and request.user.user_type >= User.TYPE_VALUE_MAP["StateLabAdmin"]
+                and request.user.state == self.facility.state
+            )
+            or (
+                hasattr(self.facility, "district")
+                and request.user.user_type >= User.TYPE_VALUE_MAP["DistrictLabAdmin"]
+                and request.user.district == self.facility.district
+            )
             or request.user in self.facility.users.all()
         )
 

--- a/care/facility/models/mixins/permissions/facility.py
+++ b/care/facility/models/mixins/permissions/facility.py
@@ -67,8 +67,14 @@ class FacilityPermissionMixin(BasePermissionMixin):
         )
 
     def has_object_read_permission(self, request):
-        return super().has_object_read_permission(request) or self.users.contains(
-            request.user
+        return (
+            super().has_object_read_permission(request)
+            or self.users.contains(request.user)
+            or (
+                hasattr(self, "district")
+                and request.user.user_type >= User.TYPE_VALUE_MAP["DistrictLabAdmin"]
+                and request.user.district == self.district
+            )
         )
 
     def has_object_write_permission(self, request):
@@ -124,6 +130,7 @@ class FacilityRelatedPermissionMixin(BasePermissionMixin):
         return (
             super().has_object_read_permission(request)
             or request.user.is_superuser
+            or request.user.user_type >= User.TYPE_VALUE_MAP["DistrictLabAdmin"]
             or request.user in self.facility.users.all()
         )
 

--- a/care/facility/tests/test_asset_location_api.py
+++ b/care/facility/tests/test_asset_location_api.py
@@ -112,3 +112,28 @@ class AssetLocationViewSetTestCase(TestUtils, APITestCase):
             f"/api/v1/facility/{self.facility.external_id}/asset_location/{self.asset_location.external_id}/",
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_user_access_to_asset_location_on_user_type(self):
+        # when a user is a state_lab_admin or a district_lab_admin
+        state_lab_admin = self.create_user(
+            "state_lab_admin", self.district, user_type=35
+        )
+        district_lab_admin = self.create_user(
+            "district_lab_admin", self.district, user_type=25
+        )
+
+        self.client.force_authenticate(user=state_lab_admin)
+
+        # when they try to access a asset_location in their state or district then they
+        # should be able to do so without permission issue
+        response = self.client.get(
+            f"/api/v1/facility/{self.facility.external_id}/asset_location/{self.asset_location_with_linked_bed.external_id}/"
+        )
+
+        self.assertIs(response.status_code, status.HTTP_200_OK)
+
+        self.client.force_authenticate(user=district_lab_admin)
+        response = self.client.get(
+            f"/api/v1/facility/{self.facility.external_id}/asset_location/{self.asset_location_with_linked_bed.external_id}/"
+        )
+        self.assertIs(response.status_code, status.HTTP_200_OK)

--- a/care/facility/tests/test_facilityuser_api.py
+++ b/care/facility/tests/test_facilityuser_api.py
@@ -45,3 +45,23 @@ class FacilityUserTest(TestUtils, APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data["results"]), 2)
+
+    def test_user_access_to_facility_on_user_type(self):
+        # when a user is a state_lab_admin or a district_lab_admin
+        state_lab_admin = self.create_user(
+            "state_lab_admin", self.district, user_type=35
+        )
+        district_lab_admin = self.create_user(
+            "district_lab_admin", self.district, user_type=25
+        )
+
+        self.client.force_authenticate(user=state_lab_admin)
+
+        # when they try to access a facility in their state or district then they
+        # should be able to do so without permission issue
+        response = self.client.get(f"/api/v1/facility/{self.facility.external_id}/")
+        self.assertIs(response.status_code, status.HTTP_200_OK)
+
+        self.client.force_authenticate(user=district_lab_admin)
+        response = self.client.get(f"/api/v1/facility/{self.facility.external_id}/")
+        self.assertIs(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
## Proposed Changes

- Brief of changes made.
   the issue here was mainly permission related 
   District Lab Admin had read access for facility but not object read access (refer FacilityPermissionMixin)
   same for asset_location while actually managing beds it uses (refer FacilityRelatedPermissionMixin) 

### Associated Issue

- Link to issue here : [issue](https://github.com/coronasafe/care_fe/issues/7102)


## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
