### PR TITLE
fix N+1 queries in /api/v1/resource/

### DIFF
--- a/care/facility/api/serializers/facility.py
+++ b/care/facility/api/serializers/facility.py
@@ -49,10 +49,7 @@ class FacilityBasicInfoSerializer(serializers.ModelSerializer):
     read_cover_image_url = serializers.CharField(read_only=True)
     features = serializers.MultipleChoiceField(choices=FEATURE_CHOICES)
     patient_count = serializers.SerializerMethodField()
-    bed_count = serializers.SerializerMethodField()
 
-    def get_bed_count(self, facility):
-        return Bed.objects.filter(facility=facility).count()
 
     def get_patient_count(self, facility):
         return PatientRegistration.objects.filter(
@@ -81,7 +78,6 @@ class FacilityBasicInfoSerializer(serializers.ModelSerializer):
             "read_cover_image_url",
             "features",
             "patient_count",
-            "bed_count",
         )
 
 

--- a/care/facility/api/serializers/resources.py
+++ b/care/facility/api/serializers/resources.py
@@ -49,6 +49,10 @@ class ResourceRequestSerializer(serializers.ModelSerializer):
 
     status = ChoiceField(choices=RESOURCE_STATUS_CHOICES)
 
+    origin_facility_bed_count = serializers.IntegerField(read_only=True)
+    approving_facility_bed_count = serializers.IntegerField(read_only=True)
+    assigned_facility_bed_count = serializers.IntegerField(read_only=True)
+
     origin_facility_object = FacilityBasicInfoSerializer(
         source="origin_facility", read_only=True, required=False
     )
@@ -133,6 +137,19 @@ class ResourceRequestSerializer(serializers.ModelSerializer):
         validated_data["last_edited_by"] = self.context["request"].user
 
         return super().create(validated_data)
+
+    def to_representation(self, instance):
+        data = super(ResourceRequestSerializer, self).to_representation(instance)
+
+        # attach bed_count
+        data["origin_facility_object"]["bed_count"] = data["origin_facility_bed_count"]
+        data["approving_facility_object"]["bed_count"] = data[
+            "approving_facility_bed_count"
+        ]
+        data["assigned_facility_object"]["bed_count"] = data[
+            "assigned_facility_bed_count"
+        ]
+        return data
 
     class Meta:
         model = ResourceRequest

--- a/care/facility/api/viewsets/resources.py
+++ b/care/facility/api/viewsets/resources.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.db.models import Count
 from django.db.models.query_utils import Q
 from django_filters import rest_framework as filters
 from djqscsv import render_to_csv_response
@@ -89,25 +90,33 @@ class ResourceRequestViewSet(
 ):
     serializer_class = ResourceRequestSerializer
     lookup_field = "external_id"
-    queryset = ResourceRequest.objects.all().select_related(
-        "origin_facility",
-        "origin_facility__ward",
-        "origin_facility__local_body",
-        "origin_facility__district",
-        "origin_facility__state",
-        "approving_facility",
-        "approving_facility__ward",
-        "approving_facility__local_body",
-        "approving_facility__district",
-        "approving_facility__state",
-        "assigned_facility",
-        "assigned_facility__ward",
-        "assigned_facility__local_body",
-        "assigned_facility__district",
-        "assigned_facility__state",
-        "assigned_to",
-        "created_by",
-        "last_edited_by",
+    queryset = (
+        ResourceRequest.objects.all()
+        .select_related(
+            "origin_facility",
+            "origin_facility__ward",
+            "origin_facility__local_body",
+            "origin_facility__district",
+            "origin_facility__state",
+            "approving_facility",
+            "approving_facility__ward",
+            "approving_facility__local_body",
+            "approving_facility__district",
+            "approving_facility__state",
+            "assigned_facility",
+            "assigned_facility__ward",
+            "assigned_facility__local_body",
+            "assigned_facility__district",
+            "assigned_facility__state",
+            "assigned_to",
+            "created_by",
+            "last_edited_by",
+        )
+        .annotate(
+            origin_facility_bed_count=Count("origin_facility__bed"),
+            approving_facility_bed_count=Count("approving_facility__bed"),
+            assigned_facility_bed_count=Count("assigned_facility__bed"),
+        )
     )
     ordering_fields = [
         "id",


### PR DESCRIPTION
## Proposed Changes

Fix the N+1 queries in the resources/ API 

### Associated Issue

#1336 


## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
