### PR TITLE
Switch to using year of birth for patient transfer confirmation

### DIFF
--- a/care/facility/api/serializers/patient.py
+++ b/care/facility/api/serializers/patient.py
@@ -452,11 +452,11 @@ class PatientTransferSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = PatientRegistration
-        fields = ("facility", "date_of_birth", "patient", "facility_object")
+        fields = ("facility", "year_of_birth", "patient", "facility_object")
 
-    def validate_date_of_birth(self, value):
-        if self.instance and self.instance.date_of_birth != value:
-            raise serializers.ValidationError("Date of birth does not match")
+    def validate_year_of_birth(self, value):
+        if self.instance and self.instance.year_of_birth != value:
+            raise serializers.ValidationError("Year of birth does not match")
         return value
 
     def create(self, validated_data):

--- a/care/facility/tests/test_patient_api.py
+++ b/care/facility/tests/test_patient_api.py
@@ -448,7 +448,7 @@ class PatientTransferTestCase(TestUtils, APITestCase):
         response = self.client.post(
             f"/api/v1/patient/{self.patient.external_id}/transfer/",
             {
-                "date_of_birth": "1992-04-01",
+                "year_of_birth": 1992,
                 "facility": self.destination_facility.external_id,
             },
         )
@@ -477,7 +477,7 @@ class PatientTransferTestCase(TestUtils, APITestCase):
         response = self.client.post(
             f"/api/v1/patient/{self.patient.external_id}/transfer/",
             {
-                "date_of_birth": "1992-04-01",
+                "year_of_birth": 1992,
                 "facility": self.facility.external_id,
             },
         )
@@ -496,7 +496,7 @@ class PatientTransferTestCase(TestUtils, APITestCase):
         response = self.client.post(
             f"/api/v1/patient/{self.patient.external_id}/transfer/",
             {
-                "date_of_birth": "1992-04-01",
+                "year_of_birth": 1992,
                 "facility": self.destination_facility.external_id,
             },
         )


### PR DESCRIPTION
## Proposed Changes

- Switch to using year of birth for patient transfer confirmation

### Associated Issue

- Required by: https://github.com/coronasafe/care_fe/issues/7574
- FE: https://github.com/coronasafe/care_fe/pull/7575

## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
