### PR TITLE
Handle missing instance.resolved_middleware in asset_updates

### DIFF
--- a/care/facility/signals/asset_updates.py
+++ b/care/facility/signals/asset_updates.py
@@ -26,7 +26,11 @@ def save_asset_fields_before_update(
 def update_asset_config_on_middleware(
     sender, instance, created, raw, using, update_fields, **kwargs
 ):
-    if raw or (update_fields and "meta" not in update_fields):
+    if (
+        raw
+        or (update_fields and "meta" not in update_fields)
+        or (instance.resolved_middleware is None)
+    ):
         return
 
     new_hostname = instance.resolved_middleware.get("hostname")


### PR DESCRIPTION
Fixes: https://github.com/coronasafe/care/issues/2083

This pull request fixes a bug in the asset_updates.py file where the code was not handling the case when the instance.resolved_middleware is None. The fix ensures that the code properly checks for this condition before proceeding.
It returns none when the middleware_hostname is null in all 3 places