### PR TITLE
Fix handling of missing resolved_middleware in asset_updates.py

### DIFF
--- a/care/facility/signals/asset_updates.py
+++ b/care/facility/signals/asset_updates.py
@@ -13,7 +13,7 @@ from care.facility.tasks.push_asset_config import (
 def save_asset_fields_before_update(
     sender, instance, raw, using, update_fields, **kwargs
 ):
-    if raw:
+    if raw or instance.resolved_middleware is None:
         return
 
     if instance.pk:
@@ -45,5 +45,7 @@ def update_asset_config_on_middleware(
 
 @receiver(post_delete, sender=Asset)
 def delete_asset_on_middleware(sender, instance, using, **kwargs):
+    if instance.resolved_middleware is None:
+        return
     hostname = instance.resolved_middleware.get("hostname")
     delete_asset_from_middleware_task.s(hostname, instance.external_id)


### PR DESCRIPTION
Fixes https://github.com/coronasafe/care/issues/2088

This pull request fixes the handling of missing resolved_middleware in the asset_updates.py file. Previously, if the resolved_middleware was None, the code would still execute, leading to potential errors. This PR adds a check to skip the execution if the resolved_middleware is None.