### PR TITLE
fixes review interval not being updated for "no review"

### DIFF
--- a/care/facility/api/serializers/daily_round.py
+++ b/care/facility/api/serializers/daily_round.py
@@ -268,8 +268,8 @@ class DailyRoundSerializer(serializers.ModelSerializer):
                     review_interval = validated_data.pop(
                         "consultation__review_interval"
                     )
+                    validated_data["consultation"].review_interval = review_interval
                     if review_interval >= 0:
-                        validated_data["consultation"].review_interval = review_interval
                         patient.review_time = localtime(now()) + timedelta(
                             minutes=review_interval
                         )


### PR DESCRIPTION
## Proposed Changes

- Fixes a case where if `review_interval` was `-1` (no review), it did not update in the related consultation model.

### Associated Issue

- Fixes https://github.com/coronasafe/care_fe/issues/7789

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
