### PR TITLE
Only log the error message in uptime monitor tasks

### DIFF
--- a/care/facility/tasks/asset_monitor.py
+++ b/care/facility/tasks/asset_monitor.py
@@ -69,8 +69,8 @@ def check_asset_status():
                     )
                 else:
                     result = asset_class.api_get(asset_class.get_url("devices/status"))
-            except Exception:
-                logger.warn(f"Middleware {resolved_middleware} is down", exc_info=True)
+            except Exception as e:
+                logger.warn(f"Middleware {resolved_middleware} is down", e)
 
             # If no status is returned, setting default status as down
             if not result or "error" in result:
@@ -116,5 +116,5 @@ def check_asset_status():
                         status=new_status.value,
                         timestamp=status_record.get("time", timezone.now()),
                     )
-        except Exception:
-            logger.error("Error in Asset Status Check", exc_info=True)
+        except Exception as e:
+            logger.error("Error in Asset Status Check", e)

--- a/care/facility/tasks/location_monitor.py
+++ b/care/facility/tasks/location_monitor.py
@@ -53,8 +53,8 @@ def check_location_status():
                 if result:
                     new_status = AvailabilityStatus.OPERATIONAL
 
-            except Exception:
-                logger.warn(f"Middleware {resolved_middleware} is down", exc_info=True)
+            except Exception as e:
+                logger.warn(f"Middleware {resolved_middleware} is down", e)
 
             # Fetching the last record of the location
             last_record = (
@@ -75,5 +75,5 @@ def check_location_status():
                     timestamp=timezone.now(),
                 )
             logger.info(f"Location {location.external_id} status: {new_status.value}")
-        except Exception:
-            logger.error("Error in Location Status Check", exc_info=True)
+        except Exception as e:
+            logger.error("Error in Location Status Check", e)


### PR DESCRIPTION
## Proposed Changes

- printing the whole exc_info was creating a lot of unnessary logs, instead we could just print the error message


## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
