### PR TITLE
bump docker healthcheck retries

### DIFF
--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -27,7 +27,7 @@ HEALTHCHECK \
   --interval=10s \
   --timeout=5s \
   --start-period=10s \
-  --retries=24 \
+  --retries=48 \
   CMD ["/app/scripts/healthcheck.sh"]
 
 WORKDIR /app

--- a/docker/prod.Dockerfile
+++ b/docker/prod.Dockerfile
@@ -57,7 +57,7 @@ HEALTHCHECK \
   --interval=30s \
   --timeout=5s \
   --start-period=10s \
-  --retries=6 \
+  --retries=12 \
   CMD ["/app/healthcheck.sh"]
 
 COPY . ${APP_HOME}


### PR DESCRIPTION
## Proposed Changes

- the migrations are taking longer than expected, so bumping the healthcheck  wil resolve the containers getting reported unhealthy

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
