### PR TITLE
fix state admin access to daily rounds

### DIFF
--- a/care/facility/models/daily_round.py
+++ b/care/facility/models/daily_round.py
@@ -589,8 +589,7 @@ class DailyRound(PatientBaseModel):
                 request.user.user_type >= User.TYPE_VALUE_MAP["StateLabAdmin"]
                 and (
                     self.consultation.patient.facility
-                    and request.user.state
-                    == self.consultation.patient.facility.district
+                    and request.user.state == self.consultation.patient.facility.state
                 )
             )
         )

--- a/care/facility/tests/test_patient_daily_rounds_api.py
+++ b/care/facility/tests/test_patient_daily_rounds_api.py
@@ -16,6 +16,12 @@ class TestDailyRoundApi(TestUtils, APITestCase):
         cls.local_body = cls.create_local_body(cls.district)
         cls.super_user = cls.create_super_user("su", cls.district)
         cls.facility = cls.create_facility(cls.super_user, cls.district, cls.local_body)
+        cls.state_admin = cls.create_user(
+            "state_admin", cls.district, home_facility=cls.facility, user_type=40
+        )
+        cls.district_admin = cls.create_user(
+            "district_admin", cls.district, home_facility=cls.facility, user_type=30
+        )
         cls.user = cls.create_user("staff1", cls.district, home_facility=cls.facility)
         cls.patient = cls.create_patient(district=cls.district, facility=cls.facility)
         cls.asset_location = cls.create_asset_location(cls.facility)
@@ -71,6 +77,24 @@ class TestDailyRoundApi(TestUtils, APITestCase):
         self.assertEqual(
             patient.action, PatientRegistration.ActionEnum.DISCHARGE_RECOMMENDED.value
         )
+
+    def test_log_update_access_by_state_admin(self):
+        self.client.force_authenticate(user=self.state_admin)
+        response = self.client.post(
+            f"/api/v1/consultation/{self.consultation_with_bed.external_id}/daily_rounds/",
+            data=self.log_update,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_log_update_access_by_district_admin(self):
+        self.client.force_authenticate(user=self.district_admin)
+        response = self.client.post(
+            f"/api/v1/consultation/{self.consultation_with_bed.external_id}/daily_rounds/",
+            data=self.log_update,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_log_update_without_bed_for_admission(
         self,


### PR DESCRIPTION
## Proposed Changes

- fix dry permission check for state admin on daily rounds

### Associated Issue

- fixes https://github.com/coronasafe/care_fe/issues/7759

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
