### PR TITLE
Fix discharge summary filters

### DIFF
--- a/care/facility/templatetags/filters.py
+++ b/care/facility/templatetags/filters.py
@@ -22,7 +22,8 @@ def suggestion_string(suggestion_code: str):
 
 @register.filter()
 def field_name_to_label(value):
-    return value.replace("_", " ").capitalize()
+    if value:
+        return value.replace("_", " ").capitalize()
 
 
 @register.filter(expects_localtime=True)

--- a/care/templates/reports/patient_discharge_summary_pdf.html
+++ b/care/templates/reports/patient_discharge_summary_pdf.html
@@ -67,7 +67,7 @@
         <span class="text-sm text-gray-500">Address:</span> {{patient.address}}
       </p>
       <p class="flex-grow">
-        <span class="text-sm text-gray-500">Ration Card Category:</span> {{patient.get_ration_card_category_display|field_name_to_label}}
+        <span class="text-sm text-gray-500">Ration Card Category:</span> {{patient.get_ration_card_category_display}}
       </p>
     </div>
   </div>


### PR DESCRIPTION
This pull request fixes the discharge summary filters. The `field_name_to_label` filter now checks if the value is not empty before applying the transformation. Additionally, the `get_ration_card_category_display` filter in the HTML template no longer uses the `field_name_to_label` filter.