### PR TITLE
Fix patient search API

### DIFF
--- a/care/facility/tests/test_patient_api.py
+++ b/care/facility/tests/test_patient_api.py
@@ -527,3 +527,28 @@ class PatientTransferTestCase(TestUtils, APITestCase):
             response.data["Patient"],
             "Patient transfer cannot be completed because the source facility does not permit it",
         )
+
+
+class PatientSearchTestCase(TestUtils, APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.state = cls.create_state()
+        cls.district = cls.create_district(cls.state)
+        cls.local_body = cls.create_local_body(cls.district)
+        cls.super_user = cls.create_super_user("su", cls.district)
+        cls.facility = cls.create_facility(cls.super_user, cls.district, cls.local_body)
+        cls.destination_facility = cls.create_facility(
+            cls.super_user, cls.district, cls.local_body, name="Facility 2"
+        )
+        cls.location = cls.create_asset_location(cls.facility)
+        cls.user = cls.create_user(
+            "doctor1", cls.district, home_facility=cls.facility, user_type=15
+        )
+        cls.patient = cls.create_patient(cls.district, cls.facility)
+
+    def test_patient_search(self):
+        response = self.client.get(
+            "/api/v1/patient/search/", {"phone_number": self.patient.phone_number}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)

--- a/config/api_router.py
+++ b/config/api_router.py
@@ -232,6 +232,7 @@ router.register("bed", BedViewSet, basename="bed")
 router.register("assetbed", AssetBedViewSet, basename="asset-bed")
 router.register("consultationbed", ConsultationBedViewSet, basename="consultation-bed")
 
+router.register("patient/search", PatientSearchViewSet, basename="patient-search")
 router.register("patient", PatientViewSet, basename="patient")
 patient_nested_router = NestedSimpleRouter(router, r"patient", lookup="patient")
 patient_nested_router.register(
@@ -250,8 +251,6 @@ patient_notes_nested_router.register(
     r"edits", PatientNotesEditViewSet, basename="patient-notes-edits"
 )
 patient_nested_router.register(r"abha", AbhaViewSet)
-
-router.register("patient/search", PatientSearchViewSet, basename="patient-search")
 
 router.register(
     "external_result", PatientExternalTestViewSet, basename="patient-external-result"


### PR DESCRIPTION
This pull request fixes the patient search API by registering the `PatientSearchViewSet` before the `PatientViewset` in the router. This allows the API to handle patient search requests properly.