### PR TITLE
ICD11: gracefully return `None` if issues with redis

### DIFF
--- a/care/facility/static_data/icd11.py
+++ b/care/facility/static_data/icd11.py
@@ -3,7 +3,6 @@ from typing import TypedDict
 
 from django.core.paginator import Paginator
 from redis_om import Field, Migrator
-from redis_om.model.model import NotFoundError as RedisModelNotFoundError
 
 from care.facility.models.icd11_diagnosis import ICD11Diagnosis
 from care.utils.static_data.models.base import BaseRedisModel
@@ -61,7 +60,7 @@ def get_icd11_diagnosis_object_by_id(
     try:
         diagnosis = ICD11.get(diagnosis_id)
         return diagnosis.get_representation() if as_dict else diagnosis
-    except RedisModelNotFoundError:
+    except Exception:
         return None
 
 


### PR DESCRIPTION
## Proposed Changes

- ICD11: gracefully return `None` if issues with redis

### Associated Issue

- Front-end: https://github.com/coronasafe/care_fe/pull/7973

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
