### PR TITLE
Exclude ICD11 entries that does not have a `meta_chapter_short` from search instead for not loading in redis table

### DIFF
--- a/care/facility/api/viewsets/icd.py
+++ b/care/facility/api/viewsets/icd.py
@@ -26,7 +26,10 @@ class ICDViewSet(ViewSet):
         except (ValueError, TypeError):
             limit = 20
 
-        query = [ICD11.has_code == 1]
+        query = [
+            ICD11.has_code == 1,
+            ICD11.chapter != None,  # noqa: E711
+        ]
         if q := request.query_params.get("query"):
             query.append(ICD11.vec % query_builder(q))
 

--- a/care/facility/api/viewsets/icd.py
+++ b/care/facility/api/viewsets/icd.py
@@ -28,7 +28,7 @@ class ICDViewSet(ViewSet):
 
         query = [
             ICD11.has_code == 1,
-            ICD11.chapter != None,  # noqa: E711
+            ICD11.chapter != "null",  # noqa: E711
         ]
         if q := request.query_params.get("query"):
             query.append(ICD11.vec % query_builder(q))

--- a/care/facility/static_data/icd11.py
+++ b/care/facility/static_data/icd11.py
@@ -1,5 +1,5 @@
 import re
-from typing import Optional, TypedDict
+from typing import TypedDict
 
 from django.core.paginator import Paginator
 from redis_om import Field, Migrator
@@ -19,7 +19,7 @@ class ICD11Object(TypedDict):
 class ICD11(BaseRedisModel):
     id: int = Field(primary_key=True)
     label: str
-    chapter: Optional[str] = Field(index=True)
+    chapter: str = Field(index=True)
     has_code: int = Field(index=True)
 
     vec: str = Field(index=True, full_text_search=True)
@@ -28,7 +28,7 @@ class ICD11(BaseRedisModel):
         return {
             "id": self.id,
             "label": self.label,
-            "chapter": self.chapter or "",
+            "chapter": self.chapter if self.chapter != "null" else "",
         }
 
 
@@ -44,7 +44,7 @@ def load_icd11_diagnosis():
             ICD11(
                 id=diagnosis[0],
                 label=diagnosis[1],
-                chapter=diagnosis[2],
+                chapter=diagnosis[2] or "null",
                 has_code=1 if re.match(DISEASE_CODE_PATTERN, diagnosis[1]) else 0,
                 vec=diagnosis[1].replace(".", "\\.", 1),
             ).save()


### PR DESCRIPTION
## Proposed Changes

- Brief of changes made.

### Associated Issue

- Fixes https://github.com/coronasafe/care_fe/issues/7938

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
