### PR TITLE
Dont allow users to set patient code status as not specified for consent

### DIFF
--- a/care/facility/api/serializers/patient_consultation.py
+++ b/care/facility/api/serializers/patient_consultation.py
@@ -55,6 +55,7 @@ from care.facility.models.patient_base import (
 )
 from care.facility.models.patient_consultation import (
     ConsentType,
+    PatientCodeStatusType,
     PatientConsent,
     PatientConsultation,
 )
@@ -883,6 +884,13 @@ class PatientConsentSerializer(serializers.ModelSerializer):
             "archived_by",
             "archived_date",
         )
+
+    def validate_patient_code_status(self, value):
+        if value == PatientCodeStatusType.NOT_SPECIFIED:
+            raise ValidationError(
+                "Specify a correct Patient Code Status for the Consent"
+            )
+        return value
 
     def validate(self, attrs):
         user = self.context["request"].user

--- a/care/facility/api/serializers/patient_consultation.py
+++ b/care/facility/api/serializers/patient_consultation.py
@@ -902,8 +902,10 @@ class PatientConsentSerializer(serializers.ModelSerializer):
                 "Only Home Facility Staff can create consent for a Consultation"
             )
 
-        if attrs.get("type") == ConsentType.PATIENT_CODE_STATUS and not attrs.get(
-            "patient_code_status"
+        if (
+            attrs.get("type", None)
+            and attrs.get("type") == ConsentType.PATIENT_CODE_STATUS
+            and not attrs.get("patient_code_status")
         ):
             raise ValidationError(
                 {
@@ -913,8 +915,10 @@ class PatientConsentSerializer(serializers.ModelSerializer):
                 }
             )
 
-        if attrs.get("type") != ConsentType.PATIENT_CODE_STATUS and attrs.get(
-            "patient_code_status"
+        if (
+            attrs.get("type", None)
+            and attrs["type"] != ConsentType.PATIENT_CODE_STATUS
+            and attrs.get("patient_code_status")
         ):
             raise ValidationError(
                 {


### PR DESCRIPTION
## Proposed Changes

- add validation to not allow users to set consent type as others

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
