### PR TITLE
Merge Develop To Staging v24.27.0

### DIFF
--- a/care/facility/api/serializers/shifting.py
+++ b/care/facility/api/serializers/shifting.py
@@ -323,8 +323,15 @@ class ShiftingSerializer(serializers.ModelSerializer):
         if (
             "status" in validated_data
             and validated_data["status"] == REVERSE_SHIFTING_STATUS_CHOICES["COMPLETED"]
+            and not has_facility_permission(user, instance.origin_facility)
         ):
-            discharge_patient(instance.patient)
+            raise ValidationError(
+                {
+                    "status": [
+                        "Permission Denied - Only staff from the origin facility can mark the shift as complete."
+                    ]
+                }
+            )
 
         old_status = instance.status
         new_instance = super().update(instance, validated_data)


### PR DESCRIPTION
* Prevent destination facility from marking shift as complete

* Update care/facility/api/serializers/shifting.py



* Update care/facility/api/serializers/shifting.py

* allow only origin facility user to mark shifting request as completed

---------

## Proposed Changes

- Brief of changes made.

### Associated Issue

- Link to issue here, explain how the proposed solution will solve the reported issue/ feature request.

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
