### PR TITLE
Prevent N+1 queries in Encounter Symptoms ViewSet

### DIFF
--- a/care/facility/api/viewsets/encounter_symptom.py
+++ b/care/facility/api/viewsets/encounter_symptom.py
@@ -24,7 +24,7 @@ class EncounterSymptomFilter(filters.FilterSet):
 class EncounterSymptomViewSet(ModelViewSet):
     serializer_class = EncounterSymptomSerializer
     permission_classes = (IsAuthenticated, DRYPermissions)
-    queryset = EncounterSymptom.objects.all()
+    queryset = EncounterSymptom.objects.select_related("created_by", "updated_by")
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = EncounterSymptomFilter
     lookup_field = "external_id"


### PR DESCRIPTION


## Proposed Changes

- Select related created_by and updated_by users for encounter symptoms to prevent N+1 queries

### Associated Issue

- Fixes #2296

## Merge Checklist

- [x] Linting Complete
- [x] Any other necessary step

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
