### PR TITLE
HCX: Fix payor search filtering and claim supporting info category URL

### DIFF
--- a/care/hcx/api/viewsets/gateway.py
+++ b/care/hcx/api/viewsets/gateway.py
@@ -322,7 +322,17 @@ class HcxGatewayViewSet(GenericViewSet):
     def payors(self, request):
         payors = Hcx().searchRegistry("roles", "payor")["participants"]
 
-        active_payors = list(filter(lambda payor: payor["status"] == "Active", payors))
+        result = list(filter(lambda payor: payor["status"] == "Active", payors))
+
+        if query := request.query_params.get("query"):
+            query = query.lower()
+            result = filter(
+                lambda payor: (
+                    query in payor["participant_name"].lower()
+                    or query in payor["participant_code"].lower()
+                ),
+                result,
+            )
 
         response = list(
             map(
@@ -330,7 +340,7 @@ class HcxGatewayViewSet(GenericViewSet):
                     "name": payor["participant_name"],
                     "code": payor["participant_code"],
                 },
-                active_payors,
+                result,
             )
         )
 

--- a/care/hcx/api/viewsets/gateway.py
+++ b/care/hcx/api/viewsets/gateway.py
@@ -322,7 +322,7 @@ class HcxGatewayViewSet(GenericViewSet):
     def payors(self, request):
         payors = Hcx().searchRegistry("roles", "payor")["participants"]
 
-        result = list(filter(lambda payor: payor["status"] == "Active", payors))
+        result = filter(lambda payor: payor["status"] == "Active", payors)
 
         if query := request.query_params.get("query"):
             query = query.lower()

--- a/care/hcx/utils/fhir.py
+++ b/care/hcx/utils/fhir.py
@@ -71,7 +71,9 @@ class SYSTEM:
     claim_bundle_identifier = "https://www.tmh.in/bundle"
     coverage_eligibility_request_bundle_identifier = "https://www.tmh.in/bundle"
     practitioner_speciality = "http://snomed.info/sct"
-    claim_supporting_info_category = "https://ig.hcxprotocol.io/v0.7.1/ValueSet-claim-supporting-info-categories.html"
+    claim_supporting_info_category = (
+        "http://hcxprotocol.io/codes/claim-supporting-info-categories"
+    )
     related_claim_relationship = (
         "http://terminology.hl7.org/CodeSystem/ex-relatedclaimrelationship"
     )


### PR DESCRIPTION
## Proposed Changes

- Fixes payor search not filtering based on query
- Fixes claim supporting info category URL


https://github.com/user-attachments/assets/cdc17f73-c327-4ffd-97db-cab4ff184692



## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
