### PR TITLE
Explicity mention Public Read ACL for Facility Image S3 Uploads

### DIFF
--- a/care/facility/api/serializers/facility.py
+++ b/care/facility/api/serializers/facility.py
@@ -172,6 +172,7 @@ class FacilityImageUploadSerializer(serializers.ModelSerializer):
             Bucket=bucket_name,
             Key=image_location,
             Body=image.file,
+            ACL="public-read",
         )
         facility.cover_image_url = image_location
         facility.save()


### PR DESCRIPTION
## Proposed Changes

- Explicitly mention ACL during file upload

### Associated Issue

- https://github.com/coronasafe/care/issues/2335
Setting ACL='public-read' specifies that the uploaded object should be publicly accessible regardless of whether AWS S3 or another S3-compatible provider is being used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
