### PR TITLE
Corrected spelling mistake of ventilator_fi02 to ventilator_fio2

### DIFF
--- a/care/facility/management/commands/load_event_types.py
+++ b/care/facility/management/commands/load_event_types.py
@@ -151,7 +151,7 @@ class Command(BaseCommand):
                     "fields": (
                         "bilateral_air_entry",
                         "etco2",
-                        "ventilator_fi02",
+                        "ventilator_fio2",
                         "ventilator_interface",
                         "ventilator_mean_airway_pressure",
                         "ventilator_mode",

--- a/care/facility/migrations/0001_initial_squashed.py
+++ b/care/facility/migrations/0001_initial_squashed.py
@@ -1524,7 +1524,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 (
-                    "ventilator_fi02",
+                    "ventilator_fio2",
                     models.IntegerField(
                         default=None,
                         null=True,

--- a/care/facility/migrations_old/0261_auto_20210710_2305.py
+++ b/care/facility/migrations_old/0261_auto_20210710_2305.py
@@ -634,7 +634,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name="dailyround",
-            name="ventilator_fi02",
+            name="ventilator_fio2",
             field=models.IntegerField(
                 default=None,
                 null=True,

--- a/care/facility/models/daily_round.py
+++ b/care/facility/models/daily_round.py
@@ -320,7 +320,7 @@ class DailyRound(PatientBaseModel):
         null=True,
         validators=[MinValueValidator(0), MaxValueValidator(70)],
     )
-    ventilator_fi02 = models.IntegerField(
+    ventilator_fio2 = models.IntegerField(
         default=None,
         null=True,
         validators=[MinValueValidator(21), MaxValueValidator(100)],


### PR DESCRIPTION


## Proposed Changes

- Corrected spelling mistake of ventilator_fi02 to ventilator_fio2

### Associated Issue

- #8241 from care_fe (frontend). Both backend and frontend spelling mistake corrected.



## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
