### PR TITLE
fix s3 client error on gcp

### DIFF
--- a/care/facility/api/serializers/facility.py
+++ b/care/facility/api/serializers/facility.py
@@ -1,4 +1,5 @@
 import boto3
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from rest_framework import serializers
 
@@ -168,12 +169,14 @@ class FacilityImageUploadSerializer(serializers.ModelSerializer):
         config, bucket_name = get_client_config(BucketType.FACILITY)
         s3 = boto3.client("s3", **config)
         image_location = f"cover_images/{facility.external_id}_cover.{image_extension}"
-        s3.put_object(
-            Bucket=bucket_name,
-            Key=image_location,
-            Body=image.file,
-            ACL="public-read",
-        )
+        boto_params = {
+            "Bucket": bucket_name,
+            "Key": image_location,
+            "Body": image.file,
+        }
+        if settings.BUCKET_HAS_FINE_ACL:
+            boto_params["ACL"] = "public-read"
+        s3.put_object(**boto_params)
         facility.cover_image_url = image_location
         facility.save()
         return facility

--- a/care/utils/csp/config.py
+++ b/care/utils/csp/config.py
@@ -17,6 +17,8 @@ BucketName: TypeAlias = str
 class CSProvider(enum.Enum):
     AWS = "AWS"
     GCP = "GCP"
+    DIGITAL_OCEAN = "DIGITAL_OCEAN"
+    MINIO = "MINIO"
     DOCKER = "DOCKER"  # localstack in docker
     LOCAL = "LOCAL"  # localstack on host
 
@@ -31,9 +33,11 @@ def get_facility_bucket_config(external) -> tuple[ClientConfig, BucketName]:
         "region_name": settings.FACILITY_S3_REGION,
         "aws_access_key_id": settings.FACILITY_S3_KEY,
         "aws_secret_access_key": settings.FACILITY_S3_SECRET,
-        "endpoint_url": settings.FACILITY_S3_BUCKET_EXTERNAL_ENDPOINT
-        if external
-        else settings.FACILITY_S3_BUCKET_ENDPOINT,
+        "endpoint_url": (
+            settings.FACILITY_S3_BUCKET_EXTERNAL_ENDPOINT
+            if external
+            else settings.FACILITY_S3_BUCKET_ENDPOINT
+        ),
     }, settings.FACILITY_S3_BUCKET
 
 
@@ -42,9 +46,11 @@ def get_patient_bucket_config(external) -> tuple[ClientConfig, BucketName]:
         "region_name": settings.FILE_UPLOAD_REGION,
         "aws_access_key_id": settings.FILE_UPLOAD_KEY,
         "aws_secret_access_key": settings.FILE_UPLOAD_SECRET,
-        "endpoint_url": settings.FILE_UPLOAD_BUCKET_EXTERNAL_ENDPOINT
-        if external
-        else settings.FILE_UPLOAD_BUCKET_ENDPOINT,
+        "endpoint_url": (
+            settings.FILE_UPLOAD_BUCKET_EXTERNAL_ENDPOINT
+            if external
+            else settings.FILE_UPLOAD_BUCKET_ENDPOINT
+        ),
     }, settings.FILE_UPLOAD_BUCKET
 
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -511,6 +511,7 @@ BUCKET_KEY = env("BUCKET_KEY", default="")
 BUCKET_SECRET = env("BUCKET_SECRET", default="")
 BUCKET_ENDPOINT = env("BUCKET_ENDPOINT", default="")
 BUCKET_EXTERNAL_ENDPOINT = env("BUCKET_EXTERNAL_ENDPOINT", default=BUCKET_ENDPOINT)
+BUCKET_HAS_FINE_ACL = env.bool("BUCKET_HAS_FINE_ACL", default=False)
 
 if BUCKET_PROVIDER not in csp_config.CSProvider.__members__:
     print(f"Warning Invalid CSP Found! {BUCKET_PROVIDER}")


### PR DESCRIPTION
ACL param is not supported by buckets with uniform access control

added a new parameter to specify wether the buckets has fine grained acl

fixes https://github.com/coronasafe/care_fe/issues/8325