### PR TITLE
fix consultation create with bed

### DIFF
--- a/care/facility/api/serializers/patient_consultation.py
+++ b/care/facility/api/serializers/patient_consultation.py
@@ -396,6 +396,8 @@ class PatientConsultationSerializer(serializers.ModelSerializer):
                 if validated_data["is_kasp"]:
                     validated_data["kasp_enabled_date"] = now()
 
+            bed = validated_data.pop("bed", None)
+
             # Coercing facility as the patient's facility
             validated_data["facility_id"] = patient.facility_id
 
@@ -440,7 +442,6 @@ class PatientConsultationSerializer(serializers.ModelSerializer):
                 for obj in create_symptoms
             )
 
-            bed = validated_data.pop("bed", None)
             if bed and consultation.suggestion == SuggestionChoices.A:
                 consultation_bed = ConsultationBed(
                     bed=bed,

--- a/care/facility/tests/test_patient_consultation_api.py
+++ b/care/facility/tests/test_patient_consultation_api.py
@@ -6,6 +6,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from care.facility.api.serializers.patient_consultation import MIN_ENCOUNTER_DATE
+from care.facility.models.bed import Bed
 from care.facility.models.encounter_symptom import Symptom
 from care.facility.models.file_upload import FileUpload
 from care.facility.models.icd11_diagnosis import (
@@ -641,3 +642,17 @@ class TestPatientConsultation(TestUtils, APITestCase):
         )
         res = self.client.post(self.get_url(), data, format="json")
         self.assertEqual(res.status_code, status.HTTP_201_CREATED)
+
+    def test_create_consultation_with_bed(self):
+        asset_location = self.create_asset_location(self.facility)
+        bed = Bed.objects.create(
+            name="bed", location=asset_location, facility=self.facility
+        )
+
+        consultation: PatientConsultation = self.create_admission_consultation(
+            suggestion=SuggestionChoices.A,
+            encounter_date=make_aware(datetime.datetime(2020, 4, 1, 15, 30, 00)),
+            bed=bed.external_id,
+        )
+
+        self.assertEqual(consultation.current_bed.bed, bed)


### PR DESCRIPTION
## Proposed Changes

- pop the bed before creating consulation

### Associated Issue

- Regression from #2299
- fixes  #2376 
- fixes https://github.com/coronasafe/care_fe/issues/8382

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
