### PR TITLE
fix pdf report generation in prod

### DIFF
--- a/scripts/celery_worker-ecs.sh
+++ b/scripts/celery_worker-ecs.sh
@@ -5,5 +5,6 @@ if [ -z "${DATABASE_URL}" ]; then
     export DATABASE_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"
 fi
 
+python manage.py collectstatic --noinput
 python manage.py compilemessages
 celery --app=config.celery_app worker --max-tasks-per-child=6 --loglevel=info

--- a/scripts/celery_worker.sh
+++ b/scripts/celery_worker.sh
@@ -7,5 +7,6 @@ fi
 
 
 export NEW_RELIC_CONFIG_FILE=/etc/newrelic.ini
+python manage.py collectstatic --noinput
 python manage.py compilemessages
 newrelic-admin run-program celery --app=config.celery_app worker --max-tasks-per-child=6 --loglevel=info


### PR DESCRIPTION
## Proposed Changes

- the worker crashes as it cannot find the care_logo while generating the pdf

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins
