### PR TITLE
fix string representation of prescription and mar

### DIFF
--- a/care/facility/models/prescription.py
+++ b/care/facility/models/prescription.py
@@ -175,7 +175,7 @@ class Prescription(BaseModel, ConsultationRelatedPermissionMixin):
         return ConsultationRelatedPermissionMixin.has_write_permission(request)
 
     def __str__(self):
-        return self.medicine + " - " + self.consultation.patient.name
+        return f"{self.consultation_id} - {self.medicine_id} ({self.id})"
 
 
 class MedicineAdministration(BaseModel, ConsultationRelatedPermissionMixin):
@@ -204,11 +204,7 @@ class MedicineAdministration(BaseModel, ConsultationRelatedPermissionMixin):
     )
 
     def __str__(self):
-        return (
-            self.prescription.medicine
-            + " - "
-            + self.prescription.consultation.patient.name
-        )
+        return f"{self.consultation_id} - {self.medicine_id} - {self.prescription_id} ({self.id})"
 
     def get_related_consultation(self):
         return self.prescription.consultation

--- a/care/facility/models/prescription.py
+++ b/care/facility/models/prescription.py
@@ -175,7 +175,7 @@ class Prescription(BaseModel, ConsultationRelatedPermissionMixin):
         return ConsultationRelatedPermissionMixin.has_write_permission(request)
 
     def __str__(self):
-        return f"{self.consultation_id} - {self.medicine_id} ({self.id})"
+        return f"Prescription({self.id}) {self.consultation_id} - {self.medicine_id}"
 
 
 class MedicineAdministration(BaseModel, ConsultationRelatedPermissionMixin):
@@ -204,7 +204,7 @@ class MedicineAdministration(BaseModel, ConsultationRelatedPermissionMixin):
     )
 
     def __str__(self):
-        return f"{self.consultation_id} - {self.medicine_id} - {self.prescription_id} ({self.id})"
+        return f"MedicineAdministration({self.id}) {self.prescription_id} - {self.administered_date}"
 
     def get_related_consultation(self):
         return self.prescription.consultation


### PR DESCRIPTION
## Proposed Changes

- the string representation of mar and prescreptions was crashing the error message raised during cascade delete of consultaions


## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins
