### PR TITLE
use static jwk instead of auto generating on aws

### DIFF
--- a/aws/backend.json
+++ b/aws/backend.json
@@ -286,6 +286,10 @@
         {
           "valueFrom": "/care/backend/PLAUSIBLE_AUTH_TOKEN",
           "name": "PLAUSIBLE_AUTH_TOKEN"
+        },
+        {
+          "valueFrom": "/care/backend/JWKS_BASE64",
+          "name": "JWKS_BASE64"
         }
       ],
       "name": "care-backend"

--- a/aws/celery.json
+++ b/aws/celery.json
@@ -275,6 +275,10 @@
         {
           "valueFrom": "/care/backend/ABDM_CLIENT_SECRET",
           "name": "ABDM_CLIENT_SECRET"
+        },
+        {
+          "valueFrom": "/care/backend/JWKS_BASE64",
+          "name": "JWKS_BASE64"
         }
       ],
       "name": "care-celery-beat"
@@ -548,6 +552,10 @@
         {
           "valueFrom": "/care/backend/ABDM_CLIENT_SECRET",
           "name": "ABDM_CLIENT_SECRET"
+        },
+        {
+          "valueFrom": "/care/backend/JWKS_BASE64",
+          "name": "JWKS_BASE64"
         }
       ],
       "name": "care-celery-worker"


### PR DESCRIPTION
## Proposed Changes

- the jwk should be common for all workers  for open_id to work correctly

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins
