### PR TITLE
Do not allow future log update taken_at time

### DIFF
--- a/care/facility/api/serializers/daily_round.py
+++ b/care/facility/api/serializers/daily_round.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 from django.db import transaction
+from django.utils import timezone
 from django.utils.timezone import localtime, now
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
@@ -295,3 +296,8 @@ class DailyRoundSerializer(serializers.ModelSerializer):
                 validated["bed_id"] = bed_object.id
 
         return validated
+
+    def validate_taken_at(self, value):
+        if value > timezone.now():
+            raise serializers.ValidationError("Cannot create an update in the future")
+        return value

--- a/care/facility/api/serializers/daily_round.py
+++ b/care/facility/api/serializers/daily_round.py
@@ -298,6 +298,6 @@ class DailyRoundSerializer(serializers.ModelSerializer):
         return validated
 
     def validate_taken_at(self, value):
-        if value > timezone.now():
+        if value and value > timezone.now():
             raise serializers.ValidationError("Cannot create an update in the future")
         return value

--- a/care/facility/tests/test_patient_daily_rounds_api.py
+++ b/care/facility/tests/test_patient_daily_rounds_api.py
@@ -1,5 +1,7 @@
 import datetime
+from datetime import timedelta
 
+from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -126,3 +128,15 @@ class TestDailyRoundApi(TestUtils, APITestCase):
             data={**self.log_update, "rounds_type": "DOCTORS_LOG"},
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_invalid_taken_at(self):
+        data = {
+            **self.log_update,
+            "taken_at": timezone.now() + timedelta(minutes=5),
+        }
+        response = self.client.post(
+            f"/api/v1/consultation/{self.consultation_with_bed.external_id}/daily_rounds/",
+            data,
+        )
+        print(response.json())
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/care/facility/tests/test_patient_daily_rounds_api.py
+++ b/care/facility/tests/test_patient_daily_rounds_api.py
@@ -138,5 +138,4 @@ class TestDailyRoundApi(TestUtils, APITestCase):
             f"/api/v1/consultation/{self.consultation_with_bed.external_id}/daily_rounds/",
             data,
         )
-        print(response.json())
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Proposed Changes

- Will throw an error if the `taken_at` time is in the future
- Fixes #2439

## Merge Checklist

- [x] Tests added/fixed
- [x] Update docs in `/docs`
- [x] Linting Complete
- [x] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@coronasafe/care-backend-maintainers @coronasafe/care-backend-admins
