### PR TITLE
Avoid printing typst version in tests

### DIFF
--- a/care/facility/tests/test_pdf_generation.py
+++ b/care/facility/tests/test_pdf_generation.py
@@ -103,7 +103,7 @@ def test_compile_typ(data):
 class TestTypstInstallation(TestCase):
     def test_typst_installed(self):
         try:
-            subprocess.run(["typst", "--version"], check=True)
+            subprocess.run(["typst", "--version"], check=True, capture_output=True)
             typst_installed = True
         except subprocess.CalledProcessError:
             typst_installed = False


### PR DESCRIPTION
## Proposed Changes

- Avoid printing typst version in tests


## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins
