### PR TITLE
Fix UnorderedObjectListWarning in patient search api

### DIFF
--- a/care/facility/api/viewsets/patient.py
+++ b/care/facility/api/viewsets/patient.py
@@ -285,7 +285,6 @@ class PatientFilterSet(filters.FilterSet):
     )
 
     def filter_by_has_consents(self, queryset, name, value: str):
-
         if not value:
             return queryset
 
@@ -805,7 +804,7 @@ class PatientSearchViewSet(ListModelMixin, GenericViewSet):
         "facility",
         "allow_transfer",
         "is_active",
-    )
+    ).order_by("id")
     serializer_class = PatientSearchSerializer
     permission_classes = (IsAuthenticated, DRYPermissions)
     pagination_class = PatientSearchSetPagination


### PR DESCRIPTION
## Proposed Changes

- Fix UnorderedObjectListWarning in patient search api


## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins
