### PR TITLE
fix aws deploys

### DIFF
--- a/aws/backend.json
+++ b/aws/backend.json
@@ -272,6 +272,10 @@
           "name": "HCX_IG_URL"
         },
         {
+          "valueFrom": "/care/backend/HCX_CERT_URL",
+          "name": "HCX_CERT_URL"
+        },
+        {
           "valueFrom": "/care/backend/ABDM_CLIENT_ID",
           "name": "ABDM_CLIENT_ID"
         },

--- a/aws/celery.json
+++ b/aws/celery.json
@@ -257,6 +257,10 @@
           "name": "HCX_IG_URL"
         },
         {
+          "valueFrom": "/care/backend/HCX_CERT_URL",
+          "name": "HCX_CERT_URL"
+        },
+        {
           "valueFrom": "/care/backend/PLAUSIBLE_HOST",
           "name": "PLAUSIBLE_HOST"
         },
@@ -532,6 +536,10 @@
         {
           "valueFrom": "/care/backend/HCX_IG_URL",
           "name": "HCX_IG_URL"
+        },
+        {
+          "valueFrom": "/care/backend/HCX_CERT_URL",
+          "name": "HCX_CERT_URL"
         },
         {
           "valueFrom": "/care/backend/PLAUSIBLE_HOST",


### PR DESCRIPTION
## Proposed Changes

- missing HCX_CERT_URL was causing initilizaton failure of care containers

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins
