### PR TITLE
disable filtering inactive users by default

### DIFF
--- a/care/users/admin.py
+++ b/care/users/admin.py
@@ -58,6 +58,13 @@ class UserAdmin(auth_admin.UserAdmin, ExportCsvMixin):
     list_display = ["username", "is_superuser"]
     search_fields = ["first_name", "last_name"]
 
+    def get_queryset(self, request):
+        # use the base manager to avoid filtering out soft deleted objects
+        qs = self.model._base_manager.get_queryset()  # noqa: SLF001
+        if ordering := self.get_ordering(request):
+            qs = qs.order_by(*ordering)
+        return qs
+
 
 @admin.register(State)
 class StateAdmin(admin.ModelAdmin):

--- a/care/users/models.py
+++ b/care/users/models.py
@@ -130,7 +130,7 @@ class Ward(models.Model):
 class CustomUserManager(UserManager):
     def get_queryset(self):
         qs = super().get_queryset()
-        return qs.filter(deleted=False, is_active=True).select_related(
+        return qs.filter(deleted=False).select_related(
             "local_body", "district", "state"
         )
 


### PR DESCRIPTION
## Proposed Changes

- disable filtering inactive users by default
- override user admin queryset to show soft deleted users

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins
