### PR TITLE
Fixed prod deploy: install libgmp-dev in prod

### DIFF
--- a/docker/prod.Dockerfile
+++ b/docker/prod.Dockerfile
@@ -54,7 +54,7 @@ RUN python3 $APP_HOME/install_plugins.py
 FROM base AS runtime
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-  libpq-dev gettext wget curl gnupg \
+  libpq-dev libgmp-dev gettext wget curl gnupg \
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && rm -rf /var/lib/apt/lists/*
 

--- a/docker/prod.Dockerfile
+++ b/docker/prod.Dockerfile
@@ -20,7 +20,7 @@ WORKDIR $APP_HOME
 FROM base AS builder
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-  build-essential libjpeg-dev zlib1g-dev libpq-dev git wget \
+  build-essential libjpeg-dev zlib1g-dev libgmp-dev libpq-dev git wget \
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Docker build was failing due to fastecdsa dependency, as this dependency requires libgmp-dev.

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins
