### PR TITLE
fixes validation preventing linking multiple cameras to a bed

### DIFF
--- a/care/facility/api/serializers/bed.py
+++ b/care/facility/api/serializers/bed.py
@@ -111,6 +111,10 @@ class AssetBedSerializer(ModelSerializer):
                 not facilities.filter(id=asset.current_location.facility.id).exists()
             ) or (not facilities.filter(id=bed.facility.id).exists()):
                 raise PermissionError
+            if AssetBed.objects.filter(asset=asset, bed=bed).exists():
+                raise ValidationError(
+                    {"non_field_errors": "Asset is already linked to bed"}
+                )
             if asset.asset_class not in [
                 AssetClasses.HL7MONITOR.name,
                 AssetClasses.ONVIF.name,

--- a/care/facility/api/serializers/bed.py
+++ b/care/facility/api/serializers/bed.py
@@ -123,11 +123,10 @@ class AssetBedSerializer(ModelSerializer):
                     {"asset": "Should be in the same facility as the bed"}
                 )
             if (
-                asset.asset_class
-                in [
-                    AssetClasses.HL7MONITOR.name,
-                    AssetClasses.ONVIF.name,
-                ]
+                asset.asset_class == AssetClasses.HL7MONITOR.name
+                and AssetBed.objects.filter(
+                    bed=bed, asset__asset_class=asset.asset_class
+                ).exists()
             ) and AssetBed.objects.filter(
                 bed=bed, asset__asset_class=asset.asset_class
             ).exists():

--- a/care/facility/api/serializers/bed.py
+++ b/care/facility/api/serializers/bed.py
@@ -135,9 +135,7 @@ class AssetBedSerializer(ModelSerializer):
                 bed=bed, asset__asset_class=asset.asset_class
             ).exists():
                 raise ValidationError(
-                    {
-                        "asset": "Bed is already in use by another asset of the same class"
-                    }
+                    {"asset": "Another HL7 Monitor is already linked to this bed."}
                 )
         else:
             raise ValidationError(

--- a/care/facility/tests/test_asset_bed_api.py
+++ b/care/facility/tests/test_asset_bed_api.py
@@ -24,6 +24,9 @@ class AssetBedViewSetTestCase(TestUtils, APITestCase):
         cls.camera_asset = cls.create_asset(
             cls.asset_location, asset_class=AssetClasses.ONVIF.name
         )
+        cls.camera_asset_1 = cls.create_asset(
+            cls.asset_location, asset_class=AssetClasses.ONVIF.name, name="Camera 2"
+        )
         cls.bed = cls.create_bed(cls.facility, cls.asset_location)
 
     def test_link_disallowed_asset_class_asset_to_bed(self):
@@ -48,6 +51,18 @@ class AssetBedViewSetTestCase(TestUtils, APITestCase):
         res = self.client.get("/api/v1/assetbed/", data)
         self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertEqual(res.data["count"], 1)
+
+    def test_linking_multiple_cameras_to_a_bed(self):
+        data = {
+            "asset": self.camera_asset.external_id,
+            "bed": self.bed.external_id,
+        }
+        res = self.client.post("/api/v1/assetbed/", data)
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)
+        # Attempt linking another camera to same bed.
+        data["asset"] = self.camera_asset_1.external_id
+        res = self.client.post("/api/v1/assetbed/", data)
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)
 
 
 class AssetBedCameraPresetViewSetTestCase(TestUtils, APITestCase):

--- a/care/facility/tests/test_asset_bed_api.py
+++ b/care/facility/tests/test_asset_bed_api.py
@@ -21,6 +21,12 @@ class AssetBedViewSetTestCase(TestUtils, APITestCase):
         )
         cls.asset_location = cls.create_asset_location(cls.facility)
         cls.asset = cls.create_asset(cls.asset_location)
+        cls.monitor_asset_1 = cls.create_asset(
+            cls.asset_location, asset_class=AssetClasses.HL7MONITOR.name
+        )
+        cls.monitor_asset_2 = cls.create_asset(
+            cls.asset_location, asset_class=AssetClasses.HL7MONITOR.name
+        )
         cls.camera_asset = cls.create_asset(
             cls.asset_location, asset_class=AssetClasses.ONVIF.name
         )
@@ -66,6 +72,18 @@ class AssetBedViewSetTestCase(TestUtils, APITestCase):
         data["asset"] = self.camera_asset_2.external_id
         res = self.client.post("/api/v1/assetbed/", data)
         self.assertEqual(res.status_code, status.HTTP_201_CREATED)
+
+    def test_link_multiple_hl7_monitor_to_same_bed(self):
+        data = {
+            "asset": self.monitor_asset_1.external_id,
+            "bed": self.bed.external_id,
+        }
+        res = self.client.post("/api/v1/assetbed/", data)
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)
+        # Attempt linking another hl7 monitor to same bed.
+        data["asset"] = self.monitor_asset_2.external_id
+        res = self.client.post("/api/v1/assetbed/", data)
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
 
 
 class AssetBedCameraPresetViewSetTestCase(TestUtils, APITestCase):

--- a/care/facility/tests/test_asset_bed_api.py
+++ b/care/facility/tests/test_asset_bed_api.py
@@ -73,7 +73,7 @@ class AssetBedViewSetTestCase(TestUtils, APITestCase):
         res = self.client.post("/api/v1/assetbed/", data)
         self.assertEqual(res.status_code, status.HTTP_201_CREATED)
 
-    def test_link_multiple_hl7_monitor_to_same_bed(self):
+    def test_linking_multiple_hl7_monitors_to_a_bed(self):
         data = {
             "asset": self.monitor_asset_1.external_id,
             "bed": self.bed.external_id,

--- a/care/facility/tests/test_asset_bed_api.py
+++ b/care/facility/tests/test_asset_bed_api.py
@@ -25,6 +25,9 @@ class AssetBedViewSetTestCase(TestUtils, APITestCase):
             cls.asset_location, asset_class=AssetClasses.ONVIF.name
         )
         cls.camera_asset_1 = cls.create_asset(
+            cls.asset_location, asset_class=AssetClasses.ONVIF.name, name="Camera 1"
+        )
+        cls.camera_asset_2 = cls.create_asset(
             cls.asset_location, asset_class=AssetClasses.ONVIF.name, name="Camera 2"
         )
         cls.bed = cls.create_bed(cls.facility, cls.asset_location)
@@ -54,13 +57,13 @@ class AssetBedViewSetTestCase(TestUtils, APITestCase):
 
     def test_linking_multiple_cameras_to_a_bed(self):
         data = {
-            "asset": self.camera_asset.external_id,
+            "asset": self.camera_asset_1.external_id,
             "bed": self.bed.external_id,
         }
         res = self.client.post("/api/v1/assetbed/", data)
         self.assertEqual(res.status_code, status.HTTP_201_CREATED)
         # Attempt linking another camera to same bed.
-        data["asset"] = self.camera_asset_1.external_id
+        data["asset"] = self.camera_asset_2.external_id
         res = self.client.post("/api/v1/assetbed/", data)
         self.assertEqual(res.status_code, status.HTTP_201_CREATED)
 


### PR DESCRIPTION
## Proposed Changes

- fixes validation preventing linking multiple cameras to a bed

### Associated Issue

- Regression from [`1370725` (#2387)](https://github.com/ohcnetwork/care/pull/2387/commits/1370725bb28e2a1213b5cbc7ae441435033da3fe)

## Merge Checklist

- [x] Tests added/fixed
- [x] Linting Complete

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins
