### PR TITLE
Flushed care_static_data prefixed redis keys

### DIFF
--- a/care/facility/management/commands/load_redis_index.py
+++ b/care/facility/management/commands/load_redis_index.py
@@ -17,6 +17,17 @@ class Command(BaseCommand):
     help = "Loads static data to redis"
 
     def handle(self, *args, **options):
+        try:
+            deleted_count = cache.delete_pattern("care_static_data*", itersize=25_000)
+            self.stdout.write(
+                f"Deleted {deleted_count} keys with prefix 'care_static_data'"
+            )
+        except Exception as e:
+            self.stdout.write(
+                f"Failed to delete keys with prefix 'care_static_data': {e}"
+            )
+            return
+
         if cache.get("redis_index_loading"):
             self.stdout.write("Redis Index already loading, skipping")
             return

--- a/care/facility/tasks/redis_index.py
+++ b/care/facility/tasks/redis_index.py
@@ -46,7 +46,7 @@ def load_redis_index():
         except ModuleNotFoundError:
             logger.debug("Module %s not found", module_path)
         except Exception as e:
-            logger.exception("Error loading static data for %s: %s", plug.name, e)
+            logger.error("Error loading static data for %s: %s", plug.name, e)
 
     cache.delete("redis_index_loading")
     logger.info("Redis Index Loaded")

--- a/care/facility/tasks/redis_index.py
+++ b/care/facility/tasks/redis_index.py
@@ -15,6 +15,13 @@ logger: Logger = get_task_logger(__name__)
 
 @shared_task
 def load_redis_index():
+    try:
+        deleted_count = cache.delete_pattern("care_static_data*", itersize=25_000)
+        logger.info("Deleted %s keys with prefix 'care_static_data'", deleted_count)
+    except Exception as e:
+        logger.error("Failed to delete keys with prefix 'care_static_data': %s", e)
+        return
+
     if cache.get("redis_index_loading"):
         logger.info("Redis Index already loading, skipping")
         return
@@ -37,9 +44,9 @@ def load_redis_index():
             if load_static_data:
                 load_static_data()
         except ModuleNotFoundError:
-            logger.info("Module %s not found", module_path)
+            logger.debug("Module %s not found", module_path)
         except Exception as e:
-            logger.info("Error loading static data for %s: %s", plug.name, e)
+            logger.exception("Error loading static data for %s: %s", plug.name, e)
 
     cache.delete("redis_index_loading")
     logger.info("Redis Index Loaded")


### PR DESCRIPTION
* Used delete_pattern from django-redis repo to delete keys

## Proposed Changes

- Deletes redis keys with ``care_static_data`` prefix

### Associated Issue

- Fixed #2249, Used Cache(from django) which has a delete_pattern() function to delete keys with ``prefix care_static_data`` within try/catch blocks to prevent uncaught exceptions.

## Merge Checklist

- [x] Linting Complete
- [x] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins
