### PR TITLE
Added profile pic url to UserBaseMinimumSerializer

### DIFF
--- a/care/facility/tests/test_patient_api.py
+++ b/care/facility/tests/test_patient_api.py
@@ -86,6 +86,7 @@ class ExpectedCreatedByObjectKeys(Enum):
     LAST_NAME = "last_name"
     USER_TYPE = "user_type"
     LAST_LOGIN = "last_login"
+    READ_PROFILE_PICTURE_URL = "read_profile_picture_url"
 
 
 class PatientNotesTestCase(TestUtils, APITestCase):

--- a/care/users/api/serializers/user.py
+++ b/care/users/api/serializers/user.py
@@ -387,7 +387,7 @@ class UserBaseMinimumSerializer(serializers.ModelSerializer):
             "last_name",
             "user_type",
             "last_login",
-            "read_profile_picture_url"
+            "read_profile_picture_url",
         )
 
 

--- a/care/users/api/serializers/user.py
+++ b/care/users/api/serializers/user.py
@@ -375,6 +375,7 @@ class UserSerializer(SignUpSerializer):
 
 class UserBaseMinimumSerializer(serializers.ModelSerializer):
     user_type = ChoiceField(choices=User.TYPE_CHOICES, read_only=True)
+    read_profile_picture_url = serializers.URLField(read_only=True)
 
     class Meta:
         model = User
@@ -386,6 +387,7 @@ class UserBaseMinimumSerializer(serializers.ModelSerializer):
             "last_name",
             "user_type",
             "last_login",
+            "read_profile_picture_url"
         )
 
 


### PR DESCRIPTION
## Proposed Changes

- Added `read_profile_picture_url` to `UserBaseMinimumSerializer`
    - Makes the image url available to `treating_physician_object` (allowing for user avatar to show up for existing choices in UserAutoComplete on frontend).

### Associated Issue

- [8967](https://github.com/ohcnetwork/care_fe/pull/8967) in FE.

## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins
