### PR TITLE
Add workflow steps to upload dummy db artifact for tests

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -38,7 +38,7 @@ jobs:
             *.cache-to=type=local,dest=/tmp/.buildx-cache-new
           files: docker-compose.yaml,docker-compose.local.yaml
         env:
-          DOCKER_BUILD_NO_SUMMARY: true
+          DOCKER_BUILD_SUMMARY: false
 
       - name: Start services
         run: |
@@ -58,7 +58,7 @@ jobs:
         run: make load-dummy-data
 
       - name: Dump db
-        # if: ${{ inputs.event_name == 'push' || github.event_name == 'push' }}
+        if: ${{ inputs.event_name == 'push' || github.event_name == 'push' }}
         run: make dump-db
 
       - name: Run tests
@@ -82,7 +82,7 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ hashFiles('Pipfile.lock', 'docker/dev.Dockerfile') }}
 
       - name: Upload db artifact
-        # if: ${{ inputs.event_name == 'push' || github.event_name == 'push' }}
+        if: ${{ inputs.event_name == 'push' || github.event_name == 'push' }}
         uses: actions/upload-artifact@v4
         with:
           name: care-db-dump

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -57,6 +57,10 @@ jobs:
       - name: Validate integrity of fixtures
         run: make load-dummy-data
 
+      - name: Dump db
+        # if: ${{ inputs.event_name == 'push' || github.event_name == 'push' }}
+        run: make dump-db
+
       - name: Run tests
         run: make test-coverage
 
@@ -76,3 +80,13 @@ jobs:
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ hashFiles('Pipfile.lock', 'docker/dev.Dockerfile') }}
+
+      - name: Upload db artifact
+        # if: ${{ inputs.event_name == 'push' || github.event_name == 'push' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: care-db-dump
+          path: care_db.dump
+          retention-days: 30
+          compression-level: 0 # file is already compressed
+          overwrite: true # keep only the last artifact

--- a/.gitignore
+++ b/.gitignore
@@ -354,3 +354,5 @@ secrets.sh
 *.rdb
 
 jwks.b64.txt
+
+care_db.dump

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ dump-db:
 
 load-db:
 	docker compose cp care_db.dump db:/tmp/care_db.dump
-	docker compose exec db sh -c "pg_restore -U postgres -d care /tmp/care_db.dump"
+	docker compose exec db sh -c "pg_restore -U postgres --clean --if-exists -d care /tmp/care_db.dump"
 
 reset-db:
 	docker compose exec backend bash -c "python manage.py reset_db --noinput"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build, re-build, up, down, list, logs, test, makemigrations, reset_db
+.PHONY: logs
 
 
 DOCKER_VERSION := $(shell docker --version 2>/dev/null)

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ re-build:
 build:
 	docker compose -f docker-compose.yaml -f $(docker_config_file) build
 
+pull:
+	docker compose -f docker-compose.yaml -f $(docker_config_file) pull
+
 up:
 	docker compose -f docker-compose.yaml -f $(docker_config_file) up -d --wait
 

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ checkmigration:
 makemigrations:
 	docker compose exec backend bash -c "python manage.py makemigrations"
 
+migrate:
+	docker compose exec backend bash -c "python manage.py migrate"
+
 test:
 	docker compose exec backend bash -c "python manage.py test --keepdb --parallel --shuffle"
 
@@ -48,9 +51,16 @@ test-coverage:
 	docker compose exec backend bash -c "coverage combine || true; coverage xml"
 	docker compose cp backend:/app/coverage.xml coverage.xml
 
-reset_db:
+dump-db:
+	docker compose exec db sh -c "pg_dump -U postgres -Fc care > /tmp/care_db.dump"
+	docker compose cp db:/tmp/care_db.dump care_db.dump
+
+load-db:
+	docker compose cp care_db.dump db:/tmp/care_db.dump
+	docker compose exec db sh -c "pg_restore -U postgres -d care /tmp/care_db.dump"
+
+reset-db:
 	docker compose exec backend bash -c "python manage.py reset_db --noinput"
-	docker compose exec backend bash -c "python manage.py migrate"
 
 ruff-all:
 	ruff check .


### PR DESCRIPTION
## Proposed Changes

- add make targets for creating and loading db dumps
- Add workflow steps to upload dummy db artifact for tests
- replace deprecated DOCKER_BUILD_NO_SUMMARY env variable

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added database management capabilities including migration, backup, and restoration processes.
	- Introduced new steps in the workflow for database dumping and artifact handling.
	- New targets in the Makefile for pulling Docker images and managing database operations.

- **Bug Fixes**
	- Improved handling of ignored files in the `.gitignore` to prevent tracking of unnecessary database dump files.

- **Refactor**
	- Updated naming conventions for clarity in the Makefile targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->