### PR TITLE
Fixing Manually cascade delete M2M models when related model is deleted

### DIFF
--- a/care/facility/models/asset.py
+++ b/care/facility/models/asset.py
@@ -59,6 +59,9 @@ class AssetLocation(BaseModel, FacilityRelatedPermissionMixin):
         if UserDefaultAssetLocation.objects.filter(location=self).exists():
             error = f"Cannot delete AssetLocation {self} because they are referenced as `location` in UserDefaultAssetLocation records."
             raise ValidationError(error)
+        if FacilityDefaultAssetLocation.objects.filter(location=self).exists():
+            error = f"Cannot delete AssetLocation {self} because they are referenced as `location` in FacilityDefaultAssetLocation records."
+            raise ValidationError(error)
         return super().delete(*args)
 
 

--- a/care/facility/models/asset.py
+++ b/care/facility/models/asset.py
@@ -2,6 +2,7 @@ import enum
 import uuid
 
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import JSONField, Q
 
@@ -53,6 +54,12 @@ class AssetLocation(BaseModel, FacilityRelatedPermissionMixin):
     middleware_address = models.CharField(
         null=True, blank=True, default=None, max_length=200
     )
+
+    def delete(self, *args):
+        if UserDefaultAssetLocation.objects.filter(location=self).exists():
+            error = f"Cannot delete AssetLocation {self} because they are referenced as `location` in UserDefaultAssetLocation records."
+            raise ValidationError(error)
+        return super().delete(*args)
 
 
 class AssetType(enum.Enum):

--- a/care/facility/models/bed.py
+++ b/care/facility/models/bed.py
@@ -59,6 +59,10 @@ class Bed(BaseModel):
         return super().save(*args, **kwargs)
 
     def delete(self, *args, **kwargs) -> None:
+        if ConsultationBed.objects.filter(bed=self).exists():
+            error = f"Cannot delete Bed {self} because they are referenced as `bed` in ConsultationBed records."
+            raise ValidationError(error)
+
         AssetBed.objects.filter(bed=self).update(deleted=True)
         super().delete(*args, **kwargs)
 

--- a/care/facility/models/facility.py
+++ b/care/facility/models/facility.py
@@ -303,6 +303,7 @@ class Facility(FacilityBaseModel, FacilityPermissionMixin):
     @transaction.atomic
     def delete(self, *args):
         from care.facility.models.asset import Asset, AssetLocation
+        from care.facility.models.patient_sample import PatientSample
 
         AssetLocation.objects.filter(facility_id=self.id).update(deleted=True)
         Asset.objects.filter(
@@ -310,6 +311,10 @@ class Facility(FacilityBaseModel, FacilityPermissionMixin):
                 facility_id=self.id
             ).values_list("id", flat=True)
         ).update(deleted=True)
+        FacilityUser.objects.filter(facility=self).delete()
+        PatientSample.objects.filter(testing_facility=self).update(
+            testing_facility=None
+        )
         return super().delete(*args)
 
     @property

--- a/care/facility/models/patient_consultation.py
+++ b/care/facility/models/patient_consultation.py
@@ -266,6 +266,7 @@ class PatientConsultation(PatientBaseModel, ConsultationRelatedPermissionMixin):
         super().save(*args, **kwargs)
 
     def delete(self, *args):
+        from care.facility.models.bed import ConsultationBed
         from care.facility.models.patient_investigation import InvestigationValue
         from care.facility.models.patient_sample import PatientSample
 
@@ -276,6 +277,11 @@ class PatientConsultation(PatientBaseModel, ConsultationRelatedPermissionMixin):
         if PatientSample.objects.filter(consultation=self).exists():
             error = f"Cannot delete PatientConsultation {self} because they are referenced as `consultation` in PatientSample records."
             raise ValidationError(error)
+
+        if ConsultationBed.objects.filter(consultation=self).exists():
+            error = f"Cannot delete PatientConsultation {self} because they are referenced as `consultation` in ConsultationBed records."
+            raise ValidationError(error)
+
         return super().delete(*args)
 
     class Meta:

--- a/care/facility/tests/test_m2m_soft_delete_for_related_fields.py
+++ b/care/facility/tests/test_m2m_soft_delete_for_related_fields.py
@@ -109,7 +109,7 @@ class TestInvestigationValueDeletion(TestUtils, TestCase):
             self.district, self.facility, local_body=self.local_body
         )
         self.consultation = self.create_consultation(self.patient, self.facility)
-        self.investigation_group = self.create_investigation_group()
+        self.investigation_group = self.create_patient_investigation_group()
         self.investigation_session = self.create_patient_investigation_session(
             self.super_user
         )

--- a/care/facility/tests/test_m2m_soft_delete_for_related_fields.py
+++ b/care/facility/tests/test_m2m_soft_delete_for_related_fields.py
@@ -1,0 +1,426 @@
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from care.facility.models import (
+    FacilityUser,
+    InvestigationSession,
+    InvestigationValue,
+    PatientConsultation,
+    PatientInvestigation,
+    PatientInvestigationGroup,
+    PatientRegistration,
+    PatientSample,
+)
+from care.users.models import User
+from care.utils.tests.test_utils import TestUtils
+
+
+class TestFacilityUserDeletion(TestUtils, TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.state = cls.create_state()
+        cls.district = cls.create_district(cls.state)
+        cls.local_body = cls.create_local_body(cls.district)
+        cls.super_user = cls.create_super_user("su", cls.district)
+
+    def setUp(self):
+        self.facility = self.create_facility(
+            self.super_user, self.district, self.local_body
+        )
+
+        self.user1 = self.create_user(
+            "user1",
+            district=self.district,
+            local_body=self.local_body,
+        )
+        self.user2 = self.create_user(
+            "user2",
+            district=self.district,
+            local_body=self.local_body,
+        )
+        self.facility_user = self.create_facility_user(
+            self.facility, self.user1, self.user2
+        )
+
+    def test_facility_user_delete_when_related_facility_is_deleted(self):
+        self.assertTrue(FacilityUser.objects.filter(facility=self.facility).exists())
+
+        self.facility.delete()
+        self.assertFalse(FacilityUser.objects.filter(facility=self.facility).exists())
+
+    def test_facility_user_delete_when_related_user_is_deleted(self):
+        self.assertTrue(FacilityUser.objects.filter(user=self.user1).exists())
+
+        self.user1.delete()
+
+        self.assertFalse(
+            User.objects.filter(external_id=self.user1.external_id).exists()
+        )
+
+    def test_facility_user_delete_when_related_created_by_is_deleted_for_existing_facility_user(
+        self,
+    ):
+        # case 1 when facility user exist for create_by user
+        self.assertTrue(FacilityUser.objects.filter(created_by=self.user2).exists())
+
+        with self.assertRaises(ValidationError) as context:
+            self.user2.delete()
+
+        self.assertIn(
+            f"Cannot delete User {self.user2} because they are referenced as `created_by` in FacilityUser records.",
+            context.exception,
+        )
+
+        self.assertTrue(
+            User.objects.filter(external_id=self.user2.external_id).exists()
+        )
+
+    def test_facility_user_delete_when_related_created_by_is_deleted(self):
+        # case 2 when facility user doesn't exist for create_by user
+
+        self.assertTrue(FacilityUser.objects.filter(created_by=self.user2).exists())
+        FacilityUser.objects.filter(created_by=self.user2).delete()
+
+        self.user2.delete()
+
+        self.assertFalse(
+            User.objects.filter(external_id=self.user2.external_id).exists()
+        )
+
+
+class TestInvestigationValueDeletion(TestUtils, TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.state = cls.create_state()
+        cls.district = cls.create_district(cls.state)
+        cls.local_body = cls.create_local_body(cls.district)
+        cls.super_user = cls.create_super_user("superuser", cls.district)
+        cls.facility = cls.create_facility(cls.super_user, cls.district, cls.local_body)
+
+    def setUp(self):
+        # Create base objects for use in tests
+        self.patient = self.create_patient(
+            self.district, self.facility, local_body=self.local_body
+        )
+        self.consultation = self.create_consultation(self.patient, self.facility)
+        self.investigation_group = self.create_investigation_group()
+        self.investigation_session = self.create_patient_investigation_session(
+            self.super_user
+        )
+        self.investigation = self.create_patient_investigation(self.investigation_group)
+
+    def test_delete_patient_investigation_with_investigation_value(self):
+        # Create an InvestigationValue referencing the PatientInvestigation
+        InvestigationValue.objects.create(
+            investigation=self.investigation,
+            group=self.investigation_group,
+            consultation=self.consultation,
+            session=self.investigation_session,
+        )
+
+        # Attempt to delete the investigation
+        with self.assertRaises(ValidationError) as context:
+            self.investigation.delete()
+
+        self.assertIn(
+            f"Cannot delete PatientInvestigation {self.investigation!s} because they are referenced as `investigation` in InvestigationValue records.",
+            context.exception,
+        )
+
+        # Ensure the investigation still exists
+        self.assertTrue(
+            PatientInvestigation.objects.filter(pk=self.investigation.pk).exists()
+        )
+
+    def test_delete_patient_investigation_without_investigation_value(self):
+        # Ensure no InvestigationValue exists
+        InvestigationValue.objects.filter(investigation=self.investigation).delete()
+
+        # Delete the investigation
+        self.investigation.delete()
+
+        # Ensure the investigation is deleted
+        self.assertFalse(
+            PatientInvestigation.objects.filter(pk=self.investigation.pk).exists()
+        )
+
+    def test_delete_investigation_session_with_investigation_value(self):
+        # Create an InvestigationValue referencing the InvestigationSession
+        InvestigationValue.objects.create(
+            investigation=self.investigation,
+            group=self.investigation_group,
+            consultation=self.consultation,
+            session=self.investigation_session,
+        )
+
+        # Attempt to delete the session
+        with self.assertRaises(ValidationError) as context:
+            self.investigation_session.delete()
+
+        self.assertIn(
+            f"Cannot delete InvestigationSession {self.investigation_session.external_id} because they are referenced as `session` in InvestigationValue records.",
+            str(context.exception),
+        )
+
+        # Ensure the session still exists
+        self.assertTrue(
+            InvestigationSession.objects.filter(
+                pk=self.investigation_session.pk
+            ).exists()
+        )
+
+    def test_delete_investigation_session_without_investigation_value(self):
+        # Ensure no InvestigationValue exists
+        InvestigationValue.objects.filter(session=self.investigation_session).delete()
+
+        # Delete the session
+        self.investigation_session.delete()
+
+        # Ensure the session is deleted
+        self.assertFalse(
+            InvestigationSession.objects.filter(
+                pk=self.investigation_session.pk
+            ).exists()
+        )
+
+    def test_delete_patient_investigation_group_with_investigation_value(self):
+        # Create an InvestigationValue referencing the PatientInvestigationGroup
+        InvestigationValue.objects.create(
+            investigation=self.investigation,
+            group=self.investigation_group,
+            consultation=self.consultation,
+            session=self.investigation_session,
+        )
+
+        # Attempt to delete the group
+        with self.assertRaises(ValidationError) as context:
+            self.investigation_group.delete()
+
+        self.assertIn(
+            f"Cannot delete PatientInvestigationGroup {self.investigation_group.name} because they are referenced as `group` in InvestigationValue records.",
+            str(context.exception),
+        )
+
+        # Ensure the group still exists
+        self.assertTrue(
+            PatientInvestigationGroup.objects.filter(
+                pk=self.investigation_group.pk
+            ).exists()
+        )
+
+    def test_delete_patient_investigation_group_without_investigation_value(self):
+        # Ensure no InvestigationValue exists
+        InvestigationValue.objects.filter(group=self.investigation_group).delete()
+
+        # Delete the group
+        self.investigation_group.delete()
+
+        # Ensure the group is deleted
+        self.assertFalse(
+            PatientInvestigationGroup.objects.filter(
+                pk=self.investigation_group.pk
+            ).exists()
+        )
+
+    def test_delete_patient_consultation_with_investigation_value(self):
+        # Create an InvestigationValue referencing the PatientConsultation
+        InvestigationValue.objects.create(
+            investigation=self.investigation,
+            group=self.investigation_group,
+            consultation=self.consultation,
+            session=self.investigation_session,
+        )
+
+        # Attempt to delete the consultation
+        with self.assertRaises(ValidationError) as context:
+            self.consultation.delete()
+
+        self.assertIn(
+            f"Cannot delete PatientConsultation {self.consultation.external_id} because they are referenced as `consultation` in InvestigationValue records.",
+            str(context.exception),
+        )
+
+        # Ensure the consultation still exists
+        self.assertTrue(
+            PatientConsultation.objects.filter(pk=self.consultation.pk).exists()
+        )
+
+    def test_delete_patient_consultation_without_investigation_value(self):
+        # Ensure no InvestigationValue exists
+        InvestigationValue.objects.filter(consultation=self.consultation).delete()
+
+        # Delete the consultation
+        self.consultation.delete()
+
+        # Ensure the consultation is deleted
+        self.assertFalse(
+            PatientConsultation.objects.filter(pk=self.consultation.pk).exists()
+        )
+
+
+class TestPatientSampleDeletion(TestUtils, TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        # Create necessary related objects
+        cls.state = cls.create_state()
+        cls.district = cls.create_district(cls.state)
+        cls.local_body = cls.create_local_body(cls.district)
+        cls.super_user = cls.create_super_user("superuser", cls.district)
+        cls.facility = cls.create_facility(cls.super_user, cls.district, cls.local_body)
+
+    def setUp(self):
+        # Create patient and consultation for the tests
+        self.patient = self.create_patient(self.district, self.facility)
+        self.consultation = self.create_consultation(self.patient, self.facility)
+
+        # Create a user to act as the creator
+        self.user = self.create_user("test_user", district=self.district)
+
+        # Create a sample linked to the patient and consultation
+        self.sample = self.create_patient_sample(
+            self.patient, self.consultation, self.facility, self.user
+        )
+
+    def test_delete_patient_registration_with_related_sample(self):
+        # Ensure the sample is linked to the patient
+        self.assertTrue(PatientSample.objects.filter(patient=self.patient).exists())
+
+        # Attempt to delete the patient
+        with self.assertRaises(ValidationError) as context:
+            self.patient.delete()
+
+        self.assertIn(
+            f"Cannot delete PatientRegistration {self.patient} because they are referenced as `patient` in PatientSample records.",
+            str(context.exception),
+        )
+
+        # Ensure the patient and sample still exist
+        self.assertTrue(PatientRegistration.objects.filter(pk=self.patient.pk).exists())
+        self.assertTrue(PatientSample.objects.filter(pk=self.sample.pk).exists())
+
+    def test_delete_patient_registration_without_sample(self):
+        # Delete the sample first
+        self.sample.delete()
+
+        # Ensure the sample no longer exists
+        self.assertFalse(PatientSample.objects.filter(patient=self.patient).exists())
+
+        # Now delete the patient
+        self.patient.delete()
+
+        # Ensure the patient is deleted
+        self.assertFalse(
+            PatientRegistration.objects.filter(pk=self.patient.pk).exists()
+        )
+
+    def test_delete_patient_consultation_with_related_sample(self):
+        # Ensure the sample is linked to the consultation
+        self.assertTrue(
+            PatientSample.objects.filter(consultation=self.consultation).exists()
+        )
+
+        # Attempt to delete the consultation
+        with self.assertRaises(ValidationError) as context:
+            self.consultation.delete()
+
+        self.assertIn(
+            f"Cannot delete PatientConsultation {self.consultation} because they are referenced as `consultation` in PatientSample records.",
+            str(context.exception),
+        )
+
+        # Ensure the consultation and sample still exist
+        self.assertTrue(
+            PatientConsultation.objects.filter(pk=self.consultation.pk).exists()
+        )
+        self.assertTrue(PatientSample.objects.filter(pk=self.sample.pk).exists())
+
+    def test_delete_patient_consultation_without_sample(self):
+        # Delete the sample first
+        self.sample.delete()
+
+        # Ensure the sample no longer exists
+        self.assertFalse(
+            PatientSample.objects.filter(consultation=self.consultation).exists()
+        )
+
+        # Now delete the consultation
+        self.consultation.delete()
+
+        # Ensure the consultation is deleted
+        self.assertFalse(
+            PatientConsultation.objects.filter(pk=self.consultation.pk).exists()
+        )
+
+    def test_delete_patient_sample(self):
+        # Ensure the sample exists
+        self.assertTrue(PatientSample.objects.filter(pk=self.sample.pk).exists())
+
+        # Delete the sample
+        self.sample.delete()
+
+        # Ensure the sample is deleted
+        self.assertFalse(PatientSample.objects.filter(pk=self.sample.pk).exists())
+
+    def test_delete_created_by_user_sets_null_in_patient_sample(self):
+        # Ensure the created_by user is linked to the sample
+        self.assertEqual(self.sample.created_by, self.user)
+
+        # Delete the user
+        self.user.delete()
+
+        # Reload the sample and ensure `created_by` is now NULL
+        self.sample.refresh_from_db()
+        self.assertIsNone(self.sample.created_by)
+
+    def test_delete_last_edited_by_user_sets_null_in_patient_sample(self):
+        # Ensure the last_edited_by user is linked to the sample
+        self.assertEqual(self.sample.last_edited_by, self.user)
+
+        # Delete the user
+        self.user.delete()
+
+        # Reload the sample and ensure `last_edited_by` is now NULL
+        self.sample.refresh_from_db()
+        self.assertIsNone(self.sample.last_edited_by)
+
+    def test_delete_created_by_and_last_edited_by_users_sets_null_in_patient_sample(
+        self,
+    ):
+        # Ensure the created_by and last_edited_by users are linked to the sample
+        self.assertEqual(self.sample.created_by, self.user)
+        self.assertEqual(self.sample.last_edited_by, self.user)
+
+        # Delete the user
+        self.user.delete()
+
+        # Reload the sample and ensure both fields are now NULL
+        self.sample.refresh_from_db()
+        self.assertIsNone(self.sample.created_by)
+        self.assertIsNone(self.sample.last_edited_by)
+
+    def test_delete_user_sets_null_in_multiple_samples(self):
+        # Create another sample by the same user
+        sample2 = PatientSample.objects.create(
+            patient=self.patient,
+            consultation=self.consultation,
+            sample_type=0,
+            created_by=self.user,
+            last_edited_by=self.user,
+        )
+
+        # Ensure the user is linked to both samples
+        self.assertEqual(self.sample.created_by, self.user)
+        self.assertEqual(self.sample.last_edited_by, self.user)
+        self.assertEqual(sample2.created_by, self.user)
+        self.assertEqual(sample2.last_edited_by, self.user)
+
+        # Delete the user
+        self.user.delete()
+
+        # Reload both samples and ensure both fields are now NULL
+        self.sample.refresh_from_db()
+        sample2.refresh_from_db()
+        self.assertIsNone(self.sample.created_by)
+        self.assertIsNone(self.sample.last_edited_by)
+        self.assertIsNone(sample2.created_by)
+        self.assertIsNone(sample2.last_edited_by)

--- a/care/facility/tests/test_m2m_soft_delete_for_related_fields.py
+++ b/care/facility/tests/test_m2m_soft_delete_for_related_fields.py
@@ -140,7 +140,9 @@ class TestInvestigationValueDeletion(TestUtils, TestCase):
 
     def test_delete_patient_investigation_without_investigation_value(self):
         # Ensure no InvestigationValue exists
-        InvestigationValue.objects.filter(investigation=self.investigation).delete()
+        InvestigationValue.objects.filter(investigation=self.investigation).update(
+            deleted=True
+        )
 
         # Delete the investigation
         self.investigation.delete()
@@ -177,7 +179,9 @@ class TestInvestigationValueDeletion(TestUtils, TestCase):
 
     def test_delete_investigation_session_without_investigation_value(self):
         # Ensure no InvestigationValue exists
-        InvestigationValue.objects.filter(session=self.investigation_session).delete()
+        InvestigationValue.objects.filter(session=self.investigation_session).update(
+            deleted=True
+        )
 
         # Delete the session
         self.investigation_session.delete()
@@ -216,7 +220,9 @@ class TestInvestigationValueDeletion(TestUtils, TestCase):
 
     def test_delete_patient_investigation_group_without_investigation_value(self):
         # Ensure no InvestigationValue exists
-        InvestigationValue.objects.filter(group=self.investigation_group).delete()
+        InvestigationValue.objects.filter(group=self.investigation_group).update(
+            deleted=True
+        )
 
         # Delete the group
         self.investigation_group.delete()
@@ -253,7 +259,9 @@ class TestInvestigationValueDeletion(TestUtils, TestCase):
 
     def test_delete_patient_consultation_without_investigation_value(self):
         # Ensure no InvestigationValue exists
-        InvestigationValue.objects.filter(consultation=self.consultation).delete()
+        InvestigationValue.objects.filter(consultation=self.consultation).update(
+            deleted=True
+        )
 
         # Delete the consultation
         self.consultation.delete()

--- a/care/users/models.py
+++ b/care/users/models.py
@@ -408,11 +408,16 @@ class User(AbstractUser):
 
     @transaction.atomic
     def delete(self, *args, **kwargs):
+        from care.facility.models.asset import UserDefaultAssetLocation
         from care.facility.models.facility import FacilityUser
         from care.facility.models.patient_sample import PatientSample
 
         if FacilityUser.objects.filter(created_by=self).exists():
             error = f"Cannot delete User {self.username} because they are referenced as `created_by` in FacilityUser records."
+            raise ValidationError(error)
+
+        if UserDefaultAssetLocation.objects.filter(user=self).exists():
+            error = f"Cannot delete User {self} because they are referenced as `user` in UserDefaultAssetLocation records."
             raise ValidationError(error)
 
         FacilityUser.objects.filter(user=self).delete()

--- a/care/utils/tests/test_utils.py
+++ b/care/utils/tests/test_utils.py
@@ -723,6 +723,24 @@ class TestUtils:
         return Prescription.objects.create(**data)
 
     @classmethod
+    def create_facility_user(
+        cls, facility: Facility, user: User, created_by: User, **kwargs
+    ) -> FacilityUser:
+        data = {
+            "facility": facility,
+            "created_by": created_by,
+            "user": user,
+        }
+        data.update(**kwargs)
+        return FacilityUser.objects.create(**data)
+
+    @classmethod
+    def create_investigation_group(cls, **kwargs) -> PatientInvestigationGroup:
+        data = {"name": now()}
+        data.update(**kwargs)
+        return PatientInvestigationGroup.objects.create(**data)
+
+    @classmethod
     def create_assetbed(cls, bed: Bed, asset: Asset, **kwargs) -> AssetBed:
         data = {"bed": bed, "asset": asset}
         data.update(kwargs)

--- a/care/utils/tests/test_utils.py
+++ b/care/utils/tests/test_utils.py
@@ -37,7 +37,12 @@ from care.facility.models import (
     User,
     Ward,
 )
-from care.facility.models.asset import Asset, AssetLocation
+from care.facility.models.asset import (
+    Asset,
+    AssetLocation,
+    FacilityDefaultAssetLocation,
+    UserDefaultAssetLocation,
+)
 from care.facility.models.bed import AssetBed, Bed, ConsultationBed
 from care.facility.models.facility import FacilityUser
 from care.facility.models.icd11_diagnosis import (
@@ -745,6 +750,20 @@ class TestUtils:
         data = {"bed": bed, "asset": asset}
         data.update(kwargs)
         return AssetBed.objects.create(**data)
+
+    @classmethod
+    def create_facility_default_asset_location(
+        cls, facility: Facility, location: AssetLocation
+    ) -> FacilityDefaultAssetLocation:
+        data = {"facility": facility, "location": location}
+        return FacilityDefaultAssetLocation.objects.create(**data)
+
+    @classmethod
+    def create_user_default_asset_location(
+        cls, user: User, location: AssetLocation
+    ) -> UserDefaultAssetLocation:
+        data = {"user": user, "location": location}
+        return UserDefaultAssetLocation.objects.create(**data)
 
     def get_list_representation(self, obj) -> dict:
         """

--- a/care/utils/tests/test_utils.py
+++ b/care/utils/tests/test_utils.py
@@ -740,12 +740,6 @@ class TestUtils:
         return FacilityUser.objects.create(**data)
 
     @classmethod
-    def create_investigation_group(cls, **kwargs) -> PatientInvestigationGroup:
-        data = {"name": now()}
-        data.update(**kwargs)
-        return PatientInvestigationGroup.objects.create(**data)
-
-    @classmethod
     def create_assetbed(cls, bed: Bed, asset: Asset, **kwargs) -> AssetBed:
         data = {"bed": bed, "asset": asset}
         data.update(kwargs)


### PR DESCRIPTION
## Proposed Changes

- Manually cascade delete M2M models when related model is deleted

### Associated Issue

- fixes #1330 


## Merge Checklist

- [x] Tests added/fixed
- [x] Linting Complete

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced deletion logic across multiple models to prevent deletion if referenced elsewhere, ensuring data integrity.
	- New validation checks for deleting `AssetLocation`, `Bed`, `Facility`, `PatientRegistration`, `PatientConsultation`, and investigation-related records.
	- Improved user deletion logic with transaction handling and validation checks.

- **Bug Fixes**
	- Improved error handling during deletion processes to raise appropriate validation errors.

- **Tests**
	- Added comprehensive unit tests to validate the new deletion behaviors and ensure referential integrity across related models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->