### PR TITLE
fixed dockerfile for local plugin installation

### DIFF
--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -37,11 +37,9 @@ RUN python -m venv /.venv
 COPY Pipfile Pipfile.lock $APP_HOME/
 RUN --mount=type=cache,target=/root/.cache/pip pipenv  install --system --categories "packages dev-packages docs"
 
-COPY plugs/ $APP_HOME/plugs/
-COPY install_plugins.py plug_config.py $APP_HOME/
-RUN --mount=type=cache,target=/root/.cache/pip python3 $APP_HOME/install_plugins.py
-
 COPY . $APP_HOME/
+
+RUN --mount=type=cache,target=/root/.cache/pip python3 $APP_HOME/install_plugins.py
 
 HEALTHCHECK \
   --interval=10s \


### PR DESCRIPTION
## Proposed Changes

- Local plugins weren't getting installed after the recent changes in dockerfile.
- **Issue** - local plugin folder was copied after the running the install command

- Tested locally

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Streamlined the installation process for the Typst application.
	- Modified the order of operations for plugin installation.
	- Ensured correct binary downloads based on system architecture.
	- Health check configuration remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->