### PR TITLE
Used UserAssignedSerializer instead of UserBaseMinimumSerializer for assigned_to_object in patient details

### DIFF
--- a/care/facility/api/serializers/patient.py
+++ b/care/facility/api/serializers/patient.py
@@ -40,7 +40,7 @@ from care.users.api.serializers.lsg import (
     StateSerializer,
     WardSerializer,
 )
-from care.users.api.serializers.user import UserBaseMinimumSerializer
+from care.users.api.serializers.user import UserAssignedSerializer, UserBaseMinimumSerializer
 from care.users.models import User
 from care.utils.notification_handler import NotificationGenerator
 from care.utils.queryset.facility import get_home_facility_queryset
@@ -86,7 +86,7 @@ class PatientListSerializer(serializers.ModelSerializer):
     )
     source = ChoiceField(choices=PatientRegistration.SourceChoices)
 
-    assigned_to_object = UserBaseMinimumSerializer(source="assigned_to", read_only=True)
+    assigned_to_object = UserAssignedSerializer(source="assigned_to", read_only=True)
 
     class Meta:
         model = PatientRegistration
@@ -167,7 +167,7 @@ class PatientDetailSerializer(PatientListSerializer):
         choices=PatientRegistration.VaccineChoices, required=False, allow_null=True
     )
 
-    assigned_to_object = UserBaseMinimumSerializer(source="assigned_to", read_only=True)
+    assigned_to_object = UserAssignedSerializer(source="assigned_to", read_only=True)
 
     assigned_to = serializers.PrimaryKeyRelatedField(
         queryset=User.objects.all(), required=False, allow_null=True

--- a/care/users/api/serializers/user.py
+++ b/care/users/api/serializers/user.py
@@ -388,7 +388,7 @@ class UserBaseMinimumSerializer(serializers.ModelSerializer):
             "user_type",
             "last_login",
             "read_profile_picture_url",
-            "phone_number"
+            "phone_number",
         )
 
 

--- a/care/users/api/serializers/user.py
+++ b/care/users/api/serializers/user.py
@@ -388,6 +388,7 @@ class UserBaseMinimumSerializer(serializers.ModelSerializer):
             "user_type",
             "last_login",
             "read_profile_picture_url",
+            "alt_phone_number"
         )
 
 

--- a/care/users/api/serializers/user.py
+++ b/care/users/api/serializers/user.py
@@ -388,7 +388,7 @@ class UserBaseMinimumSerializer(serializers.ModelSerializer):
             "user_type",
             "last_login",
             "read_profile_picture_url",
-            "alt_phone_number"
+            "phone_number"
         )
 
 

--- a/care/users/api/serializers/user.py
+++ b/care/users/api/serializers/user.py
@@ -388,7 +388,6 @@ class UserBaseMinimumSerializer(serializers.ModelSerializer):
             "user_type",
             "last_login",
             "read_profile_picture_url",
-            "phone_number",
         )
 
 


### PR DESCRIPTION
## Proposed Changes

- Fixes #2623 
- Used UserAssignedSerializer instead of UserBaseMinimumSerializer for assigned_to_object in patient details for volunteer contact

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
	- Updated user assignment serialization for patient records
	- Enhanced representation of assigned user details in patient-related data structures
<!-- end of auto-generated comment: release notes by coderabbit.ai -->