### PR TITLE
Enforce `/scripts` directory uses LF line endings on all systems

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+scripts/* text eol=lf

--- a/README.md
+++ b/README.md
@@ -60,13 +60,6 @@ to load dummy data for testing run:
 make load-dummy-data
 ```
 
-> [!NOTE]
-> If you are unable to compose up care in windows, ensure line endings are set to `LF` (`docker-entrypoint.sh` won't
-> work with `CRLF` line endings).
-> ```
-> git config core.autocrlf false
-> ```
-
 #### Docker
 
 Prebuilt docker images for server deployments are available


### PR DESCRIPTION
## Proposed Changes

- Enforce `/scripts` directory uses LF line endings on all systems

## Merge Checklist

- [x] Update docs in `/docs`
- [x] Linting Complete


@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated README.md to include a note on Windows compatibility with Docker Compose, emphasizing the need for LF line endings to ensure proper script functionality.
	- Added a command to disable automatic line ending conversion in Git for users experiencing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->