### PR TITLE
chore: Add total doctors count to hospital doctor list response

### DIFF
--- a/care/facility/api/serializers/hospital_doctor.py
+++ b/care/facility/api/serializers/hospital_doctor.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from django.db.models import Sum
 
 from care.facility.api.serializers import TIMESTAMP_FIELDS
 from care.facility.models import DOCTOR_TYPES, HospitalDoctors
@@ -19,11 +20,14 @@ class HospitalDoctorSerializer(serializers.ModelSerializer):
         )
         exclude = (*TIMESTAMP_FIELDS, "facility", "external_id")
 
-        def to_representation(self, instance):
-            representation = super().to_representation(instance)
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+        try:
             representation["total_doctors"] = (
                 HospitalDoctors.objects.filter(facility=instance.facility)
                 .aggregate(total_doctors=Sum("count"))["total_doctors"]
                 or 0
             )
-            return representation
+        except Exception as e:
+            representation["total_doctors"] = 0
+        return representation

--- a/care/facility/api/serializers/hospital_doctor.py
+++ b/care/facility/api/serializers/hospital_doctor.py
@@ -8,11 +8,22 @@ from care.utils.serializers.fields import ChoiceField
 class HospitalDoctorSerializer(serializers.ModelSerializer):
     area_text = ChoiceField(choices=DOCTOR_TYPES, read_only=True, source="area")
     id = serializers.UUIDField(source="external_id", read_only=True)
+    total_doctors = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = HospitalDoctors
         read_only_fields = (
             "id",
             "area_text",
+            "total_doctors"
         )
         exclude = (*TIMESTAMP_FIELDS, "facility", "external_id")
+
+        def to_representation(self, instance):
+            representation = super().to_representation(instance)
+            representation["total_doctors"] = (
+                HospitalDoctors.objects.filter(facility=instance.facility)
+                .aggregate(total_doctors=Sum("count"))["total_doctors"]
+                or 0
+            )
+            return representation

--- a/care/facility/api/viewsets/hospital_doctor.py
+++ b/care/facility/api/viewsets/hospital_doctor.py
@@ -2,6 +2,7 @@ from dry_rest_permissions.generics import DRYPermissions
 from rest_framework.generics import get_object_or_404
 from rest_framework.mixins import ListModelMixin
 from rest_framework.permissions import IsAuthenticated
+from django.db.models import Sum
 
 from care.facility.api.serializers.hospital_doctor import HospitalDoctorSerializer
 from care.facility.api.viewsets import FacilityBaseViewset
@@ -41,6 +42,12 @@ class HospitalDoctorViewSet(FacilityBaseViewset, ListModelMixin):
         if not self.request.user.is_superuser:
             facility_qs.filter(users__id__exact=self.request.user.id)
         return get_object_or_404(facility_qs)
+
+    def list(self, request, *args, **kwargs):
+        response = super().list(request, *args, **kwargs)
+        total_doctors = self.get_queryset().aggregate(total_doctors=Sum('count'))['total_doctors']
+        response.data["total_doctors"] = total_doctors
+        return response
 
     def perform_create(self, serializer):
         serializer.save(facility=self.get_facility())

--- a/care/facility/api/viewsets/hospital_doctor.py
+++ b/care/facility/api/viewsets/hospital_doctor.py
@@ -8,10 +8,13 @@ from care.facility.api.viewsets import FacilityBaseViewset
 from care.facility.models import Facility, HospitalDoctors
 from care.users.models import User
 from care.utils.cache.cache_allowed_facilities import get_accessible_facilities
+
+
 class HospitalDoctorViewSet(FacilityBaseViewset, ListModelMixin):
     serializer_class = HospitalDoctorSerializer
     queryset = HospitalDoctors.objects.filter(facility__deleted=False)
     permission_classes = (IsAuthenticated, DRYPermissions)
+
     def get_queryset(self):
         user = self.request.user
         queryset = self.queryset.filter(
@@ -27,8 +30,10 @@ class HospitalDoctorViewSet(FacilityBaseViewset, ListModelMixin):
             allowed_facilities = get_accessible_facilities(user)
             queryset = queryset.filter(facility__id__in=allowed_facilities)
         return queryset
+
     def get_object(self):
         return get_object_or_404(self.get_queryset(), area=self.kwargs.get("pk"))
+
     def get_facility(self):
         facility_qs = Facility.objects.filter(
             external_id=self.kwargs.get("facility_external_id")

--- a/care/facility/api/viewsets/hospital_doctor.py
+++ b/care/facility/api/viewsets/hospital_doctor.py
@@ -46,7 +46,7 @@ class HospitalDoctorViewSet(FacilityBaseViewset, ListModelMixin):
     def list(self, request, *args, **kwargs):
         response = super().list(request, *args, **kwargs)
         total_doctors = self.get_queryset().aggregate(total_doctors=Sum('count'))['total_doctors']
-        response.data["total_doctors"] = total_doctors
+        response.data["total_doctors"] = total_doctors or 0
         return response
 
     def perform_create(self, serializer):

--- a/care/facility/api/viewsets/hospital_doctor.py
+++ b/care/facility/api/viewsets/hospital_doctor.py
@@ -2,20 +2,16 @@ from dry_rest_permissions.generics import DRYPermissions
 from rest_framework.generics import get_object_or_404
 from rest_framework.mixins import ListModelMixin
 from rest_framework.permissions import IsAuthenticated
-from django.db.models import Sum
 
 from care.facility.api.serializers.hospital_doctor import HospitalDoctorSerializer
 from care.facility.api.viewsets import FacilityBaseViewset
 from care.facility.models import Facility, HospitalDoctors
 from care.users.models import User
 from care.utils.cache.cache_allowed_facilities import get_accessible_facilities
-
-
 class HospitalDoctorViewSet(FacilityBaseViewset, ListModelMixin):
     serializer_class = HospitalDoctorSerializer
     queryset = HospitalDoctors.objects.filter(facility__deleted=False)
     permission_classes = (IsAuthenticated, DRYPermissions)
-
     def get_queryset(self):
         user = self.request.user
         queryset = self.queryset.filter(
@@ -31,10 +27,8 @@ class HospitalDoctorViewSet(FacilityBaseViewset, ListModelMixin):
             allowed_facilities = get_accessible_facilities(user)
             queryset = queryset.filter(facility__id__in=allowed_facilities)
         return queryset
-
     def get_object(self):
         return get_object_or_404(self.get_queryset(), area=self.kwargs.get("pk"))
-
     def get_facility(self):
         facility_qs = Facility.objects.filter(
             external_id=self.kwargs.get("facility_external_id")
@@ -42,12 +36,6 @@ class HospitalDoctorViewSet(FacilityBaseViewset, ListModelMixin):
         if not self.request.user.is_superuser:
             facility_qs.filter(users__id__exact=self.request.user.id)
         return get_object_or_404(facility_qs)
-
-    def list(self, request, *args, **kwargs):
-        response = super().list(request, *args, **kwargs)
-        total_doctors = self.get_queryset().aggregate(total_doctors=Sum('count'))['total_doctors']
-        response.data["total_doctors"] = total_doctors or 0
-        return response
 
     def perform_create(self, serializer):
         serializer.save(facility=self.get_facility())


### PR DESCRIPTION
## Proposed Changes

- fixes #2628 
- Auto-scroll should stop at the staff capacity section instead of the page's top.
- Total capacity card should display the total staff capacity across all pages.

### Associated Issue

- Fix reference Frontend: [[Issue #9122](https://github.com/ohcnetwork/care_fe/issues/9122)]
- Fix reference Frontend Pull Request: [[PR #9275](https://github.com/ohcnetwork/care_fe/pull/9275)]

https://github.com/user-attachments/assets/d34b76ef-dd5f-4a0e-8775-9fd7de7c9008




## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new read-only field, `total_doctors`, displaying the total count of doctors associated with a facility.
	- Enhanced data representation with a customized output method for better clarity on doctor counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->