### PR TITLE
[Staging-patch] Revert helathcheck instruction to work with older docker runtimes

### DIFF
--- a/docker/prod.Dockerfile
+++ b/docker/prod.Dockerfile
@@ -77,10 +77,9 @@ COPY --chown=django:django . $APP_HOME
 USER django
 
 HEALTHCHECK \
-  --start-period=20s \
-  --start-interval=1s \
   --interval=30s \
   --timeout=5s \
+  --start-period=10s \
   --retries=12 \
   CMD ["./healthcheck.sh"]
 


### PR DESCRIPTION
## Proposed Changes

- Revert helathcheck instruction to work with older docker runtimes

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins
