### PR TITLE
Facility Users filter out deleted users

### DIFF
--- a/care/facility/api/viewsets/facility_users.py
+++ b/care/facility/api/viewsets/facility_users.py
@@ -39,6 +39,7 @@ class FacilityUserViewSet(GenericViewSet, mixins.ListModelMixin):
                 external_id=self.kwargs.get("facility_external_id"),
             )
             queryset = facility.users.filter(
+                is_active=True,
                 deleted=False,
             ).order_by("-last_login")
             return queryset.prefetch_related(

--- a/care/facility/tests/test_facilityuser_api.py
+++ b/care/facility/tests/test_facilityuser_api.py
@@ -65,3 +65,26 @@ class FacilityUserTest(TestUtils, APITestCase):
         self.client.force_authenticate(user=district_lab_admin)
         response = self.client.get(f"/api/v1/facility/{self.facility.external_id}/")
         self.assertIs(response.status_code, status.HTTP_200_OK)
+
+    def test_user_is_not_listed_if_deleted(self):
+        # Testing FE's delete functionality (soft delete/is_active is set to false when user is deleted)
+        response = self.client.get(
+            f"/api/v1/facility/{self.facility.external_id}/get_users/"
+        )
+        response_json = response.json()
+        results = response_json["results"]
+        self.assertIs(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(results), 2)
+        self.assertIn(self.super_user.username, [user["username"] for user in results])
+        self.assertIn(self.user.username, [user["username"] for user in results])
+        self.user.is_active = False
+        self.user.save()
+        response = self.client.get(
+            f"/api/v1/facility/{self.facility.external_id}/get_users/"
+        )
+        response_json = response.json()
+        results = response_json["results"]
+        self.assertIs(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(results), 1)
+        self.assertIn(self.super_user.username, [user["username"] for user in results])
+        self.assertNotIn(self.user.username, [user["username"] for user in results])


### PR DESCRIPTION
## Proposed Changes

- In UserViewSet, delete route sets `is_active` flag to be false, which we aren't filtering out in FacilityUsers, resulting in deleted users being displayed in Facility Users page, Doctors Connect and LinkedFacilityUsers (used in Shift update).

### Associated Issue

- [#9271](https://github.com/ohcnetwork/care_fe/issues/9271) on FE

## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced user retrieval to include only active users associated with a facility.
- **Bug Fixes**
	- Added a test to ensure soft-deleted users are excluded from the user listing in API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->