### PR TITLE
Fixing list asset bed preset and list bed preset 

### DIFF
--- a/care/facility/api/viewsets/camera_preset.py
+++ b/care/facility/api/viewsets/camera_preset.py
@@ -38,7 +38,7 @@ class AssetBedCameraPresetViewSet(ModelViewSet):
 
 class CameraPresetViewSet(GenericViewSet, ListModelMixin):
     serializer_class = CameraPresetSerializer
-    queryset = CameraPreset.objects.all().select_related(
+    queryset = CameraPreset.objects.filter(asset_bed__deleted=False).select_related(
         "asset_bed", "created_by", "updated_by"
     )
     lookup_field = "external_id"

--- a/care/facility/tests/test_assetbed_api.py
+++ b/care/facility/tests/test_assetbed_api.py
@@ -425,6 +425,49 @@ class AssetBedCameraPresetViewSetTestCase(TestUtils, APITestCase):
     def get_base_url(self, asset_bed_id=None):
         return f"/api/v1/assetbed/{asset_bed_id or self.asset_bed1.external_id}/camera_presets/"
 
+
+    def test_list_bed_with_deleted_assetbed(self):
+        # self.asset_bed1.update(deleted=)
+        res=self.client.post(
+            self.get_base_url(self.asset_bed1.external_id),
+            {
+                "name": "Preset with proper position",
+                "position": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "zoom": 1.0,
+                },
+            },
+            format="json",
+        )
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)
+        res=self.client.post(
+            self.get_base_url(self.asset_bed2.external_id),
+            {
+                "name": "Preset with proper position 2",
+                "position": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "zoom": 1.0,
+                },
+            },
+            format="json",
+        )
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)
+
+        res = self.client.get(
+            f"/api/v1/bed/{self.bed.external_id}/camera_presets/"
+        )
+        self.assertEqual(len(res.json()["results"]),2)
+
+        self.asset_bed1.delete()
+        self.asset_bed1.refresh_from_db()
+        res = self.client.get(
+            f"/api/v1/bed/{self.bed.external_id}/camera_presets/"
+        )
+        self.assertEqual(len(res.json()["results"]),1)
+
+
     def test_create_camera_preset_without_position(self):
         res = self.client.post(
             self.get_base_url(),

--- a/care/facility/tests/test_assetbed_api.py
+++ b/care/facility/tests/test_assetbed_api.py
@@ -425,10 +425,8 @@ class AssetBedCameraPresetViewSetTestCase(TestUtils, APITestCase):
     def get_base_url(self, asset_bed_id=None):
         return f"/api/v1/assetbed/{asset_bed_id or self.asset_bed1.external_id}/camera_presets/"
 
-
     def test_list_bed_with_deleted_assetbed(self):
-        # self.asset_bed1.update(deleted=)
-        res=self.client.post(
+        res = self.client.post(
             self.get_base_url(self.asset_bed1.external_id),
             {
                 "name": "Preset with proper position",
@@ -441,7 +439,7 @@ class AssetBedCameraPresetViewSetTestCase(TestUtils, APITestCase):
             format="json",
         )
         self.assertEqual(res.status_code, status.HTTP_201_CREATED)
-        res=self.client.post(
+        res = self.client.post(
             self.get_base_url(self.asset_bed2.external_id),
             {
                 "name": "Preset with proper position 2",
@@ -455,18 +453,13 @@ class AssetBedCameraPresetViewSetTestCase(TestUtils, APITestCase):
         )
         self.assertEqual(res.status_code, status.HTTP_201_CREATED)
 
-        res = self.client.get(
-            f"/api/v1/bed/{self.bed.external_id}/camera_presets/"
-        )
-        self.assertEqual(len(res.json()["results"]),2)
+        res = self.client.get(f"/api/v1/bed/{self.bed.external_id}/camera_presets/")
+        self.assertEqual(len(res.json()["results"]), 2)
 
         self.asset_bed1.delete()
         self.asset_bed1.refresh_from_db()
-        res = self.client.get(
-            f"/api/v1/bed/{self.bed.external_id}/camera_presets/"
-        )
-        self.assertEqual(len(res.json()["results"]),1)
-
+        res = self.client.get(f"/api/v1/bed/{self.bed.external_id}/camera_presets/")
+        self.assertEqual(len(res.json()["results"]), 1)
 
     def test_create_camera_preset_without_position(self):
         res = self.client.post(


### PR DESCRIPTION
## Proposed Changes

Fixed : #2619  

- Added filter with `deleted=False` for list bed preset, to fix listing deleted assetbed beds

## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the camera preset retrieval to exclude presets linked to deleted asset beds, ensuring more accurate data display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->