### PR TITLE
Allow to use maintenance while the migrations are in progress

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -424,7 +424,7 @@ CELERY_TASK_SOFT_TIME_LIMIT = 1800
 # Maintenance Mode
 # ------------------------------------------------------------------------------
 # https://github.com/fabiocaccamo/django-maintenance-mode/tree/main#configuration-optional
-MAINTENANCE_MODE = int(env("MAINTENANCE_MODE", default="0"))
+MAINTENANCE_MODE_STATE_BACKEND = "maintenance_mode.backends.CacheBackend"
 
 #  Password Reset
 # ------------------------------------------------------------------------------

--- a/config/views.py
+++ b/config/views.py
@@ -1,6 +1,9 @@
 from django.conf import settings
 from django.http import JsonResponse
 from django.shortcuts import render
+from maintenance_mode.decorators import (
+    force_maintenance_mode_off,
+)
 
 
 def app_version(request):
@@ -11,5 +14,6 @@ def home_view(request):
     return render(request, "pages/home.html")
 
 
+@force_maintenance_mode_off
 def ping(request):
     return JsonResponse({"status": "OK"})

--- a/scripts/celery_beat.sh
+++ b/scripts/celery_beat.sh
@@ -1,14 +1,22 @@
 #!/bin/bash
 printf "celery-beat" > /tmp/container-role
 
-set -euo pipefail
+set -eo pipefail
 
 ./wait_for_db.sh
 ./wait_for_redis.sh
 
+if [[ "${AUTO_MAINTENANCE_MODE}" == "true" ]]; then
+    python manage.py maintenance_mode on
+fi
+
 python manage.py migrate --noinput
 python manage.py compilemessages -v 0
 python manage.py load_redis_index
+
+if [[ "${AUTO_MAINTENANCE_MODE}" == "true" ]]; then
+    python manage.py maintenance_mode off
+fi
 
 touch /tmp/healthy
 


### PR DESCRIPTION
## Proposed Changes

- Allow to use maintenance while the migrations are in progress

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a more structured backend approach for managing maintenance mode.
	- Added new environment variables for rate limiting, SMS notifications, and cloud storage configurations.
	- Implemented a decorator to ensure maintenance mode is disabled for specific endpoints.
	- Enhanced script to handle maintenance mode during database migrations.

- **Bug Fixes**
	- Adjusted script behavior to ensure proper toggling of maintenance mode during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->