### PR TITLE
Serialize ServiceRequest properly to get requester fields

### DIFF
--- a/care/emr/resources/diagnostic_report/spec.py
+++ b/care/emr/resources/diagnostic_report/spec.py
@@ -201,6 +201,9 @@ class DiagnosticReportReadSpec(BaseDiagnosticReportSpec):
 
     @classmethod
     def perform_extra_serialization(cls, mapping, obj):
+        mapping["based_on"] = ServiceRequestReadSpec.serialize(obj.based_on).model_dump(
+            exclude=["meta"]
+        )
         mapping["id"] = obj.external_id
 
         mapping["subject"] = PatientDetailSerializer(obj.subject).data

--- a/care/emr/resources/service_request/spec.py
+++ b/care/emr/resources/service_request/spec.py
@@ -203,7 +203,7 @@ class ServiceRequestReadSpec(BaseServiceRequestSpec):
 
     @classmethod
     def perform_extra_serialization(cls, mapping, obj):
-        mapping["id"] = obj.external_id
+        mapping["id"] = obj.id
 
         mapping["subject"] = PatientDetailSerializer(obj.subject).data
         mapping["encounter"] = PatientConsultationSerializer(obj.encounter).data

--- a/care/emr/resources/specimen/spec.py
+++ b/care/emr/resources/specimen/spec.py
@@ -204,6 +204,10 @@ class SpecimenReadSpec(BaseSpecimenSpec):
             else None
         )
 
+        mapping["request"] = ServiceRequestReadSpec.serialize(obj.request).model_dump(
+            exclude=["meta"]
+        )
+
 
 class SpecimenCollectRequest(BaseModel):
     identifier: str | None = Field(


### PR DESCRIPTION
## Proposed Changes

- Serialize ServiceRequest properly to get requester fields, as it is not returning `requester` details with default ServiceRequest spec serializers 

### Associated Issue

- Link to issue here, explain how the proposed solution will solve the reported issue/ feature request.

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_


