### PR TITLE
Fix Karnataka district names in data files

### DIFF
--- a/data/india/states-and-districts.json
+++ b/data/india/states-and-districts.json
@@ -77,7 +77,7 @@
   {
     "state": "Karnataka",
     "slug": "karnataka",
-    "districts": "Bagalkot, Ballari (Bellary), Belagavi (Belgaum), Bengaluru (Bangalore) Rural, Bengaluru (Bangalore) Urban, Bidar, Chamarajanagar, Chikballapur, Chikkamagaluru (Chikmagalur), Chitradurga, Dakshina Kannada, Davangere, Dharwad, Gadag, Hassan, Haveri, Kalaburagi (Gulbarga), Kodagu, Kolar, Koppal, Mandya, Mysuru (Mysore), Raichur, Ramanagara, Shivamogga (Shimoga), Tumakuru (Tumkur), Udupi, Uttara Kannada (Karwar), Vijayapura (Bijapur), Yadgir"
+    "districts": "Bagalkote, Ballari, Belagavi, Bengaluru Rural, Bengaluru Urban, Bidar, Chamarajanagara, Chikkaballapura, Chikkamagaluru, Chitradurga, Dakshina Kannada, Davangere, Dharwad, Gadag, Hassan, Haveri, Kalaburagi, Kodagu, Kolar, Koppal, Mandya, Mysuru, Raichur, Ramanagara, Shivamogga, Tumakuru, Udupi, Uttara Kannada, Vijayapura, Yadgir"
   },
   {
     "state": "Kerala",


### PR DESCRIPTION
Correct district names for Karnataka to align with the local self-government files.

| **Old Name**                     | **New Name**            |
|----------------------------------|-------------------------|
| Bagalkot                         | Bagalkote               |
| Ballari (Bellary)               | Ballari                 |
| Belagavi (Belgaum)              | Belagavi                |
| Bengaluru (Bangalore) Rural      | Bengaluru Rural         |
| Bengaluru (Bangalore) Urban      | Bengaluru Urban         |
| Chamarajanagar                   | Chamarajanagara         |
| Chikballapur                     | Chikkaballapura         |
| Chikkamagaluru (Chikmagalur)     | Chikkamagaluru          |
| Kalaburagi (Gulbarga)            | Kalaburagi              |
| Mysuru (Mysore)                  | Mysuru                  |
| Shivamogga (Shimoga)             | Shivamogga              |
| Tumakuru (Tumkur)                | Tumakuru                |
| Uttara Kannada (Karwar)          | Uttara Kannada          |
| Vijayapura (Bijapur)             | Vijayapura              |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated district names for Karnataka state to reflect official/current naming conventions
	- Corrected spellings and simplified district names
	- Removed parenthetical alternate names from district listings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->