### PR TITLE
Move validate_data to base EMR viewset and add slot_type filter in availability query

### DIFF
--- a/care/emr/api/viewsets/base.py
+++ b/care/emr/api/viewsets/base.py
@@ -94,9 +94,6 @@ class EMRCreateMixin:
     def authorize_create(self, instance):
         pass
 
-    def validate_data(self, instance, model_obj=None):
-        pass
-
     def create(self, request, *args, **kwargs):
         return Response(self.handle_create(request.data))
 
@@ -252,6 +249,9 @@ class EMRBaseViewSet(GenericViewSet):
         return get_object_or_404(
             queryset, **{self.lookup_field: self.kwargs[self.lookup_field]}
         )
+
+    def validate_data(self, instance, model_obj=None):
+        pass
 
     def fetch_encounter_from_instance(self, instance):
         return instance.encounter

--- a/care/emr/api/viewsets/scheduling/availability.py
+++ b/care/emr/api/viewsets/scheduling/availability.py
@@ -223,7 +223,8 @@ class SlotViewSet(EMRRetrieveMixin, EMRBaseViewSet):
         availabilities = {}
         for schedule in schedules:
             availabilities[schedule["id"]] = Availability.objects.filter(
-                schedule_id=schedule["id"]
+                schedule_id=schedule["id"],
+                slot_type=SlotTypeOptions.appointment.value,
             ).values()
 
         availability_exceptions = AvailabilityException.objects.filter(


### PR DESCRIPTION

## Proposed Changes

- Move validate_data to base EMR viewset 
- Add slot_type filter in availability query

### Associated Issue

- Link to issue here, explain how the proposed solution will solve the reported issue/ feature request.

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated availability statistics to only consider appointment slots
	- Restored data validation method placeholder in base viewset

<!-- end of auto-generated comment: release notes by coderabbit.ai -->