### PR TITLE
fixes heatmap API edge case

### DIFF
--- a/care/emr/api/viewsets/scheduling/availability.py
+++ b/care/emr/api/viewsets/scheduling/availability.py
@@ -269,7 +269,7 @@ class SlotViewSet(EMRRetrieveMixin, EMRBaseViewSet):
 
         booked_slots = (
             TokenSlot.objects.filter(
-                start_datetime__date__lte=request_data.to_date,
+                start_datetime__lte=request_data.to_date,
                 end_datetime__gt=request_data.from_date,
                 resource=resource,
             )

--- a/care/emr/api/viewsets/scheduling/availability.py
+++ b/care/emr/api/viewsets/scheduling/availability.py
@@ -269,8 +269,8 @@ class SlotViewSet(EMRRetrieveMixin, EMRBaseViewSet):
 
         booked_slots = (
             TokenSlot.objects.filter(
-                start_datetime__lte=request_data.to_date,
-                end_datetime__gte=request_data.from_date,
+                start_datetime__date__lte=request_data.to_date,
+                end_datetime__gt=request_data.from_date,
                 resource=resource,
             )
             .values("start_datetime__date")


### PR DESCRIPTION
## Proposed Changes

- Fixes heatmap API 

In an edge case, `booked_slots` also includes "yesterdays" slot even though FE/client never asked for it. Hence throws KeyError since that day doesn't exist in `response_days`


## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved accuracy of slot availability calculations.
	- Enhanced date-based filtering for scheduling statistics.

- **New Features**
	- Added advanced slot calculation method to improve scheduling precision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->