### PR TITLE
added filter for is_archieved on file viewset

### DIFF
--- a/care/emr/api/viewsets/file_upload.py
+++ b/care/emr/api/viewsets/file_upload.py
@@ -1,4 +1,5 @@
 from django.utils import timezone
+from django_filters import rest_framework as filters
 from pydantic import BaseModel
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
@@ -50,6 +51,10 @@ def file_authorizer(user, file_type, associating_id, permission):
         raise PermissionDenied("Cannot View File")
 
 
+class FileUploadFilter(filters.FilterSet):
+    is_archived = filters.BooleanFilter(field_name="is_archived")
+
+
 class FileUploadViewSet(
     EMRCreateMixin, EMRRetrieveMixin, EMRUpdateMixin, EMRListMixin, EMRBaseViewSet
 ):
@@ -58,6 +63,8 @@ class FileUploadViewSet(
     pydantic_retrieve_model = FileUploadRetrieveSpec
     pydantic_update_model = FileUploadUpdateSpec
     pydantic_read_model = FileUploadListSpec
+    filterset_class = FileUploadFilter
+    filter_backends = [filters.DjangoFilterBackend]
 
     def authorize_create(self, instance):
         file_authorizer(


### PR DESCRIPTION
## Proposed Changes

- added a filefilter class for fileupload viewset

### Associated Issue

- Fixes #2699 



_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added filtering capabilities for file uploads based on archived status
	- Enabled more granular querying of file uploads through Django's filtering framework

<!-- end of auto-generated comment: release notes by coderabbit.ai -->