### PR TITLE
Fix delete method in viewsets

### DIFF
--- a/care/emr/api/viewsets/base.py
+++ b/care/emr/api/viewsets/base.py
@@ -174,18 +174,18 @@ class EMRUpdateMixin:
         return self.get_retrieve_pydantic_model().serialize(model_instance).to_json()
 
 
-class EMRDeleteMixin:
-    def authorize_delete(self, instance):
+class EMRDestroyMixin:
+    def authorize_destroy(self, instance):
         pass
 
-    def perform_delete(self, instance):
+    def perform_destroy(self, instance):
         instance.deleted = True
         instance.save(update_fields=["deleted"])
 
-    def delete(self, request, *args, **kwargs):
+    def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
-        self.authorize_delete(instance)
-        self.perform_delete(instance)
+        self.authorize_destroy(instance)
+        self.perform_destroy(instance)
         return Response(status=204)
 
 
@@ -271,7 +271,7 @@ class EMRModelViewSet(
     EMRRetrieveMixin,
     EMRUpdateMixin,
     EMRListMixin,
-    EMRDeleteMixin,
+    EMRDestroyMixin,
     EMRBaseViewSet,
     EMRUpsertMixin,
 ):

--- a/care/emr/api/viewsets/encounter_authz_base.py
+++ b/care/emr/api/viewsets/encounter_authz_base.py
@@ -24,7 +24,7 @@ class EncounterBasedAuthorizationBase:
         ):
             raise PermissionDenied("You do not have permission to update encounter")
 
-    def authorize_delete(self, instance):
+    def authorize_destroy(self, instance):
         if not AuthorizationController.call(
             "can_update_encounter_obj", self.request.user, instance.encounter
         ):

--- a/care/emr/api/viewsets/facility.py
+++ b/care/emr/api/viewsets/facility.py
@@ -70,7 +70,7 @@ class FacilityViewSet(EMRModelViewSet):
         ):
             raise PermissionDenied("You do not have permission to create Facilities")
 
-    def authorize_delete(self, instance):
+    def authorize_destroy(self, instance):
         if not self.request.user.is_superuser:
             raise PermissionDenied("Only Super Admins can delete Facilities")
 

--- a/care/emr/api/viewsets/facility_organization.py
+++ b/care/emr/api/viewsets/facility_organization.py
@@ -65,7 +65,7 @@ class FacilityOrganizationViewSet(EMRModelViewSet):
         ):
             raise ValidationError("Organization already exists with same name")
 
-    def authorize_delete(self, instance):
+    def authorize_destroy(self, instance):
         if instance.type == "root":
             raise PermissionDenied("Cannot delete root organization")
 
@@ -189,7 +189,7 @@ class FacilityOrganizationUsersViewSet(EMRModelViewSet):
         if queryset.exists():
             raise ValidationError("User association already exists")
 
-    def authorize_delete(self, instance):
+    def authorize_destroy(self, instance):
         organization = self.get_organization_obj()
         if not AuthorizationController.call(
             "can_manage_facility_organization_users_obj",

--- a/care/emr/api/viewsets/organization.py
+++ b/care/emr/api/viewsets/organization.py
@@ -78,7 +78,7 @@ class OrganizationViewSet(EMRModelViewSet):
         ):
             raise ValidationError("Organization already exists with same name")
 
-    def authorize_delete(self, instance):
+    def authorize_destroy(self, instance):
         if Organization.objects.filter(parent=instance).exists():
             raise PermissionDenied("Cannot delete organization with children")
 
@@ -246,7 +246,7 @@ class OrganizationUsersViewSet(EMRModelViewSet):
         ):
             raise PermissionDenied("User does not have permission for this action")
 
-    def authorize_delete(self, instance):
+    def authorize_destroy(self, instance):
         organization = self.get_organization_obj()
         if not AuthorizationController.call(
             "can_manage_organization_users_obj",

--- a/care/emr/api/viewsets/patient.py
+++ b/care/emr/api/viewsets/patient.py
@@ -46,7 +46,7 @@ class PatientViewSet(EMRModelViewSet):
         if not AuthorizationController.call("can_create_patient", self.request.user):
             raise PermissionDenied("Cannot Create Patient")
 
-    def authorize_delete(self, instance):
+    def authorize_destroy(self, instance):
         if not self.request.user.is_superuser:
             raise PermissionDenied("Cannot delete patient")
 

--- a/care/emr/api/viewsets/questionnaire.py
+++ b/care/emr/api/viewsets/questionnaire.py
@@ -89,7 +89,7 @@ class QuestionnaireViewSet(EMRModelViewSet):
         if not self.request.user.is_superuser:
             raise PermissionDenied("Only Superusers can edit a questionnaire")
 
-    def authorize_delete(self, instance):
+    def authorize_destroy(self, instance):
         if not self.request.user.is_superuser:
             raise PermissionDenied("Only Superusers can delete a questionnaire")
 

--- a/care/emr/api/viewsets/resource_request.py
+++ b/care/emr/api/viewsets/resource_request.py
@@ -4,7 +4,7 @@ from rest_framework.generics import get_object_or_404
 from care.emr.api.viewsets.base import (
     EMRBaseViewSet,
     EMRCreateMixin,
-    EMRDeleteMixin,
+    EMRDestroyMixin,
     EMRListMixin,
     EMRModelViewSet,
     EMRRetrieveMixin,
@@ -74,7 +74,7 @@ class ResourceRequestViewSet(EMRModelViewSet):
 
 
 class ResourceRequestCommentViewSet(
-    EMRCreateMixin, EMRRetrieveMixin, EMRListMixin, EMRDeleteMixin, EMRBaseViewSet
+    EMRCreateMixin, EMRRetrieveMixin, EMRListMixin, EMRDestroyMixin, EMRBaseViewSet
 ):
     database_model = ResourceRequestComment
     pydantic_model = ResourceRequestCommentCreateSpec

--- a/care/emr/api/viewsets/scheduling/availability_exceptions.py
+++ b/care/emr/api/viewsets/scheduling/availability_exceptions.py
@@ -35,7 +35,7 @@ class AvailabilityExceptionsViewSet(EMRModelViewSet):
         request_data["facility"] = self.kwargs["facility_external_id"]
         return request_data
 
-    def authorize_delete(self, instance):
+    def authorize_destroy(self, instance):
         self.authorize_update({}, instance)
 
     def authorize_create(self, instance):

--- a/care/emr/api/viewsets/scheduling/schedule.py
+++ b/care/emr/api/viewsets/scheduling/schedule.py
@@ -52,7 +52,7 @@ class ScheduleViewSet(EMRModelViewSet):
         with Lock(f"booking:resource:{instance.resource.id}"):
             super().perform_update(instance)
 
-    def perform_delete(self, instance):
+    def perform_destroy(self, instance):
         with Lock(f"booking:resource:{instance.resource.id}"), transaction.atomic():
             # Check if there are any tokens allocated for this schedule in the future
             availabilities = instance.availability_set.all()
@@ -71,7 +71,7 @@ class ScheduleViewSet(EMRModelViewSet):
                 resource=instance.resource,
                 availability_id__in=availabilities.values_list("id", flat=True),
             ).update(deleted=True)
-            super().perform_delete(instance)
+            super().perform_destroy(instance)
 
     def validate_data(self, instance, model_obj=None):
         # Validate user is part of the facility
@@ -103,7 +103,7 @@ class ScheduleViewSet(EMRModelViewSet):
         ):
             raise PermissionDenied("You do not have permission to view user schedule")
 
-    def authorize_delete(self, instance):
+    def authorize_destroy(self, instance):
         self.authorize_update({}, instance)
 
     def clean_create_data(self, request_data):
@@ -165,7 +165,7 @@ class AvailabilityViewSet(EMRModelViewSet):
         with Lock(f"booking:resource:{instance.schedule.resource.id}"):
             super().perform_update(instance)
 
-    def perform_delete(self, instance):
+    def perform_destroy(self, instance):
         with Lock(f"booking:resource:{instance.schedule.resource.id}"):
             has_future_bookings = TokenSlot.objects.filter(
                 availability_id=instance.id,
@@ -176,7 +176,7 @@ class AvailabilityViewSet(EMRModelViewSet):
                 raise ValidationError(
                     "Cannot delete availability as there are future bookings associated with it"
                 )
-            super().perform_delete(instance)
+            super().perform_destroy(instance)
 
     def authorize_create(self, instance):
         facility = self.get_facility_obj()
@@ -189,5 +189,5 @@ class AvailabilityViewSet(EMRModelViewSet):
     def authorize_update(self, request_obj, model_instance):
         self.authorize_create(model_instance)
 
-    def authorize_delete(self, instance):
+    def authorize_destroy(self, instance):
         self.authorize_update({}, instance)

--- a/care/emr/api/viewsets/user.py
+++ b/care/emr/api/viewsets/user.py
@@ -79,7 +79,7 @@ class UserViewSet(EMRModelViewSet):
         if not AuthorizationController.call("can_create_user", self.request.user):
             raise PermissionDenied("You do not have permission to create Users")
 
-    def authorize_delete(self, instance):
+    def authorize_destroy(self, instance):
         return self.request.user.is_superuser
 
     @action(detail=False, methods=["GET"])


### PR DESCRIPTION
## Proposed Changes

- Fix delete method in viewsets

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed various `authorize_delete` methods to `authorize_destroy` across multiple viewsets
	- Updated method and mixin names related to deletion operations to maintain consistent naming conventions

- **Technical Note**
	- No functional changes to the underlying logic or authorization checks
	- Purely a terminology and naming standardization effort

<!-- end of auto-generated comment: release notes by coderabbit.ai -->