### PR TITLE
Fixes slot_key not tz naive when checking for already created slots

### DIFF
--- a/care/emr/api/viewsets/scheduling/availability.py
+++ b/care/emr/api/viewsets/scheduling/availability.py
@@ -142,7 +142,7 @@ class SlotViewSet(EMRRetrieveMixin, EMRBaseViewSet):
             resource=schedulable_resource_obj,
         )
         for slot in created_slots:
-            slot_key = f"{slot.start_datetime.time()}-{slot.end_datetime.time()}"
+            slot_key = f"{timezone.make_naive(slot.start_datetime).time()}-{timezone.make_naive(slot.end_datetime).time()}"
             if (
                 slot_key in slots
                 and slots[slot_key]["availability_id"] == slot.availability.id


### PR DESCRIPTION


## Proposed Changes

- When computing the `slot_key` ensure existing slot's start and end time is timezone naive before extracting the time

### Associated Issue

- Resolves https://github.com/ohcnetwork/care_fe/issues/9877

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved timezone handling for slot scheduling to ensure accurate time comparisons and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->