### PR TITLE
updating the symptom test cases and adding a make command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,11 @@ python manage.py runserver
 Docker:
 
 ```bash
+# To run all tests
 make test
+
+# To run a specific test file, class, or method:
+make test path=<path_to_test>
 ```
 Local:
 

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ migrate:
 	docker compose exec backend bash -c "python manage.py migrate"
 
 test:
-	docker compose exec backend bash -c "python manage.py test --keepdb --parallel --shuffle"
+	docker compose exec backend bash -c "python manage.py test $(path) --keepdb --parallel --shuffle"
 
 test-coverage:
 	docker compose exec backend bash -c "coverage run manage.py test --settings=config.settings.test --keepdb --parallel --shuffle"

--- a/care/emr/tests/test_symptom_api.py
+++ b/care/emr/tests/test_symptom_api.py
@@ -322,7 +322,7 @@ class TestSymptomViewSet(CareAPITestBase):
         response = self.client.post(self.base_url, symptom_data_dict, format="json")
         self.assertEqual(response.status_code, 403)
 
-    #                         RETRIEVE TESTS
+    # RETRIEVE TESTS
     def test_retrieve_symptom_with_permissions(self):
         """
         Users with `can_view_clinical_data` => (HTTP 200).
@@ -395,7 +395,7 @@ class TestSymptomViewSet(CareAPITestBase):
         retrieve_response = self.client.get(url)
         self.assertEqual(retrieve_response.status_code, 403)
 
-    #                         UPDATE TESTS
+    # UPDATE TESTS
     def test_update_symptom_with_permissions(self):
         """
         Users with `can_write_encounter` + `can_view_clinical_data`
@@ -535,7 +535,7 @@ class TestSymptomViewSet(CareAPITestBase):
         update_response = self.client.put(url, symptom_data_updated, format="json")
         self.assertEqual(update_response.status_code, 403)
 
-    #                         DELETE TESTS
+    # DELETE TESTS
     def test_delete_symptom_with_permission(self):
         """
         Users with `can_write_encounter` + `can_view_clinical_data` => (HTTP 204).

--- a/care/emr/tests/test_symptom_api.py
+++ b/care/emr/tests/test_symptom_api.py
@@ -220,13 +220,19 @@ class TestSymptomViewSet(CareAPITestBase):
 
     def test_create_symptom_without_permissions_on_facility(self):
         """
-        Users who lack `can_write_encounter` get (HTTP 403) when creating.
+        Tests that a user with `can_write_encounter` permissions but belonging to a different
+        organization receives (HTTP 403) when attempting to create a symptom.
         """
-        # No permission attached
         permissions = [EncounterPermissions.can_write_encounter.name]
         role = self.create_role_with_permissions(permissions)
-        organization = self.create_organization(org_type="govt")
-        self.attach_role_organization_user(organization, self.user, role)
+        external_user = self.create_user()
+        external_facility = self.create_facility(user=external_user)
+        external_organization = self.create_facility_organization(
+            facility=external_facility
+        )
+        self.attach_role_facility_organization_user(
+            external_organization, self.user, role
+        )
 
         encounter = self.create_encounter(
             patient=self.patient,
@@ -237,6 +243,43 @@ class TestSymptomViewSet(CareAPITestBase):
         symptom_data_dict = self.generate_data_for_symptom(encounter)
 
         response = self.client.post(self.base_url, symptom_data_dict, format="json")
+        self.assertEqual(response.status_code, 403)
+
+    def test_create_symptom_with_organisation_user_with_permissions(self):
+        """
+        Ensures that a user from a certain organization, who has both
+        `can_write_encounter` and `can_view_clinical_data`, can successfully
+        view symptom data (HTTP 200) but still receives (HTTP 403) when attempting
+        to create a symptom for an encounter.
+        """
+        organization = self.create_organization(org_type="govt")
+        patient = self.create_patient(geo_organization=organization)
+
+        permissions = [
+            EncounterPermissions.can_write_encounter.name,
+            PatientPermissions.can_view_clinical_data.name,
+        ]
+        role = self.create_role_with_permissions(permissions)
+        self.attach_role_organization_user(organization, self.user, role)
+
+        # Verify the user can view symptom data (HTTP 200)
+        test_url = reverse(
+            "symptom-list", kwargs={"patient_external_id": patient.external_id}
+        )
+        response = self.client.get(test_url)
+        self.assertEqual(response.status_code, 200)
+
+        encounter = self.create_encounter(
+            patient=patient,
+            facility=self.facility,
+            organization=self.organization,
+            status=None,
+        )
+
+        symptom_data_dict = self.generate_data_for_symptom(encounter)
+        response = self.client.post(test_url, symptom_data_dict, format="json")
+
+        # User gets 403 because the encounter belongs to a different organization
         self.assertEqual(response.status_code, 403)
 
     def test_create_symptom_with_permissions(self):


### PR DESCRIPTION
## Proposed Changes

- Updated the test case 
- Added make commadn to run specific tests

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated `CONTRIBUTING.md` with new instructions for running tests in Docker.
	- Added commands to run all tests and specific test files/methods.

- **Tests**
	- Enhanced test coverage for symptom API permissions.
	- Added test to verify organizational boundaries for symptom creation and viewing.

- **Chores**
	- Modified Makefile to support flexible test execution with optional path specification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->