### PR TITLE
switched to ubuntu-24.04-arm runners

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
   build:
     needs: test
     name: Build & Push to container registries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
 
@@ -118,7 +118,7 @@ jobs:
     needs: build
     if: startsWith(github.event.ref, 'refs/tags/v')
     name: Notify release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Notify release
         run: |
@@ -128,7 +128,7 @@ jobs:
     needs: build
     if: github.ref == 'refs/heads/develop'
     name: Deploy to ECS API Egov
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     environment:
       name: Staging-egov
       url: https://careapi.ohc.network

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,14 +17,14 @@ jobs:
   build-docs:
     if: github.repository == 'ohcnetwork/care'
     name: Build docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-          cache: 'pipenv'
+          cache: "pipenv"
 
       - name: Install pipenv
         run: pip install pipenv
@@ -46,7 +46,7 @@ jobs:
   deploy-docs:
     if: github.repository == 'ohcnetwork/care' && github.ref == 'refs/heads/develop'
     name: Deploy docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: build-docs
     permissions:
       contents: write

--- a/.github/workflows/issue-automation.yml
+++ b/.github/workflows/issue-automation.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   issue_opened_and_reopened:
     name: issue_opened_and_reopened
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     if: github.repository == 'ohcnetwork/care' && github.event_name == 'issues' && github.event.action == 'opened' || github.event.action == 'reopened'
     steps:
       - name: 'Move issue to "Triage"'
@@ -21,7 +21,7 @@ jobs:
           status_value: "Triage"
   issue_closed:
     name: issue_closed
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     if: github.repository == 'ohcnetwork/care' && github.event_name == 'issues' && github.event.action == 'closed'
     steps:
       - name: 'Moved issue to "Done"'

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
[Reference](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Infrastructure**
	- Updated GitHub Actions workflow environments from `ubuntu-latest` to `ubuntu-24.04-arm` across multiple workflow files
	- Impacted workflows include deployment, documentation, issue automation, linting, and testing configurations

The changes focus on standardizing the operating system environment for GitHub Actions, specifically transitioning to Ubuntu 24.04 with ARM architecture support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->