### PR TITLE
Cached deployment through github actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,6 @@
 name: Deploy Care
 
+# Test change to trigger workflow
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,6 +62,9 @@ jobs:
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=moby/buildkit:latest
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -69,19 +72,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-build-${{ hashFiles('Pipfile.lock', 'docker/prod.Dockerfile') }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-build-
-
-      - name: Create new cache
-        run: |
-          mkdir -p /tmp/.buildx-cache
-          mkdir -p /tmp/.buildx-cache-new
 
       - name: Build and push image
         uses: docker/build-push-action@v6
@@ -95,8 +85,10 @@ jobs:
           build-args: |
             APP_VERSION=${{ github.sha }}
             ADDITIONAL_PLUGS=${{ env.ADDITIONAL_PLUGS }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
+            type=registry,ref=ghcr.io/${{ github.repository }}:latest
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max
 
       - name: Create Sentry release
         uses: getsentry/action-release@v1
@@ -106,13 +98,6 @@ jobs:
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         with:
           version: ${{ github.sha }}
-      - name: Update cache
-        if: always() # Run even if previous steps fail
-        run: |
-          if [ -d "/tmp/.buildx-cache-new" ]; then
-            rm -rf /tmp/.buildx-cache
-            mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-          fi
 
   notify-release:
     needs: build


### PR DESCRIPTION
Added registry-based cache configuration:
Added BuildKit configuration to ensure latest buildkit image is used. This approach is better because:
Registry-based caching persists between workflow runs We're using both the buildcache and latest tags as sources No need to manage local cache directories

## Proposed Changes

- Removed the local filesystem caching in favor of registry-based caching
- Added registry-based cache configuration:
  - Cache is now pulled from both the buildcache and latest tags
  - Cache is pushed to a dedicated buildcache tag
- Added BuildKit configuration to ensure latest buildkit image is used

### Associated Issue

- #2496 

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated deployment workflow configuration to allow manual execution.
	- Improved Docker build caching strategy using GitHub Container Registry.
	- Optimized build process with a revised remote caching mechanism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->