### PR TITLE
fix typo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ concurrency:
 env:
   AWS_DEFAULT_REGION: ap-south-1
   AWS_DEFAULT_OUTPUT: json
-  ECS_SERVICE_BACKEND: "care-backend"
+  ECS_SERVICE_BACKEND: "care"
   ECS_SERVICE_CELERY: "care-celery"
   ECS_CLUSTER: "egov"
   CONTAINER_NAME_BACKEND: "care-backend"


### PR DESCRIPTION
fixed typo in ECS_SERVICE_BACKEND value that broke the deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated deployment workflow configuration
	- Modified backend service naming in ECS deployment settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->