### PR TITLE
make note optional in condition spec

### DIFF
--- a/care/emr/resources/condition/spec.py
+++ b/care/emr/resources/condition/spec.py
@@ -62,7 +62,7 @@ class ConditionSpec(BaseConditionSpec):
     code: Coding = Field(json_schema_extra={"slug": CARE_CODITION_CODE_VALUESET.slug})
     encounter: UUID4
     onset: ConditionOnSetSpec = {}
-    note: str = ""
+    note: str | None = None
 
     @field_validator("code")
     @classmethod
@@ -104,7 +104,7 @@ class ConditionSpecRead(BaseConditionSpec):
     onset: ConditionOnSetSpec = dict
     created_by: UserSpec = dict
     updated_by: UserSpec = dict
-    note: str
+    note: str | None = None
 
     @classmethod
     def perform_extra_serialization(cls, mapping, obj):
@@ -123,7 +123,7 @@ class ConditionSpecUpdate(BaseConditionSpec):
     severity: SeverityChoices | None = None
     code: Coding = Field(json_schema_extra={"slug": CARE_CODITION_CODE_VALUESET.slug})
     onset: ConditionOnSetSpec = {}
-    note: str = ""
+    note: str | None = None
 
     @field_validator("code")
     @classmethod


### PR DESCRIPTION
## Proposed Changes

- make note optional in condition spec

### Associated Issue

- Link to issue here, explain how the proposed solution will solve the reported issue/ feature request.

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated `note` attribute in `ConditionSpec`, `ConditionSpecRead`, and `ConditionSpecUpdate` classes to allow `None` values
	- Made `note` field optional across multiple data model classes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->