### PR TITLE
Added alt phone number, and doctor specific fields

### DIFF
--- a/care/emr/resources/user/spec.py
+++ b/care/emr/resources/user/spec.py
@@ -36,6 +36,10 @@ class UserBaseSpec(EMRResource):
     first_name: str
     last_name: str
     phone_number: str = Field(max_length=14)
+    alt_phone_number: str = Field(max_length=14)
+    qualification: str
+    doctor_experience_commenced_on: str
+    doctor_medical_council_registration: str
 
 
 class UserUpdateSpec(UserBaseSpec):


### PR DESCRIPTION
## Proposed Changes

- Adding alt phone number, qualification to UserBaseSpec (allowing for creation, edition and retrieval of these fields)

### Associated Issue

- FE [PR](https://github.com/ohcnetwork/care_fe/pull/10027)

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced user profile with additional fields:
		- Alternative phone number
		- Professional qualification
		- Doctor's experience start date
		- Medical council registration details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->