### PR TITLE
Delete TokenSlots when availability is deleted

### DIFF
--- a/care/emr/api/viewsets/scheduling/schedule.py
+++ b/care/emr/api/viewsets/scheduling/schedule.py
@@ -180,6 +180,7 @@ class AvailabilityViewSet(EMRCreateMixin, EMRDestroyMixin, EMRBaseViewSet):
                 raise ValidationError(
                     "Cannot delete availability as there are future bookings associated with it"
                 )
+            TokenSlot.objects.filter(availability_id=instance.id).update(deleted=True)
             super().perform_destroy(instance)
 
     def authorize_create(self, instance):


### PR DESCRIPTION
## Proposed Changes

- Delete TokenSlots when availability is deleted

### Associated Issue

- Fixes https://github.com/ohcnetwork/care_fe/issues/10239

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data integrity for availability deletions by automatically marking associated token slots as deleted.

- **Tests**
	- Improved test suite for availability viewset with new helper methods for creating availability and slot instances.
	- Refactored test cases to use consistent setup and reduce code duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->