### PR TITLE
Override Dob Or Age for Patients

### DIFF
--- a/care/emr/resources/patient/spec.py
+++ b/care/emr/resources/patient/spec.py
@@ -71,11 +71,12 @@ class PatientCreateSpec(PatientBaseSpec):
         obj.geo_organization = Organization.objects.get(
             external_id=self.geo_organization
         )
-        if not is_update:
-            if self.age:
-                obj.year_of_birth = timezone.now().date().year - self.age
-            else:
-                obj.year_of_birth = self.date_of_birth.year
+        if self.age:
+            # override dob if user chooses to update age
+            obj.date_of_birth = None
+            obj.year_of_birth = timezone.now().date().year - self.age
+        else:
+            obj.year_of_birth = self.date_of_birth.year
 
 
 class PatientListSpec(PatientBaseSpec):


### PR DESCRIPTION
## Proposed Changes

- Allow override for age or dob

### Associated Issue

- [FE 10280](https://github.com/ohcnetwork/care_fe/pull/10280)

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved patient year of birth calculation logic to consistently update based on age or date of birth, regardless of whether it's a new or existing patient record.
- **Tests**
	- Added comprehensive tests for updating a patient's age and date of birth, ensuring accurate year of birth calculations in various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->