### PR TITLE
Revert "Allergy | Add encounter filter"

### DIFF
--- a/care/emr/api/viewsets/allergy_intolerance.py
+++ b/care/emr/api/viewsets/allergy_intolerance.py
@@ -1,5 +1,4 @@
 from django_filters import CharFilter, FilterSet
-from django_filters import rest_framework as filters
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework.exceptions import PermissionDenied
@@ -30,7 +29,6 @@ from care.security.authorization import AuthorizationController
 
 
 class AllergyIntoleranceFilters(FilterSet):
-    encounter = filters.UUIDFilter(field_name="encounter__external_id")
     clinical_status = CharFilter(field_name="clinical_status")
 
 


### PR DESCRIPTION
Reverts ohcnetwork/care#2800

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Filters**
  - Removed encounter-based filtering for Allergy Intolerance records
  - Clinical status filtering remains unchanged

The change impacts how users can query Allergy Intolerance data, specifically removing the ability to filter by encounter external ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->