### PR TITLE
Fix date range logic and enhance tests for booking API.

### DIFF
--- a/care/emr/api/viewsets/scheduling/availability.py
+++ b/care/emr/api/viewsets/scheduling/availability.py
@@ -281,7 +281,7 @@ class SlotViewSet(EMRRetrieveMixin, EMRBaseViewSet):
         days = {}
         response_days = {}
         day = request_data.from_date
-        while day < request_data.to_date:
+        while day <= request_data.to_date:
             days[day] = {"total_slots": 0, "booked_slots": 0}
             response_days[str(day)] = {"total_slots": 0, "booked_slots": 0}
             day += timedelta(days=1)

--- a/care/emr/tests/test_booking_api.py
+++ b/care/emr/tests/test_booking_api.py
@@ -867,16 +867,29 @@ class TestSlotViewSetSlotStatsApis(CareAPITestBase):
         self,
     ):
         """Availability heatmap slot counts should match individual day slot counts when there are no exceptions."""
+        from_date = datetime.now(UTC).date()
+        end_date = from_date + timedelta(days=7)
         data = {
             "user": self.user.external_id,
-            "from_date": datetime.now(UTC).strftime("%Y-%m-%d"),
-            "to_date": (datetime.now(UTC) + timedelta(days=7)).strftime("%Y-%m-%d"),
+            "from_date": from_date.strftime("%Y-%m-%d"),
+            "to_date": end_date.strftime("%Y-%m-%d"),
         }
         response = self.client.post(
             self._get_availability_stats_url(), data, format="json"
         )
         self.assertEqual(response.status_code, 200)
 
+        # verify all days are present
+        date = from_date
+        while date <= end_date:
+            self.assertContains(
+                response,
+                status_code=200,
+                text=date.strftime("%Y-%m-%d"),
+            )
+            date += timedelta(days=1)
+
+        # verify booked slots and total slots from get slots for day matches heatmap
         for day, slot_stats in response.data.items():
             data = {"user": self.user.external_id, "day": day}
             response = self.client.post(

--- a/care/emr/tests/test_booking_api.py
+++ b/care/emr/tests/test_booking_api.py
@@ -882,11 +882,7 @@ class TestSlotViewSetSlotStatsApis(CareAPITestBase):
         # verify all days are present
         date = from_date
         while date <= end_date:
-            self.assertContains(
-                response,
-                status_code=200,
-                text=date.strftime("%Y-%m-%d"),
-            )
+            self.assertContains(response, text=date.strftime("%Y-%m-%d"))
             date += timedelta(days=1)
 
         # verify booked slots and total slots from get slots for day matches heatmap


### PR DESCRIPTION
## Proposed Changes

Update the `to_date` condition in availability logic to include the end date, fixing a missing day issue. Enhance test coverage to validate that all days in the range are accounted for and their slot statistics are consistent.

### Associated Issue

- Fixes https://github.com/ohcnetwork/care_fe/issues/10304

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [x] Tests added/fixed
- [x] Linting Complete


@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed an issue with date range calculation in availability statistics to ensure the end date is correctly included.

- **Tests**
	- Enhanced test coverage for availability heatmap slots
	- Added comprehensive tests for slot availability with and without exceptions
	- Improved test method to dynamically validate date range statistics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->