### PR TITLE
Added encounter filter for Notes

### DIFF
--- a/care/emr/api/viewsets/notes.py
+++ b/care/emr/api/viewsets/notes.py
@@ -1,3 +1,4 @@
+from django_filters import rest_framework as filters
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.generics import get_object_or_404
 
@@ -24,6 +25,10 @@ from care.emr.resources.notes.thread_spec import (
 from care.security.authorization import AuthorizationController
 
 
+class NoteThreadFilters(filters.FilterSet):
+    encounter = filters.UUIDFilter(field_name="encounter__external_id")
+
+
 class NoteThreadViewSet(
     EMRCreateMixin,
     EMRRetrieveMixin,
@@ -35,6 +40,8 @@ class NoteThreadViewSet(
     pydantic_model = NoteThreadCreateSpec
     pydantic_read_model = NoteThreadUpdateSpec
     pydantic_update_model = NoteThreadReadSpec
+    filterset_class = NoteThreadFilters
+    filter_backends = [filters.DjangoFilterBackend]
 
     def get_patient(self):
         return get_object_or_404(


### PR DESCRIPTION
## Proposed Changes

- Added encounter id filter for notes (display encounter specific notes)

### Associated Issue

- [FE Issue #10313](https://github.com/ohcnetwork/care_fe/issues/10313)

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced filtering capabilities for note threads by enabling filtering based on encounter's external ID.

- **Improvements**
	- Added support for more granular querying of note thread data through advanced filtering mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->