### PR TITLE
feat: add preview_search endpoint to ValueSetViewSet

### DIFF
--- a/care/emr/api/viewsets/valueset.py
+++ b/care/emr/api/viewsets/valueset.py
@@ -29,6 +29,7 @@ class ValueSetViewSet(EMRModelViewSet):
             "lookup_code",
             "expand",
             "validate_code",
+            "preview_search",
         ]:
             return True
         # Only superusers have write permission over valuesets
@@ -45,6 +46,18 @@ class ValueSetViewSet(EMRModelViewSet):
     def expand(self, request, *args, **kwargs):
         request_params = ExpandRequest(**request.data).model_dump()
         results = self.get_object().search(**request_params)
+        return Response({"results": [result.model_dump() for result in results]})
+
+    @extend_schema(request=ValueSetSpec, responses={200: None}, methods=["POST"])
+    @action(detail=False, methods=["POST"])
+    def preview_search(self, request, *args, **kwargs):
+        # Create temporary ValueSet object from request data
+        valueset_data = ValueSetSpec(**request.data)
+        temp_valueset = ValueSet(**valueset_data.model_dump())
+
+        # Use the same parameters as expand endpoint
+        search_params = ExpandRequest().model_dump()
+        results = temp_valueset.search(**search_params)
         return Response({"results": [result.model_dump() for result in results]})
 
     @extend_schema(request=Coding, responses={200: None}, methods=["POST"])

--- a/care/emr/api/viewsets/valueset.py
+++ b/care/emr/api/viewsets/valueset.py
@@ -51,13 +51,16 @@ class ValueSetViewSet(EMRModelViewSet):
     @extend_schema(request=ValueSetSpec, responses={200: None}, methods=["POST"])
     @action(detail=False, methods=["POST"])
     def preview_search(self, request, *args, **kwargs):
-        # Create temporary ValueSet object from request data
+        # Get search parameters from query params
+        search_text = request.query_params.get("search", "")
+        count = int(request.query_params.get("count", 10))
+
+        # Create temporary ValueSet object from request body
         valueset_data = ValueSetSpec(**request.data)
         temp_valueset = ValueSet(**valueset_data.model_dump())
 
-        # Use the same parameters as expand endpoint
-        search_params = ExpandRequest().model_dump()
-        results = temp_valueset.search(**search_params)
+        # Use the search parameters from query params
+        results = temp_valueset.search(search=search_text, count=count)
         return Response({"results": [result.model_dump() for result in results]})
 
     @extend_schema(request=Coding, responses={200: None}, methods=["POST"])


### PR DESCRIPTION
Added a new preview_search endpoint to ValueSetViewSet that allows testing search functionality with unsaved valueset objects.

Changes:
- Added new preview_search action that accepts ValueSetSpec in request body
- Created temporary ValueSet object from request data
- Uses default ExpandRequest parameters for search
- Returns search results without requiring ValueSet to be saved
- Added endpoint to permissions_controller for public access

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a preview search capability that lets users submit criteria and quickly receive a list of matching results.
  - Updated access controls to allow seamless use of this new functionality without additional permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->