### PR TITLE
Fix for empty questionnaire title

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,10 @@ teardown:
 load-dummy-data:
 	docker compose exec backend bash -c "python manage.py load_dummy_data"
 
+load-seed-data:
+	docker compose exec backend bash -c "python manage.py load_govt_organization --state kerala --load-districts --load-local-bodies --load-wards"
+	docker compose exec backend bash -c "python manage.py sync_permissions_roles"
+
 list:
 	docker compose -f docker-compose.yaml -f $(docker_config_file) ps
 

--- a/care/emr/resources/questionnaire/spec.py
+++ b/care/emr/resources/questionnaire/spec.py
@@ -212,6 +212,13 @@ class QuestionnaireWriteSpec(QuestionnaireBaseSpec):
             raise ValueError(err)
         return slug
 
+    @field_validator("title")
+    @classmethod
+    def validate_title(cls, title: str, info):
+        if not title.strip():
+            raise ValueError("Title cannot be empty")
+        return title.strip()
+
     def get_all_ids(self):
         ids = []
         for question in self.questions:

--- a/care/emr/tests/test_questionnaire_api.py
+++ b/care/emr/tests/test_questionnaire_api.py
@@ -501,9 +501,13 @@ class QuestionnairePermissionTests(QuestionnaireTestBase):
         role = self.create_role_with_permissions(permissions)
         self.attach_role_organization_user(self.organization, self.user, role)
 
-        response = self.client.post(
-            self.base_url, self._create_questionnaire(), format="json"
-        )
+        questionnaire_data = self._create_questionnaire()
+        questionnaire_data["title"] = ""
+        response = self.client.post(self.base_url, questionnaire_data, format="json")
+        self.assertEqual(response.status_code, 400)
+
+        questionnaire_data["title"] = self.fake.text(max_nb_chars=255)
+        response = self.client.post(self.base_url, questionnaire_data, format="json")
         self.assertEqual(response.status_code, 200)
 
     def test_questionnaire_retrieval_access_denied(self):


### PR DESCRIPTION
## Proposed Changes

- Fixed empty string being a valid title
- added a make command for seeding data
- added test for checking questionnaire title

### Associated Issue

- Fixes [#10624](https://github.com/ohcnetwork/care_fe/issues/10624)

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced a new administrative command to load government organization data and update permissions.

- **New Features**
  - Enhanced questionnaire creation by enforcing valid titles, preventing submissions with empty or whitespace-only titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->