### PR TITLE
Make typst installation configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -358,3 +358,5 @@ secrets.sh
 jwks.b64.txt
 
 care_db.dump
+
+typst*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,8 @@
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true,
   "githubPullRequests.ignoredPullRequestBranches": ["develop", "staging"],
-  "python.languageServer": "Pylance"
+  "python.languageServer": "Pylance",
+  "cSpell.words": [
+    "Typst"
+  ]
 }

--- a/care/emr/reports/discharge_summary.py
+++ b/care/emr/reports/discharge_summary.py
@@ -143,23 +143,24 @@ def compile_typ(output_file, data):
         )
 
         data["logo_path"] = str(logo_path)
+        with tempfile.NamedTemporaryFile(suffix=".typ") as template:
+            template.write(
+                render_to_string(
+                    "reports/patient_discharge_summary_pdf_template.typ", context=data
+                ).encode("utf-8")
+            )
+            template.flush()
 
-        content = render_to_string(
-            "reports/patient_discharge_summary_pdf_template.typ", context=data
-        )
-
-        subprocess.run(  # noqa: S603
-            [  # noqa: S607
-                "typst",
-                "compile",
-                "-",
-                str(output_file),
-            ],
-            input=content.encode("utf-8"),
-            capture_output=True,
-            check=True,
-            cwd="/",
-        )
+            subprocess.run(  # noqa: S603
+                [
+                    settings.TYPST_BIN,
+                    str(template.name),
+                    str(output_file),
+                ],
+                capture_output=True,
+                check=True,
+                cwd="/",
+            )
 
         logging.info(
             "Successfully Compiled Summary pdf for %s", data["encounter"].external_id

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -649,3 +649,6 @@ MIDDLEWARE_REQUEST_TIMEOUT = env.int("MIDDLEWARE_REQUEST_TIMEOUT", 20)
 SNOWSTORM_DEPLOYMENT_URL = env(
     "SNOWSTORM_DEPLOYMENT_URL", default="http://165.22.211.144/fhir"
 )
+
+# Path to the typst binary, see scripts/install_typst.sh
+TYPST_BIN = env("TYPST_BIN", default="typst")

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -13,21 +13,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && rm -rf /var/lib/apt/lists/*
 
-# Download and install Typst for the correct architecture
-RUN ARCH=$(dpkg --print-architecture) && \
-    if [ "$ARCH" = "amd64" ]; then \
-        TYPST_ARCH="x86_64-unknown-linux-musl"; \
-    elif [ "$ARCH" = "arm64" ]; then \
-        TYPST_ARCH="aarch64-unknown-linux-musl"; \
-    else \
-        echo "Unsupported architecture: $ARCH"; \
-        exit 1; \
-    fi && \
-    wget -qO typst.tar.xz https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-${TYPST_ARCH}.tar.xz && \
-    tar -xf typst.tar.xz && \
-    mv typst-${TYPST_ARCH}/typst /usr/local/bin/typst && \
-    chmod +x /usr/local/bin/typst && \
-    rm -rf typst.tar.xz typst-${TYPST_ARCH}
+COPY --chmod=0755 scripts/install_typst.sh $APP_HOME
+RUN TYPST_VERSION=${TYPST_VERSION} $APP_HOME/install_typst.sh
 
 # use pipenv to manage virtualenv
 ENV PATH=/.venv/bin:$PATH

--- a/docker/prod.Dockerfile
+++ b/docker/prod.Dockerfile
@@ -23,20 +23,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && rm -rf /var/lib/apt/lists/*
 
-# Download and install Typst for the correct architecture
-RUN ARCH=$(dpkg --print-architecture) && \
-    if [ "$ARCH" = "amd64" ]; then \
-        TYPST_ARCH="x86_64-unknown-linux-musl"; \
-    elif [ "$ARCH" = "arm64" ]; then \
-        TYPST_ARCH="aarch64-unknown-linux-musl"; \
-    else \
-        echo "Unsupported architecture: $ARCH"; \
-        exit 1; \
-    fi && \
-    wget -qO typst.tar.xz https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-${TYPST_ARCH}.tar.xz && \
-    tar -xf typst.tar.xz && \
-    mv typst-${TYPST_ARCH}/typst /usr/local/bin/typst && \
-    rm -rf typst.tar.xz typst-${TYPST_ARCH}
+COPY --chmod=0755 scripts/install_typst.sh $APP_HOME
+RUN TYPST_VERSION=${TYPST_VERSION} $APP_HOME/install_typst.sh
 
 # use pipenv to manage virtualenv
 RUN pip install pipenv==2024.4.0

--- a/scripts/install_typst.sh
+++ b/scripts/install_typst.sh
@@ -15,71 +15,71 @@
 INSTALL_PATH="${TYPST_INSTALL_DIR:-/usr/local/bin}"
 
 if [ -z "${TYPST_VERSION}" ]; then
-    echo "TYPST_VERSION is not set. Exiting."
-    exit 1
+  echo "TYPST_VERSION is not set. Exiting."
+  exit 1
 fi
 
 if ! command -v wget >/dev/null 2>&1; then
-    echo "wget is required but not installed. Exiting."
-    exit 1
+  echo "wget is required but not installed. Exiting."
+  exit 1
 fi
 
 if ! command -v tar >/dev/null 2>&1; then
-    echo "tar is required but not installed. Exiting."
-    exit 1
+  echo "tar is required but not installed. Exiting."
+  exit 1
 fi
 
 
 get_arch() {
-    OS=$(uname -s)
-    MACHINE=$(uname -m)
-    case "$OS" in
-        Darwin)
-            case "$MACHINE" in
-                x86_64)
-                    echo "x86_64-apple-darwin"
-                    ;;
-                arm64)
-                    echo "aarch64-apple-darwin"
-                    ;;
-                *)
-                    echo "Unsupported architecture: $MACHINE on Darwin" >&2
-                    exit 1
-                    ;;
-            esac
-            ;;
-        Linux)
-            case "$MACHINE" in
-                x86_64|amd64)
-                    echo "x86_64-unknown-linux-musl"
-                    ;;
-                arm64|aarch64)
-                    echo "aarch64-unknown-linux-musl"
-                    ;;
-                *)
-                    echo "Unsupported architecture: $MACHINE on Linux" >&2
-                    exit 1
-                    ;;
-            esac
-            ;;
+  OS=$(uname -s)
+  MACHINE=$(uname -m)
+  case "$OS" in
+    Darwin)
+      case "$MACHINE" in
+        x86_64)
+          echo "x86_64-apple-darwin"
+          ;;
+        arm64)
+          echo "aarch64-apple-darwin"
+          ;;
         *)
-            echo "Unsupported OS: $OS" >&2
-            exit 1
-            ;;
-    esac
+          echo "Unsupported architecture: $MACHINE on Darwin" >&2
+          exit 1
+          ;;
+      esac
+      ;;
+    Linux)
+      case "$MACHINE" in
+        x86_64|amd64)
+          echo "x86_64-unknown-linux-musl"
+          ;;
+        arm64|aarch64)
+          echo "aarch64-unknown-linux-musl"
+          ;;
+        *)
+          echo "Unsupported architecture: $MACHINE on Linux" >&2
+          exit 1
+          ;;
+      esac
+      ;;
+    *)
+      echo "Unsupported OS: $OS" >&2
+      exit 1
+      ;;
+  esac
 }
 
 TYPST_ARCH=$(get_arch)
 
 wget -qO typst.tar.xz \
-     https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-${TYPST_ARCH}.tar.xz
+    "https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-${TYPST_ARCH}.tar.xz"
 
 tar -xf typst.tar.xz
 
-mkdir -p ${INSTALL_PATH}
-mv typst-$(TYPST_ARCH)/typst ${INSTALL_PATH}/typst
-chmod +x ${INSTALL_PATH}/typst
+mkdir -p "${INSTALL_PATH}"
+mv "typst-${TYPST_ARCH}/typst" "${INSTALL_PATH}/typst"
+chmod +x "${INSTALL_PATH}/typst"
 
-rm -rf typst.tar.xz typst-$(get_arch)
+rm -rf "typst.tar.xz" "typst-${TYPST_ARCH}"
 
 echo "Typst v${TYPST_VERSION} has been installed to ${INSTALL_PATH}/typst"

--- a/scripts/install_typst.sh
+++ b/scripts/install_typst.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+
+# This script installs Typst binary based on the given version and path
+# Supported platforms: Linux(x86_64, aarch64), Darwin(x86_64, arm64)
+#
+# Environment variables:
+# TYPST_VERSION: The version of Typst to install
+# TYPST_INSTALL_DIR: The directory to install Typst to. Defaults to /usr/local/bin
+#
+# Example usage:
+# TYPST_VERSION=0.12.0 ./scripts/install_typst.sh
+# TYPST_VERSION=0.12.0 TYPST_INSTALL_DIR=./bin ./scripts/install_typst.sh
+
+
+INSTALL_PATH="${TYPST_INSTALL_DIR:-/usr/local/bin}"
+
+if [ -z "${TYPST_VERSION}" ]; then
+    echo "TYPST_VERSION is not set. Exiting."
+    exit 1
+fi
+
+if ! command -v wget >/dev/null 2>&1; then
+    echo "wget is required but not installed. Exiting."
+    exit 1
+fi
+
+if ! command -v tar >/dev/null 2>&1; then
+    echo "tar is required but not installed. Exiting."
+    exit 1
+fi
+
+
+get_arch() {
+    OS=$(uname -s)
+    MACHINE=$(uname -m)
+    case "$OS" in
+        Darwin)
+            case "$MACHINE" in
+                x86_64)
+                    echo "x86_64-apple-darwin"
+                    ;;
+                arm64)
+                    echo "aarch64-apple-darwin"
+                    ;;
+                *)
+                    echo "Unsupported architecture: $MACHINE on Darwin" >&2
+                    exit 1
+                    ;;
+            esac
+            ;;
+        Linux)
+            case "$MACHINE" in
+                x86_64|amd64)
+                    echo "x86_64-unknown-linux-musl"
+                    ;;
+                arm64|aarch64)
+                    echo "aarch64-unknown-linux-musl"
+                    ;;
+                *)
+                    echo "Unsupported architecture: $MACHINE on Linux" >&2
+                    exit 1
+                    ;;
+            esac
+            ;;
+        *)
+            echo "Unsupported OS: $OS" >&2
+            exit 1
+            ;;
+    esac
+}
+
+TYPST_ARCH=$(get_arch)
+
+wget -qO typst.tar.xz \
+     https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-${TYPST_ARCH}.tar.xz
+
+tar -xf typst.tar.xz
+
+mkdir -p ${INSTALL_PATH}
+mv typst-$(TYPST_ARCH)/typst ${INSTALL_PATH}/typst
+chmod +x ${INSTALL_PATH}/typst
+
+rm -rf typst.tar.xz typst-$(get_arch)
+
+echo "Typst v${TYPST_VERSION} has been installed to ${INSTALL_PATH}/typst"


### PR DESCRIPTION
## Proposed Changes
- closes #2846
- add typst_install script to install typst on linux/darwin
- use the install script to install typst in docker containers
- introduce TYPST_BIN setting to configure typst path
- write django template -> output to a tempfile and use that as input for typst instead of passing the data from std input

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a script-based installation approach for a critical dependency to enhance deployment flexibility.
	- Added a new entry for the word "Typst" to the spell checker dictionary.
- **Refactor**
	- Updated the document report generation process to improve overall reliability.
- **Chores**
	- Refined configuration settings and updated ignore rules to streamline development and deployment workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->