### PR TITLE
Fix Facility.DoesNotExist in scheduling

### DIFF
--- a/care/emr/api/viewsets/scheduling/booking.py
+++ b/care/emr/api/viewsets/scheduling/booking.py
@@ -156,7 +156,7 @@ class TokenBookingViewSet(
 
     @action(detail=False, methods=["GET"])
     def available_users(self, request, *args, **kwargs):
-        facility = Facility.objects.get(external_id=self.kwargs["facility_external_id"])
+        facility = self.get_facility_obj()
         facility_users = FacilityOrganizationUser.objects.filter(
             organization__facility=facility,
             user_id__in=SchedulableUserResource.objects.filter(


### PR DESCRIPTION
## Proposed Changes

- use get_or_404 instead
- fixes #2843

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the internal process for retrieving facility data, aligning our methods with established best practices for improved consistency and maintainability. These changes reinforce system stability and backend performance without altering any user-facing features, ensuring a seamless experience while strengthening our platform’s overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->