### PR TITLE
Allow updating mode for locations

### DIFF
--- a/care/emr/resources/location/spec.py
+++ b/care/emr/resources/location/spec.py
@@ -78,7 +78,7 @@ class FacilityLocationSpec(FacilityLocationBaseSpec):
 
 
 class FacilityLocationUpdateSpec(FacilityLocationSpec):
-    pass
+    mode: FacilityLocationModeChoices
 
 
 class FacilityLocationWriteSpec(FacilityLocationSpec):


### PR DESCRIPTION
## Proposed Changes

- Allow updating mode for locations
   - Ex: Updating from Room -> Bed wasn't changing mode from kind to instance.

### Associated Issue

- Related to [10731 on FE](https://github.com/ohcnetwork/care_fe/issues/10731)

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced facility location configuration by introducing an additional operational mode option, providing more detailed control over location behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->