### PR TITLE
Validate and sign mime types and file extensions for file uploads

### DIFF
--- a/care/emr/models/file_upload.py
+++ b/care/emr/models/file_upload.py
@@ -7,6 +7,7 @@ from care.emr.models import EMRBaseModel
 from care.emr.utils.file_manager import S3FilesManager
 from care.users.models import User
 from care.utils.csp.config import BucketType
+from care.utils.models.validators import parse_file_extension
 
 
 class FileUpload(EMRBaseModel):
@@ -32,9 +33,8 @@ class FileUpload(EMRBaseModel):
     files_manager = S3FilesManager(BucketType.PATIENT)
 
     def get_extension(self):
-        # TODO: improve this logic to handle files with multiple extensions
-        parts = self.internal_name.split(".")
-        return f".{parts[-1]}" if len(parts) > 1 else ""
+        extensions = parse_file_extension(self.internal_name)
+        return f".{".".join(extensions)}" if extensions else ""
 
     def save(self, *args, **kwargs):
         """

--- a/care/emr/resources/file_upload/spec.py
+++ b/care/emr/resources/file_upload/spec.py
@@ -2,11 +2,13 @@ import datetime
 from enum import Enum
 
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from pydantic import UUID4, field_validator
 
 from care.emr.models import FileUpload
 from care.emr.resources.base import EMRResource
 from care.emr.resources.user.spec import UserSpec
+from care.utils.models.validators import file_name_validator
 
 
 class FileTypeChoices(str, Enum):
@@ -53,6 +55,18 @@ class FileUploadCreateSpec(FileUploadBaseSpec):
             err = "Invalid mime type"
             raise ValueError(err)
         return mime_type
+
+    @field_validator("original_name")
+    @classmethod
+    def validate_original_name(cls, original_name: str):
+        if not original_name:
+            err = "File name cannot be empty"
+            raise ValueError(err)
+        try:
+            file_name_validator(original_name)
+        except ValidationError as e:
+            raise ValueError(e.message) from e
+        return original_name
 
 
 class FileUploadListSpec(FileUploadBaseSpec):

--- a/care/emr/resources/file_upload/spec.py
+++ b/care/emr/resources/file_upload/spec.py
@@ -1,7 +1,8 @@
 import datetime
 from enum import Enum
 
-from pydantic import UUID4
+from django.conf import settings
+from pydantic import UUID4, field_validator
 
 from care.emr.models import FileUpload
 from care.emr.resources.base import EMRResource
@@ -37,11 +38,21 @@ class FileUploadCreateSpec(FileUploadBaseSpec):
     file_type: FileTypeChoices
     file_category: FileCategoryChoices
     associating_id: str
+    mime_type: str
 
     def perform_extra_deserialization(self, is_update, obj):
         # Authz Performed in the request
         obj._just_created = True  # noqa SLF001
         obj.internal_name = self.original_name
+        obj.meta["mime_type"] = self.mime_type
+
+    @field_validator("mime_type")
+    @classmethod
+    def validate_mime_type(cls, mime_type: str):
+        if mime_type not in settings.ALLOWED_MIME_TYPES:
+            err = "Invalid mime type"
+            raise ValueError(err)
+        return mime_type
 
 
 class FileUploadListSpec(FileUploadBaseSpec):
@@ -56,11 +67,13 @@ class FileUploadListSpec(FileUploadBaseSpec):
     created_date: datetime.datetime
     extension: str
     uploaded_by: dict
+    mime_type: str
 
     @classmethod
     def perform_extra_serialization(cls, mapping, obj):
         mapping["id"] = obj.external_id
         mapping["extension"] = obj.get_extension()
+        mapping["mime_type"] = obj.meta.get("mime_type")
         if obj.created_by:
             mapping["uploaded_by"] = UserSpec.serialize(obj.created_by)
 

--- a/care/emr/utils/file_manager.py
+++ b/care/emr/utils/file_manager.py
@@ -22,8 +22,10 @@ class S3FilesManager(FileManger):
             "Bucket": bucket_name,
             "Key": f"{file_obj.file_type}/{file_obj.internal_name}",
         }
-        if mime_type:
-            params["ContentType"] = mime_type
+
+        _mime_type = file_obj.meta.get("mime_type") or mime_type
+        if _mime_type:
+            params["ContentType"] = _mime_type
         return s3.generate_presigned_url(
             "put_object",
             Params=params,

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -569,44 +569,46 @@ FILE_UPLOAD_BUCKET_EXTERNAL_ENDPOINT = env(
     ),
 )
 
-ALLOWED_MIME_TYPES = env.list(
-    "ALLOWED_MIME_TYPES",
-    default=[
-        # Images
-        "image/jpeg",
-        "image/png",
-        "image/gif",
-        "image/bmp",
-        "image/webp",
-        "image/svg+xml",
-        # Videos
-        "video/mp4",
-        "video/mpeg",
-        "video/x-msvideo",
-        "video/quicktime",
-        "video/x-ms-wmv",
-        "video/x-flv",
-        "video/webm",
-        # Audio
-        "audio/mpeg",
-        "audio/wav",
-        "audio/aac",
-        "audio/ogg",
-        "audio/midi",
-        "audio/x-midi",
-        "audio/webm",
-        "audio/mp4",
-        # Documents
-        "text/plain",
-        "text/csv",
-        "application/rtf",
-        "application/msword",
-        "application/vnd.oasis.opendocument.text",
-        "application/pdf",
-        "application/vnd.ms-excel",
-        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        "application/vnd.oasis.opendocument.spreadsheet",
-    ],
+ALLOWED_MIME_TYPES = set(
+    env.list(
+        "ALLOWED_MIME_TYPES",
+        default=[
+            # Images
+            "image/jpeg",
+            "image/png",
+            "image/gif",
+            "image/bmp",
+            "image/webp",
+            "image/svg+xml",
+            # Videos
+            "video/mp4",
+            "video/mpeg",
+            "video/x-msvideo",
+            "video/quicktime",
+            "video/x-ms-wmv",
+            "video/x-flv",
+            "video/webm",
+            # Audio
+            "audio/mpeg",
+            "audio/wav",
+            "audio/aac",
+            "audio/ogg",
+            "audio/midi",
+            "audio/x-midi",
+            "audio/webm",
+            "audio/mp4",
+            # Documents
+            "text/plain",
+            "text/csv",
+            "application/rtf",
+            "application/msword",
+            "application/vnd.oasis.opendocument.text",
+            "application/pdf",
+            "application/vnd.ms-excel",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "application/vnd.oasis.opendocument.spreadsheet",
+        ],
+    )
 )
 
 FACILITY_S3_BUCKET = env("FACILITY_S3_BUCKET", default="")

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -611,6 +611,74 @@ ALLOWED_MIME_TYPES = set(
     )
 )
 
+ALLOWED_FILE_EXTENSIONS = set(
+    env.list(
+        "ALLOWED_FILE_EXTENSIONS",
+        default=[
+            # Images
+            "jpg",
+            "jpeg",
+            "png",
+            "gif",
+            "bmp",
+            "webp",
+            "svg",
+            # Videos
+            "mp4",
+            "mpeg",
+            "avi",
+            "mov",
+            "wmv",
+            "flv",
+            "webm",
+            # Audio
+            "mp3",
+            "wav",
+            "aac",
+            "ogg",
+            "midi",
+            "mid",
+            "m4a",
+            # Documents
+            "txt",
+            "csv",
+            "rtf",
+            "doc",
+            "odt",
+            "pdf",
+            "xls",
+            "xlsx",
+            "ods",
+        ],
+    )
+)
+
+BLOCKED_FILE_EXTENSIONS = set(
+    env.list(
+        "BLOCKED_FILE_EXTENSIONS",
+        default=[
+            # Executable Files
+            "exe",
+            "dll",
+            "msi",
+            "msp",
+            "mst",
+            "com",
+            "scr",
+            "sys",
+            "pif",
+            # Registry Files
+            "reg",
+            # Script Files
+            "bat",
+            "cmd",
+            "wsf",
+            "sh",
+        ],
+    )
+)
+
+
 FACILITY_S3_BUCKET = env("FACILITY_S3_BUCKET", default="")
 FACILITY_S3_REGION = env("FACILITY_S3_REGION_CODE", default=BUCKET_REGION)
 FACILITY_S3_KEY = env("FACILITY_S3_KEY", default=BUCKET_KEY)


### PR DESCRIPTION
## Proposed Changes

- Validate and sign mime types for file uploads
- validate file extensions based on `ALLOWED_FILE_EXTENSIONS` and `BLOCKED_FILE_EXTENSIONS` settings

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced file upload functionality with advanced MIME type validation to ensure only approved file formats are accepted.
  - Improved content type handling by dynamically retrieving information from file metadata for more reliable uploads.
  - Optimized the configuration of allowed MIME types and introduced new variables for allowed and blocked file extensions.
  - Added a new function for extracting multiple file extensions from filenames for better compatibility.

- **Bug Fixes**
  - Updated logic for handling file extensions to accommodate files with multiple extensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->