### PR TITLE
Correctly serialized the updated_by mapping in the ValueSetReadSpec

### DIFF
--- a/care/emr/resources/valueset/spec.py
+++ b/care/emr/resources/valueset/spec.py
@@ -72,7 +72,7 @@ class ValueSetReadSpec(ValueSetBaseSpec):
         if obj.created_by:
             mapping["created_by"] = UserSpec.serialize(obj.created_by)
         if obj.updated_by:
-            mapping["updated_by"] = UserSpec.serialize(obj.created_by)
+            mapping["updated_by"] = UserSpec.serialize(obj.updated_by)
 
 
 ValueSetSpec.model_rebuild()


### PR DESCRIPTION
## Proposed Changes

- In the class ValueSetReadSpec the method perform_extra_serialization is incorrectly serialized the mapping["updated_by"]

- proposed solution : Correctly serialized the mapping["updated_by"] with obj.updated_by

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed the issue where the wrong user data was shown for updates, ensuring that records now accurately display the correct updater information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->