### PR TITLE
fixed location encounter bug

### DIFF
--- a/care/emr/tests/test_location_api.py
+++ b/care/emr/tests/test_location_api.py
@@ -1023,7 +1023,6 @@ class TestFacilityLocationEncounterViewSet(FacilityLocationMixin, CareAPITestBas
         # Update Facility Location Encounter
         response = self.client.put(url, data=data, format="json")
         self.assertEqual(response.status_code, 200)
-
         # Fetch updated object
         encounter_location_obj = FacilityLocationEncounter.objects.get(
             external_id=response.json()["id"]
@@ -1056,3 +1055,9 @@ class TestFacilityLocationEncounterViewSet(FacilityLocationMixin, CareAPITestBas
             LocationEncounterAvailabilityStatusChoices.completed.value,
         )
         self.assertIsNotNone(encounter_location_obj.end_datetime)
+
+        self.assertIsNone(
+            FacilityLocation.objects.get(
+                external_id=self.location["id"]
+            ).current_encounter
+        )


### PR DESCRIPTION
## Proposed Changes

- location with deleted encounter were not updating their current_encounter , causing bug 

### Associated Issue

-Fixes https://github.com/ohcnetwork/care_fe/issues/10909



_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the processing of encounter completions so that all related updates occur simultaneously, ensuring that all active associations are properly cleared when an encounter is finalized.

- **Tests**
  - Augmented validations to confirm that facility records no longer show ongoing encounters once an encounter is completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->