### PR TITLE
Added name and status filters to condition and allergy intolerance

### DIFF
--- a/care/emr/api/viewsets/allergy_intolerance.py
+++ b/care/emr/api/viewsets/allergy_intolerance.py
@@ -35,7 +35,8 @@ from care.security.authorization import AuthorizationController
 class AllergyIntoleranceFilters(FilterSet):
     encounter = filters.UUIDFilter(field_name="encounter__external_id")
     clinical_status = CharFilter(field_name="clinical_status")
-
+    verification_status=CharFilter(field_name="verification_status")
+    name = CharFilter(field_name="code__display", lookup_expr="icontains")
 
 @extend_schema_view(
     create=extend_schema(request=AllergyIntoleranceWriteSpec),

--- a/care/emr/api/viewsets/condition.py
+++ b/care/emr/api/viewsets/condition.py
@@ -56,6 +56,7 @@ class ConditionFilters(FilterSet):
         field_name="verification_status", lookup_expr="iexact"
     )
     severity = CharFilter(field_name="severity", lookup_expr="iexact")
+    name = CharFilter(field_name="code__display", lookup_expr="icontains")
 
 
 class SymptomViewSet(


### PR DESCRIPTION
## Proposed Changes

- Added name and verification_status and name filters to Allergy_intolerance and name filter to Condition(diagnosis and symptoms)

### Associated Issue

- Fixes: https://github.com/ohcnetwork/care/issues/2817

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced filtering options for allergy intolerance records, now allowing searches by verification status and partial name matching.
	- Added a new case-insensitive name search for condition records to streamline data lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->