### PR TITLE
fixed bug in consent create spec

### DIFF
--- a/care/emr/api/viewsets/consent.py
+++ b/care/emr/api/viewsets/consent.py
@@ -19,7 +19,9 @@ from care.emr.resources.consent.spec import (
 
 
 class ConsentViewSet(
-    EMRModelViewSet, EncounterBasedAuthorizationBase, ValidateEncounterMixin
+    ValidateEncounterMixin,
+    EncounterBasedAuthorizationBase,
+    EMRModelViewSet,
 ):
     database_model = Consent
     pydantic_model = ConsentCreateSpec

--- a/care/emr/resources/consent/spec.py
+++ b/care/emr/resources/consent/spec.py
@@ -8,6 +8,8 @@ from care.emr.models import Encounter, FileUpload
 from care.emr.models.consent import Consent
 from care.emr.resources.base import EMRResource, PeriodSpec
 from care.emr.resources.file_upload.spec import (
+    FileCategoryChoices,
+    FileTypeChoices,
     FileUploadListSpec,
 )
 from care.emr.resources.user.spec import UserSpec
@@ -50,6 +52,7 @@ class ConsentVerificationSpec(BaseModel):
 
 class ConsentBaseSpec(EMRResource):
     __model__ = Consent
+    __exclude__ = ["encounter"]
 
     id: UUID4 | None = Field(
         default=None, description="Unique identifier for the consent record"
@@ -92,7 +95,11 @@ class ConsentListSpec(ConsentBaseSpec):
         mapping["id"] = obj.external_id
         mapping["source_attachments"] = [
             FileUploadListSpec.serialize(attachment).to_json()
-            for attachment in FileUpload.objects.filter(associating_id=obj.external_id)
+            for attachment in FileUpload.objects.filter(
+                associating_id=obj.external_id,
+                file_category=FileCategoryChoices.consent_attachment,
+                file_type=FileTypeChoices.consent,
+            )
         ]
         mapping["encounter"] = obj.encounter.external_id
 

--- a/care/emr/tests/test_consent_api.py
+++ b/care/emr/tests/test_consent_api.py
@@ -82,9 +82,32 @@ class TestConsentViewSet(CareAPITestBase):
         response = self.client.get(self.base_url)
         self.assertEqual(response.status_code, 403)
 
+    # CREATE TESTS
+    def test_create_consent_without_permissions(self):
+        encounter = self.create_encounter(
+            patient=self.patient, facility=self.facility, organization=self.organization
+        )
+        data = self.generate_data_for_consent(encounter)
+        response = self.client.post(self.base_url, data, format="json")
+        self.assertEqual(response.status_code, 403)
+
+    def test_create_consent_with_permissions(self):
+        permissions = [EncounterPermissions.can_write_encounter.name]
+        role = self.create_role_with_permissions(permissions)
+        self.attach_role_facility_organization_user(self.organization, self.user, role)
+        encounter = self.create_encounter(
+            patient=self.patient, facility=self.facility, organization=self.organization
+        )
+        data = self.generate_data_for_consent(encounter)
+        response = self.client.post(self.base_url, data, format="json")
+        self.assertEqual(response.status_code, 200)
+
     # RETRIEVE TESTS
     def test_retrieve_consent_with_permissions(self):
-        permissions = [PatientPermissions.can_view_clinical_data.name]
+        permissions = [
+            PatientPermissions.can_view_clinical_data.name,
+            EncounterPermissions.can_write_encounter.name,
+        ]
         role = self.create_role_with_permissions(permissions)
         self.attach_role_facility_organization_user(self.organization, self.user, role)
 
@@ -109,7 +132,10 @@ class TestConsentViewSet(CareAPITestBase):
 
     # UPDATE TESTS
     def test_update_consent_with_permissions(self):
-        permissions = [PatientPermissions.can_view_clinical_data.name]
+        permissions = [
+            PatientPermissions.can_view_clinical_data.name,
+            EncounterPermissions.can_write_encounter.name,
+        ]
         role = self.create_role_with_permissions(permissions)
         self.attach_role_facility_organization_user(self.organization, self.user, role)
 
@@ -137,7 +163,10 @@ class TestConsentViewSet(CareAPITestBase):
 
     # DELETE TESTS
     def test_delete_consent_with_permissions(self):
-        permissions = [PatientPermissions.can_view_clinical_data.name]
+        permissions = [
+            PatientPermissions.can_view_clinical_data.name,
+            EncounterPermissions.can_write_encounter.name,
+        ]
         role = self.create_role_with_permissions(permissions)
         self.attach_role_facility_organization_user(self.organization, self.user, role)
 


### PR DESCRIPTION
## Proposed Changes

- include encounter in exclude
- Added test for create consent (they were left out for some reason)
- Fixed consent viewset's class inheritance sequence 



_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Refined consent attachment handling to ensure only appropriate file uploads are processed.
  - Updated permission checks for creating, retrieving, updating, and deleting consent records to enforce proper access.
  
- **Tests**
  - Added test cases covering consent creation scenarios with and without the required permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->