### PR TITLE
Add more consent types

### DIFF
--- a/care/emr/resources/consent/spec.py
+++ b/care/emr/resources/consent/spec.py
@@ -37,9 +37,19 @@ class DecisionType(str, Enum):
 
 
 class CategoryChoice(str, Enum):
+    unknown = "unknown"
     research = "research"
-    patient_privacy = "patient_privacy"
+    privacy_consent = "privacy_consent"
+    admission = "admission"
     treatment = "treatment"
+    procedure = "procedure"
+    high_risk = "high_risk_consent"
+    # patient code status consents
+    unknown_code_status = "unknown_code_status"
+    dnh = "dnh"
+    dnr = "dnr"
+    comfort_care = "comfort_care"
+    active_treatment = "active_treatment"
 
 
 class ConsentVerificationSpec(BaseModel):

--- a/care/emr/resources/consent/spec.py
+++ b/care/emr/resources/consent/spec.py
@@ -39,7 +39,7 @@ class DecisionType(str, Enum):
 class CategoryChoice(str, Enum):
     unknown = "unknown"
     research = "research"
-    privacy_consent = "privacy_consent"
+    patient_privacy = "patient_privacy"
     admission = "admission"
     treatment = "treatment"
     procedure = "procedure"

--- a/care/emr/resources/consent/spec.py
+++ b/care/emr/resources/consent/spec.py
@@ -43,7 +43,7 @@ class CategoryChoice(str, Enum):
     admission = "admission"
     treatment = "treatment"
     procedure = "procedure"
-    high_risk = "high_risk_consent"
+    high_risk = "high_risk"
     # patient code status consents
     unknown_code_status = "unknown_code_status"
     dnh = "dnh"


### PR DESCRIPTION
## Proposed Changes

- Add more consent types to allow migration of older consent records

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced consent categorization by adding multiple granular options: `unknown`, `admission`, `procedure`, `high_risk`, `unknown_code_status`, `dnh`, `dnr`, `comfort_care`, and `active_treatment`. Existing selections remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->