### PR TITLE
adding limit and some contrainsts

### DIFF
--- a/care/emr/api/viewsets/consent.py
+++ b/care/emr/api/viewsets/consent.py
@@ -1,5 +1,3 @@
-import datetime
-
 from drf_spectacular.utils import extend_schema
 from pydantic import UUID4, BaseModel
 from rest_framework.decorators import action
@@ -17,6 +15,7 @@ from care.emr.resources.consent.spec import (
     ConsentUpdateSpec,
     ConsentVerificationSpec,
 )
+from care.utils.time_util import care_now
 
 
 class ConsentViewSet(
@@ -46,9 +45,7 @@ class ConsentViewSet(
         request_data = ConsentVerificationSpec(**request.data)
 
         request_data.verified_by = str(self.request.user.external_id)
-        request_data.verification_date = datetime.datetime.now(
-            tz=datetime.UTC
-        ).isoformat()
+        request_data.verification_date = care_now().isoformat()
 
         if request_data.verified_by in [
             verification.get("verified_by")

--- a/care/emr/api/viewsets/consent.py
+++ b/care/emr/api/viewsets/consent.py
@@ -1,4 +1,5 @@
-from django.utils.timezone import now
+import datetime
+
 from drf_spectacular.utils import extend_schema
 from pydantic import UUID4, BaseModel
 from rest_framework.decorators import action
@@ -45,7 +46,9 @@ class ConsentViewSet(
         request_data = ConsentVerificationSpec(**request.data)
 
         request_data.verified_by = str(self.request.user.external_id)
-        request_data.verification_date = now().isoformat()
+        request_data.verification_date = datetime.datetime.now(
+            tz=datetime.UTC
+        ).isoformat()
 
         if request_data.verified_by in [
             verification.get("verified_by")

--- a/care/emr/api/viewsets/location.py
+++ b/care/emr/api/viewsets/location.py
@@ -1,5 +1,6 @@
+import datetime
+
 from django.db import transaction
-from django.utils.timezone import now
 from django_filters import rest_framework as filters
 from drf_spectacular.utils import extend_schema
 from pydantic import UUID4, BaseModel
@@ -447,6 +448,6 @@ def close_related_location_from_encounter(instance):
             FacilityLocationEncounter.objects.filter(encounter=instance).exclude(
                 status__in=COMPLETED_CHOICES
             ).update(
-                end_datetime=now(),
+                end_datetime=datetime.datetime.now(tz=datetime.UTC),
                 status=LocationEncounterAvailabilityStatusChoices.completed.value,
             )

--- a/care/emr/api/viewsets/location.py
+++ b/care/emr/api/viewsets/location.py
@@ -1,5 +1,3 @@
-import datetime
-
 from django.db import transaction
 from django_filters import rest_framework as filters
 from drf_spectacular.utils import extend_schema
@@ -35,6 +33,7 @@ from care.emr.resources.location.spec import (
 from care.facility.models import Facility
 from care.security.authorization import AuthorizationController
 from care.utils.lock import Lock
+from care.utils.time_util import care_now
 
 
 class AvailabilityFilter(filters.BooleanFilter):
@@ -448,6 +447,6 @@ def close_related_location_from_encounter(instance):
             FacilityLocationEncounter.objects.filter(encounter=instance).exclude(
                 status__in=COMPLETED_CHOICES
             ).update(
-                end_datetime=datetime.datetime.now(tz=datetime.UTC),
+                end_datetime=care_now(),
                 status=LocationEncounterAvailabilityStatusChoices.completed.value,
             )

--- a/care/emr/api/viewsets/scheduling/availability.py
+++ b/care/emr/api/viewsets/scheduling/availability.py
@@ -1,6 +1,7 @@
 import datetime
 from datetime import time, timedelta
 
+from django.conf import settings
 from django.db import transaction
 from django.db.models import Sum
 from django.utils import timezone
@@ -222,6 +223,19 @@ class SlotViewSet(EMRRetrieveMixin, EMRBaseViewSet):
     def create_appointment_handler(cls, obj, request_data, user):
         request_data = AppointmentBookingSpec(**request_data)
         patient = Patient.objects.filter(external_id=request_data.patient).first()
+
+        if (
+            TokenBooking.objects.filter(
+                patient=patient,
+                token_slot__start_datetime__gte=datetime.datetime.now(datetime.UTC),
+            )
+            .exclude(status__in=CANCELLED_STATUS_CHOICES)
+            .count()
+            >= settings.MAX_APPOINTMENTS_PER_PATIENT
+        ):
+            error = f"Patient already has maximum number of appointments ({settings.MAX_APPOINTMENTS_PER_PATIENT})"
+            raise ValidationError(error)
+
         if not patient:
             raise ValidationError("Patient not found")
         appointment = lock_create_appointment(

--- a/care/emr/api/viewsets/scheduling/availability.py
+++ b/care/emr/api/viewsets/scheduling/availability.py
@@ -25,6 +25,7 @@ from care.emr.resources.scheduling.slot.spec import (
 from care.security.authorization import AuthorizationController
 from care.users.models import User
 from care.utils.lock import Lock
+from care.utils.time_util import care_now
 
 
 class SlotsForDayRequestSpec(BaseModel):
@@ -227,7 +228,7 @@ class SlotViewSet(EMRRetrieveMixin, EMRBaseViewSet):
         if (
             TokenBooking.objects.filter(
                 patient=patient,
-                token_slot__start_datetime__gte=datetime.datetime.now(datetime.UTC),
+                token_slot__start_datetime__gte=care_now(),
             )
             .exclude(status__in=CANCELLED_STATUS_CHOICES)
             .count()

--- a/care/emr/resources/condition/spec.py
+++ b/care/emr/resources/condition/spec.py
@@ -50,6 +50,13 @@ class ConditionOnSetSpec(EMRResource):
     onset_string: str | None = None
     note: str | None = None
 
+    @field_validator("onset_datetime")
+    @classmethod
+    def validate_onset_datetime(cls, onset_datetime: datetime.datetime, info):
+        if onset_datetime and onset_datetime > datetime.datetime.now(tz=datetime.UTC):
+            raise ValueError("Onset date cannot be in the future")
+        return onset_datetime
+
 
 class ConditionAbatementSpec(EMRResource):
     abatement_datetime: datetime.datetime | None = None

--- a/care/emr/resources/condition/spec.py
+++ b/care/emr/resources/condition/spec.py
@@ -11,6 +11,7 @@ from care.emr.resources.base import EMRResource
 from care.emr.resources.common.coding import Coding
 from care.emr.resources.condition.valueset import CARE_CODITION_CODE_VALUESET
 from care.emr.resources.user.spec import UserSpec
+from care.utils.time_util import care_now
 
 
 class ClinicalStatusChoices(str, Enum):
@@ -53,7 +54,7 @@ class ConditionOnSetSpec(EMRResource):
     @field_validator("onset_datetime")
     @classmethod
     def validate_onset_datetime(cls, onset_datetime: datetime.datetime, info):
-        if onset_datetime and onset_datetime > datetime.datetime.now(tz=datetime.UTC):
+        if onset_datetime and onset_datetime > care_now():
             raise ValueError("Onset date cannot be in the future")
         return onset_datetime
 

--- a/care/emr/tests/test_device_api.py
+++ b/care/emr/tests/test_device_api.py
@@ -1,9 +1,9 @@
+import datetime
 import uuid
 from secrets import choice
 from uuid import uuid4
 
 from django.urls import reverse
-from django.utils.timezone import now
 
 from care.emr.models import Device
 from care.emr.resources.device.spec import (
@@ -688,7 +688,7 @@ class TestDeviceServiceHistoryViewSet(DeviceBaseTest):
 
     def generate_data_for_device_service_history(self, **kwargs):
         data = {
-            "serviced_on": now(),
+            "serviced_on": datetime.datetime.now(tz=datetime.UTC),
             "note": self.fake.text(),
         }
         data.update(**kwargs)

--- a/care/emr/tests/test_device_api.py
+++ b/care/emr/tests/test_device_api.py
@@ -1,4 +1,3 @@
-import datetime
 import uuid
 from secrets import choice
 from uuid import uuid4
@@ -23,6 +22,7 @@ from care.security.permissions.facility_organization import (
 )
 from care.security.permissions.location import FacilityLocationPermissions
 from care.utils.tests.base import CareAPITestBase
+from care.utils.time_util import care_now
 
 
 class DeviceBaseTest(CareAPITestBase, FacilityLocationMixin):
@@ -688,7 +688,7 @@ class TestDeviceServiceHistoryViewSet(DeviceBaseTest):
 
     def generate_data_for_device_service_history(self, **kwargs):
         data = {
-            "serviced_on": datetime.datetime.now(tz=datetime.UTC),
+            "serviced_on": care_now(),
             "note": self.fake.text(),
         }
         data.update(**kwargs)

--- a/care/emr/tests/test_diagnosis_api.py
+++ b/care/emr/tests/test_diagnosis_api.py
@@ -18,6 +18,7 @@ from care.emr.resources.resource_request.spec import StatusChoices
 from care.security.permissions.encounter import EncounterPermissions
 from care.security.permissions.patient import PatientPermissions
 from care.utils.tests.base import CareAPITestBase
+from care.utils.time_util import care_now
 
 
 class TestDiagnosisViewSet(CareAPITestBase):
@@ -319,8 +320,7 @@ class TestDiagnosisViewSet(CareAPITestBase):
         diagnosis_data_dict = self.generate_data_for_diagnosis(
             encounter,
             onset={
-                "onset_datetime": datetime.datetime.now(tz=datetime.UTC)
-                + datetime.timedelta(seconds=20),
+                "onset_datetime": care_now() + datetime.timedelta(seconds=20),
             },
         )
         response = self.client.post(self.base_url, diagnosis_data_dict, format="json")

--- a/care/emr/tests/test_diagnosis_api.py
+++ b/care/emr/tests/test_diagnosis_api.py
@@ -1,3 +1,4 @@
+import datetime
 import uuid
 from secrets import choice
 from unittest.mock import patch
@@ -303,6 +304,31 @@ class TestDiagnosisViewSet(CareAPITestBase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["severity"], diagnosis_data_dict["severity"])
         self.assertEqual(response.json()["code"], diagnosis_data_dict["code"])
+
+    def test_create_symptom_with_onset_date_of_future(self):
+        permissions = [EncounterPermissions.can_write_encounter.name]
+        role = self.create_role_with_permissions(permissions)
+        self.attach_role_facility_organization_user(self.organization, self.user, role)
+
+        encounter = self.create_encounter(
+            patient=self.patient,
+            facility=self.facility,
+            organization=self.organization,
+            status=None,
+        )
+        diagnosis_data_dict = self.generate_data_for_diagnosis(
+            encounter,
+            onset={
+                "onset_datetime": datetime.datetime.now(tz=datetime.UTC)
+                + datetime.timedelta(seconds=20),
+            },
+        )
+        response = self.client.post(self.base_url, diagnosis_data_dict, format="json")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("errors", response.json())
+        error = response.json()["errors"][0]
+        self.assertEqual(error["type"], "value_error")
+        self.assertIn("Onset date cannot be in the future", error["msg"])
 
     def test_create_diagnosis_with_permissions_and_encounter_status_completed(self):
         """

--- a/care/emr/tests/test_symptom_api.py
+++ b/care/emr/tests/test_symptom_api.py
@@ -18,6 +18,7 @@ from care.emr.resources.resource_request.spec import StatusChoices
 from care.security.permissions.encounter import EncounterPermissions
 from care.security.permissions.patient import PatientPermissions
 from care.utils.tests.base import CareAPITestBase
+from care.utils.time_util import care_now
 
 
 class TestSymptomViewSet(CareAPITestBase):
@@ -319,8 +320,7 @@ class TestSymptomViewSet(CareAPITestBase):
         symptom_data_dict = self.generate_data_for_symptom(
             encounter,
             onset={
-                "onset_datetime": datetime.datetime.now(tz=datetime.UTC)
-                + datetime.timedelta(seconds=20),
+                "onset_datetime": care_now() + datetime.timedelta(seconds=20),
             },
         )
 

--- a/care/emr/tests/test_symptom_api.py
+++ b/care/emr/tests/test_symptom_api.py
@@ -1,3 +1,4 @@
+import datetime
 import uuid
 from secrets import choice
 from unittest.mock import patch
@@ -303,6 +304,32 @@ class TestSymptomViewSet(CareAPITestBase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["severity"], symptom_data_dict["severity"])
         self.assertEqual(response.json()["code"], symptom_data_dict["code"])
+
+    def test_create_symptom_with_onset_date_of_future(self):
+        permissions = [EncounterPermissions.can_write_encounter.name]
+        role = self.create_role_with_permissions(permissions)
+        self.attach_role_facility_organization_user(self.organization, self.user, role)
+
+        encounter = self.create_encounter(
+            patient=self.patient,
+            facility=self.facility,
+            organization=self.organization,
+            status=None,
+        )
+        symptom_data_dict = self.generate_data_for_symptom(
+            encounter,
+            onset={
+                "onset_datetime": datetime.datetime.now(tz=datetime.UTC)
+                + datetime.timedelta(seconds=20),
+            },
+        )
+
+        response = self.client.post(self.base_url, symptom_data_dict, format="json")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("errors", response.json())
+        error = response.json()["errors"][0]
+        self.assertEqual(error["type"], "value_error")
+        self.assertIn("Onset date cannot be in the future", error["msg"])
 
     def test_create_symptom_with_permissions_and_encounter_status_completed(self):
         """

--- a/care/utils/time_util.py
+++ b/care/utils/time_util.py
@@ -1,0 +1,5 @@
+from django.utils.timezone import now
+
+
+def care_now():
+    return now()

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -722,3 +722,9 @@ SNOWSTORM_DEPLOYMENT_URL = env(
 
 # Path to the typst binary, see scripts/install_typst.sh
 TYPST_BIN = env("TYPST_BIN", default="typst")
+
+MAX_APPOINTMENTS_PER_PATIENT = env.int("MAX_APPOINTMENTS_PER_PATIENT", default=10)
+
+MAX_ACTIVE_ENCOUNTERS_PER_PATIENT = env.int(
+    "MAX_ACTIVE_ENCOUNTERS_PER_PATIENT", default=5
+)


### PR DESCRIPTION
## Proposed Changes

- Only allow 5 active encounters for a given patient at a time
- Onset date for Symptom and Diagnosis should not be in the future
- Limit total scheduled appointments for a patient
- replacing django's now() with datetime.now()

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced validations for appointment and encounter creation to enforce maximum limits and verify necessary entity existence.
  - Added checks to prevent the use of future dates for condition and symptom onset.
  - Enabled new configuration options to dynamically set appointment and encounter limits.
  - Added a utility function for obtaining the current timestamp.
- **Bug Fixes**
  - Updated timestamp handling to consistently use the new utility function across various operations.
- **Tests**
  - Expanded test coverage to verify appointment limits and validate future date restrictions for conditions and symptoms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->