### PR TITLE
Added a Backend validation for not allowing users to submit questions with empty custom choice options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: logs
 
 
-DOCKER_VERSION := docker --version
+DOCKER_VERSION := $(shell docker --version 2>/dev/null)
 
 docker_config_file := 'docker-compose.local.yaml'
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: logs
 
 
-DOCKER_VERSION := $(shell docker --version 2>/dev/null)
+DOCKER_VERSION := docker --version
 
 docker_config_file := 'docker-compose.local.yaml'
 

--- a/care/emr/resources/questionnaire/spec.py
+++ b/care/emr/resources/questionnaire/spec.py
@@ -1,6 +1,5 @@
 import uuid
 from enum import Enum
-from functools import reduce
 from typing import Any
 
 from pydantic import UUID4, ConfigDict, Field, field_validator, model_validator
@@ -174,7 +173,7 @@ class Question(QuestionnaireBaseSpec):
             raise ValueError(err)
 
         if self.answer_option:
-            options_present=reduce(lambda x,y:x and y.value,self.answer_option,True)
+            options_present = all(option.value for option in self.answer_option)
             if not options_present:
                 err="All the answer options must be provided for custom choices"
                 raise ValueError(err)

--- a/care/emr/resources/questionnaire/spec.py
+++ b/care/emr/resources/questionnaire/spec.py
@@ -95,6 +95,12 @@ class AnswerOption(QuestionnaireBaseSpec):
         default=False,
         description="Whether option is initially selected",
     )
+    @field_validator("value")
+    @classmethod
+    def validate_title(cls, value: str, info):
+        if not value.strip():
+            raise ValueError("All the answer option values must be provided for custom choices")
+        return value.strip()
 
 
 class Question(QuestionnaireBaseSpec):
@@ -171,13 +177,6 @@ class Question(QuestionnaireBaseSpec):
         ):
             err = "Either answer options or a value set must be provided for choice type questions"
             raise ValueError(err)
-
-        if self.answer_option:
-            options_present = all(option.value.strip() for option in self.answer_option)
-            if not options_present:
-                err="All the answer options must be provided for custom choices"
-                raise ValueError(err)
-
         return self
 
     @model_validator(mode="after")

--- a/care/emr/resources/questionnaire/spec.py
+++ b/care/emr/resources/questionnaire/spec.py
@@ -97,7 +97,7 @@ class AnswerOption(QuestionnaireBaseSpec):
     )
     @field_validator("value")
     @classmethod
-    def validate_title(cls, value: str, info):
+    def validate_value(cls, value: str, info):
         if not value.strip():
             raise ValueError("All the answer option values must be provided for custom choices")
         return value.strip()

--- a/care/emr/resources/questionnaire/spec.py
+++ b/care/emr/resources/questionnaire/spec.py
@@ -99,7 +99,9 @@ class AnswerOption(QuestionnaireBaseSpec):
     @classmethod
     def validate_value(cls, value: str, info):
         if not value.strip():
-            raise ValueError("All the answer option values must be provided for custom choices")
+            raise ValueError(
+                "All the answer option values must be provided for custom choices"
+            )
         return value.strip()
 
 

--- a/care/emr/resources/questionnaire/spec.py
+++ b/care/emr/resources/questionnaire/spec.py
@@ -1,5 +1,6 @@
 import uuid
 from enum import Enum
+from functools import reduce
 from typing import Any
 
 from pydantic import UUID4, ConfigDict, Field, field_validator, model_validator
@@ -171,6 +172,13 @@ class Question(QuestionnaireBaseSpec):
         ):
             err = "Either answer options or a value set must be provided for choice type questions"
             raise ValueError(err)
+
+        if self.answer_option:
+            options_present=reduce(lambda x,y:x and y.value,self.answer_option,True)
+            if not options_present:
+                err="All the answer options must be provided for custom choices"
+                raise ValueError(err)
+
         return self
 
     @model_validator(mode="after")

--- a/care/emr/resources/questionnaire/spec.py
+++ b/care/emr/resources/questionnaire/spec.py
@@ -173,7 +173,7 @@ class Question(QuestionnaireBaseSpec):
             raise ValueError(err)
 
         if self.answer_option:
-            options_present = all(option.value for option in self.answer_option)
+            options_present = all(option.value.strip() for option in self.answer_option)
             if not options_present:
                 err="All the answer options must be provided for custom choices"
                 raise ValueError(err)

--- a/care/emr/tests/test_questionnaire_api.py
+++ b/care/emr/tests/test_questionnaire_api.py
@@ -286,7 +286,7 @@ class QuestionnaireValidationTests(QuestionnaireTestBase):
         self.assertIn("errors", data)
         error = data["errors"][0]
         self.assertEqual(error["type"], "value_error")
-        self.assertIn("All the answer options must be provided for custom choices", error["msg"])
+        self.assertIn("All the answer option values must be provided for custom choices", error["msg"])
 
 
 class RequiredFieldValidationTests(QuestionnaireTestBase):

--- a/care/emr/tests/test_questionnaire_api.py
+++ b/care/emr/tests/test_questionnaire_api.py
@@ -255,6 +255,39 @@ class QuestionnaireValidationTests(QuestionnaireTestBase):
                 self.assertEqual(error["question_id"], question["id"])
                 self.assertIn(f"Invalid {question_type}", error["msg"])
 
+    def test_false_choice_values_validations(self):
+        questionnaire_definition = {
+            "title": "Comprehensive Health Assessment",
+            "slug": "ques-choices-type",
+            "description": "Complete health assessment questionnaire with various response types",
+            "status": "active",
+            "subject_type": "patient",
+            "organizations": [str(self.organization.external_id)],
+            "questions": [
+                {
+                    "link_id": "1",
+                    "type": "choice",
+                    "text": "Overall health assessment",
+                    "answer_option": [
+                        {"value": " ", "display": "Excellent"},
+                        {"value": "GOOD", "display": "Good"},
+                        {"value": "FAIR", "display": "Fair"},
+                        {"value": "POOR", "display": "Poor"},
+                    ]
+                },
+            ],
+        }
+        response = self.client.post(
+            self.base_url, questionnaire_definition, format="json"
+        )
+        data=response.json()
+        status_code=response.status_code
+        self.assertEqual(status_code, 400)
+        self.assertIn("errors", data)
+        error = data["errors"][0]
+        self.assertEqual(error["type"], "value_error")
+        self.assertIn("All the answer options must be provided for custom choices", error["msg"])
+
 
 class RequiredFieldValidationTests(QuestionnaireTestBase):
     """

--- a/care/emr/tests/test_questionnaire_api.py
+++ b/care/emr/tests/test_questionnaire_api.py
@@ -273,20 +273,23 @@ class QuestionnaireValidationTests(QuestionnaireTestBase):
                         {"value": "GOOD", "display": "Good"},
                         {"value": "FAIR", "display": "Fair"},
                         {"value": "POOR", "display": "Poor"},
-                    ]
+                    ],
                 },
             ],
         }
         response = self.client.post(
             self.base_url, questionnaire_definition, format="json"
         )
-        data=response.json()
-        status_code=response.status_code
+        data = response.json()
+        status_code = response.status_code
         self.assertEqual(status_code, 400)
         self.assertIn("errors", data)
         error = data["errors"][0]
         self.assertEqual(error["type"], "value_error")
-        self.assertIn("All the answer option values must be provided for custom choices", error["msg"])
+        self.assertIn(
+            "All the answer option values must be provided for custom choices",
+            error["msg"],
+        )
 
 
 class RequiredFieldValidationTests(QuestionnaireTestBase):


### PR DESCRIPTION
## Proposed Changes

- Added a backend validation to check if all the answer options has a value in it. Even if one option has value field empty it will raise a value Error

### Associated Issue

- Fixes https://github.com/ohcnetwork/care_fe/issues/11332
- Fixes https://github.com/ohcnetwork/care/issues/2930

##Screen Recording

https://github.com/user-attachments/assets/400cbb23-adea-4ff8-81f1-7a6b5b3e51a9



## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [x] Screen recording added

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@Jacobjeevan @rithviknishad @gigincg @vigneshhari 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced validation for answer option values in questionnaires, ensuring that custom choices are not left blank and providing clear error messages for invalid submissions.

- **Tests**
  - Added tests to confirm that invalid answer option values result in appropriate error responses during questionnaire submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->