### PR TITLE
Allow booking appointment for ongoing slot

### DIFF
--- a/care/emr/api/viewsets/scheduling/availability.py
+++ b/care/emr/api/viewsets/scheduling/availability.py
@@ -108,7 +108,7 @@ def convert_availability_and_exceptions_to_slots(availabilities, exceptions, day
 
 def lock_create_appointment(token_slot, patient, created_by, reason_for_visit):
     with Lock(f"booking:resource:{token_slot.resource.id}"), transaction.atomic():
-        if token_slot.start_datetime < timezone.now():
+        if token_slot.end_datetime < timezone.now():
             raise ValidationError("Slot is already past")
         if token_slot.allocated >= token_slot.availability.tokens_per_slot:
             raise ValidationError("Slot is already full")

--- a/care/emr/tests/test_booking_api.py
+++ b/care/emr/tests/test_booking_api.py
@@ -552,6 +552,22 @@ class TestSlotViewSetAppointmentApi(CareAPITestBase):
         )
         self.assertContains(response, status_code=400, text="Slot is already past")
 
+    def test_create_appointment_ongoing_slot(self):
+        """Users can create appointments for a slot that's currently ongoing."""
+        permissions = [UserSchedulePermissions.can_create_appointment.name]
+        role = self.create_role_with_permissions(permissions)
+        self.attach_role_facility_organization_user(self.organization, self.user, role)
+
+        slot = self.create_slot(
+            start_datetime=datetime.now(UTC) - timedelta(minutes=5),
+            end_datetime=datetime.now(UTC) + timedelta(minutes=5),
+        )
+        data = self.get_appointment_data()
+        response = self.client.post(
+            self._get_create_appointment_url(slot.external_id), data, format="json"
+        )
+        self.assertEqual(response.status_code, 200)
+
     def test_create_multiple_appointments_on_same_slot(self):
         """Users cannot create multiple appointments on the same slot for the same patient."""
         permissions = [UserSchedulePermissions.can_create_appointment.name]


### PR DESCRIPTION
## Proposed Changes

- Allow booking for ongoing slot

### Associated Issue

- https://github.com/ohcnetwork/care_fe/issues/11402

## Merge Checklist

- [x] Tests added/fixed
- [x] Linting Complete

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated appointment booking validation so that time slots remain available for booking until their end time, ensuring ongoing slots are accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->