### PR TITLE
Added Backend Validations for preventing Entry of Death Date Before Birth Date in Patient Form

### DIFF
--- a/care/emr/resources/patient/spec.py
+++ b/care/emr/resources/patient/spec.py
@@ -57,11 +57,15 @@ class PatientCreateSpec(PatientBaseSpec):
     def validate_date_of_birth_and_death_date(self):
         if not (self.age or self.date_of_birth):
             raise ValueError("Either age or date of birth is required")
-        if self.date_of_birth and self.death_datetime and self.date_of_birth > self.death_datetime.date():
+        if (
+            self.date_of_birth
+            and self.death_datetime
+            and self.date_of_birth > self.death_datetime.date()
+        ):
             raise ValueError("Date of birth cannot be after the date of death")
         if self.age and self.death_datetime:
-            curr_year=datetime.datetime.now().year
-            if curr_year-self.age > self.death_datetime.year:
+            curr_year = datetime.datetime.now().year
+            if curr_year - self.age > self.death_datetime.year:
                 raise ValueError("Year of birth cannot be after the year of death")
         return self
 

--- a/care/emr/resources/patient/spec.py
+++ b/care/emr/resources/patient/spec.py
@@ -54,9 +54,15 @@ class PatientCreateSpec(PatientBaseSpec):
     age: int | None = None
 
     @model_validator(mode="after")
-    def validate_age(self):
+    def validate_date_of_birth_and_death_date(self):
         if not (self.age or self.date_of_birth):
             raise ValueError("Either age or date of birth is required")
+        if self.date_of_birth and self.death_datetime and self.date_of_birth > self.death_datetime.date():
+            raise ValueError("Date of birth cannot be after the date of death")
+        if self.age and self.death_datetime:
+            curr_year=datetime.datetime.now().year
+            if curr_year-self.age > self.death_datetime.year:
+                raise ValueError("Year of birth cannot be after the year of death")
         return self
 
     @field_validator("geo_organization")

--- a/care/emr/tests/test_patient_api.py
+++ b/care/emr/tests/test_patient_api.py
@@ -175,3 +175,54 @@ class TestPatientViewSet(CareAPITestBase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["date_of_birth"], "1992-01-10")
         self.assertEqual(response.data["year_of_birth"], 1992)
+    def test_invalid_date_of_birth_and_death_date(self):
+        user = self.create_user()
+        geo_organization = self.create_organization(org_type="govt")
+        role = self.create_role_with_permissions(
+            permissions=[
+                PatientPermissions.can_create_patient.name,
+                PatientPermissions.can_write_patient.name,
+                PatientPermissions.can_list_patients.name,
+            ]
+        )
+        self.attach_role_organization_user(geo_organization, user, role)
+        self.client.force_authenticate(user=user)
+        patient_data = self.generate_patient_data(
+            geo_organization=geo_organization.external_id,
+            date_of_birth=datetime.date(1993, 1, 10),
+            death_datetime=datetime.datetime(1992, 5, 15, 14, 30, 0)
+        )
+        response = self.client.post(self.base_url, patient_data, format="json")
+        data=response.json()
+        status_code=response.status_code
+        self.assertEqual(status_code, 400)
+        self.assertIn("errors", data)
+        error = data["errors"][0]
+        self.assertEqual(error["type"], "value_error")
+        self.assertIn("Date of birth cannot be after the date of death", error["msg"])
+
+    def test_invalid_age_and_death_date(self):
+        user = self.create_user()
+        geo_organization = self.create_organization(org_type="govt")
+        role = self.create_role_with_permissions(
+            permissions=[
+                PatientPermissions.can_create_patient.name,
+                PatientPermissions.can_write_patient.name,
+                PatientPermissions.can_list_patients.name,
+            ]
+        )
+        self.attach_role_organization_user(geo_organization, user, role)
+        self.client.force_authenticate(user=user)
+        patient_data = self.generate_patient_data(
+            geo_organization=geo_organization.external_id,
+            age=12,
+            death_datetime=datetime.datetime(2010, 5, 15, 14, 30, 0)
+        )
+        response = self.client.post(self.base_url, patient_data, format="json")
+        data=response.json()
+        status_code=response.status_code
+        self.assertEqual(status_code, 400)
+        self.assertIn("errors", data)
+        error = data["errors"][0]
+        self.assertEqual(error["type"], "value_error")
+        self.assertIn("Year of birth cannot be after the year of death", error["msg"])

--- a/care/emr/tests/test_patient_api.py
+++ b/care/emr/tests/test_patient_api.py
@@ -190,11 +190,11 @@ class TestPatientViewSet(CareAPITestBase):
         patient_data = self.generate_patient_data(
             geo_organization=geo_organization.external_id,
             date_of_birth=datetime.date(1993, 1, 10),
-            death_datetime=datetime.datetime(1992, 5, 15, 14, 30, 0)
+            death_datetime=datetime.datetime(1992, 5, 15, 14, 30, 0),
         )
         response = self.client.post(self.base_url, patient_data, format="json")
-        data=response.json()
-        status_code=response.status_code
+        data = response.json()
+        status_code = response.status_code
         self.assertEqual(status_code, 400)
         self.assertIn("errors", data)
         error = data["errors"][0]
@@ -216,11 +216,11 @@ class TestPatientViewSet(CareAPITestBase):
         patient_data = self.generate_patient_data(
             geo_organization=geo_organization.external_id,
             age=12,
-            death_datetime=datetime.datetime(2010, 5, 15, 14, 30, 0)
+            death_datetime=datetime.datetime(2010, 5, 15, 14, 30, 0),
         )
         response = self.client.post(self.base_url, patient_data, format="json")
-        data=response.json()
-        status_code=response.status_code
+        data = response.json()
+        status_code = response.status_code
         self.assertEqual(status_code, 400)
         self.assertIn("errors", data)
         error = data["errors"][0]


### PR DESCRIPTION
## Proposed Changes

- Added Validations in PatientCreateSpec for preventing Entry of Death Date Before Birth Date  or Age(birth year) in Patient Form 
- Added test cases for some invalid cases

### Associated Issue

- Fixes https://github.com/ohcnetwork/care/issues/2933
- Fixes https://github.com/ohcnetwork/care_fe/issues/11389

###Screen Recording

https://github.com/user-attachments/assets/da82f42d-990e-49ca-959f-4c55e66fdd94

## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [x] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@vigneshhari @sainak @DraKen0009 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced patient registration validation now checks that provided birth and death date information is consistent, ensuring users receive clear error messages for contradictory data.

- **Tests**
  - Introduced comprehensive tests that verify the improved validation logic, ensuring that inconsistent date entries reliably trigger appropriate error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->