### PR TITLE
Fixed patient filter in consent viewset

### DIFF
--- a/care/emr/api/viewsets/consent.py
+++ b/care/emr/api/viewsets/consent.py
@@ -34,7 +34,7 @@ class ConsentViewSet(
         return (
             super()
             .get_queryset()
-            .filter(patient__external_id=self.kwargs["patient_external_id"])
+            .filter(encounter__patient__external_id=self.kwargs["patient_external_id"])
             .select_related("encounter", "created_by", "updated_by")
         )
 

--- a/care/emr/api/viewsets/consent.py
+++ b/care/emr/api/viewsets/consent.py
@@ -34,6 +34,7 @@ class ConsentViewSet(
         return (
             super()
             .get_queryset()
+            .filter(patient__external_id=self.kwargs["patient_external_id"])
             .select_related("encounter", "created_by", "updated_by")
         )
 

--- a/care/emr/tests/test_consent_api.py
+++ b/care/emr/tests/test_consent_api.py
@@ -102,7 +102,7 @@ class TestConsentViewSet(CareAPITestBase):
         consents = data.get("results", data)
 
         self.assertEqual(len(consents), 1)
-        self.assertEqual(consents[0]["id"], consent_self.external_id)
+        self.assertEqual(consents[0]["id"], str(consent_self.external_id))
 
     def test_list_consent_without_permissions(self):
         self.create_encounter(

--- a/care/emr/tests/test_consent_api.py
+++ b/care/emr/tests/test_consent_api.py
@@ -102,7 +102,7 @@ class TestConsentViewSet(CareAPITestBase):
         consents = data.get("results", data)
 
         self.assertEqual(len(consents), 1)
-        self.assertEqual(consents[0]["external_id"], consent_self.external_id)
+        self.assertEqual(consents[0]["id"], consent_self.external_id)
 
     def test_list_consent_without_permissions(self):
         self.create_encounter(

--- a/care/emr/tests/test_consent_api.py
+++ b/care/emr/tests/test_consent_api.py
@@ -75,6 +75,31 @@ class TestConsentViewSet(CareAPITestBase):
         response = self.client.get(self.base_url)
         self.assertEqual(response.status_code, 200)
 
+    def test_list_consent_are_filtered_by_patients(self):
+        permissions = [PatientPermissions.can_view_clinical_data.name]
+        role = self.create_role_with_permissions(permissions)
+        self.attach_role_facility_organization_user(self.organization, self.user, role)
+
+        encounter_self = self.create_encounter(
+            patient=self.patient, facility=self.facility, organization=self.organization
+        )
+        consent_self = self.create_consent(encounter=encounter_self)
+
+        other_patient = self.create_patient()
+        encounter_other = self.create_encounter(
+            patient=other_patient, facility=self.facility, organization=self.organization
+        )
+        self.create_consent(encounter=encounter_other)
+
+        response = self.client.get(self.base_url)
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        consents = data.get("results", data)
+
+        self.assertEqual(len(consents), 1)
+        self.assertEqual(consents[0]["external_id"], consent_self.external_id)
+
     def test_list_consent_without_permissions(self):
         self.create_encounter(
             patient=self.patient, facility=self.facility, organization=self.organization

--- a/care/emr/tests/test_consent_api.py
+++ b/care/emr/tests/test_consent_api.py
@@ -81,13 +81,17 @@ class TestConsentViewSet(CareAPITestBase):
         self.attach_role_facility_organization_user(self.organization, self.user, role)
 
         encounter_self = self.create_encounter(
-            patient=self.patient, facility=self.facility, organization=self.organization
+            patient=self.patient,
+            facility=self.facility,
+            organization=self.organization,
         )
         consent_self = self.create_consent(encounter=encounter_self)
 
         other_patient = self.create_patient()
         encounter_other = self.create_encounter(
-            patient=other_patient, facility=self.facility, organization=self.organization
+            patient=other_patient,
+            facility=self.facility,
+            organization=self.organization,
         )
         self.create_consent(encounter=encounter_other)
 


### PR DESCRIPTION
## Proposed Changes

- Currently consents are not filtered by patients; added patient filter to the queryset in the viewset


## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced data retrieval to return only consent records relevant to the specified patient.

- **Tests**
  - Added a test to validate that only the appropriate consent records are returned for the authenticated patient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->