### PR TITLE
Call `handle_delete` instead of `handle_update` when deleting device

### DIFF
--- a/care/emr/api/viewsets/device.py
+++ b/care/emr/api/viewsets/device.py
@@ -107,7 +107,7 @@ class DeviceViewSet(EMRModelViewSet):
                 care_device_class = DeviceTypeRegistry.get_care_device_class(
                     instance.care_type
                 )
-                care_device_class().handle_update(self.request.data, instance)
+                care_device_class().handle_delete(instance)
             super().perform_destroy(instance)
 
     def get_queryset(self):


### PR DESCRIPTION
## Proposed Changes

- Call `handle_delete` instead of `handle_update` when deleting device

### Associated Issue

- https://github.com/ohcnetwork/care_fe/pull/11116#issuecomment-2736382319



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the device removal process to ensure that devices are properly deleted, delivering a more reliable and consistent deletion experience for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->