### PR TITLE
Retrieve External Id in QuestionnaireTag

### DIFF
--- a/care/emr/models/questionnaire.py
+++ b/care/emr/models/questionnaire.py
@@ -16,7 +16,11 @@ class QuestionnaireTag(EMRBaseModel):
 
     @classmethod
     def serialize_model(cls, obj):
-        return {"name": obj.name, "slug": obj.slug}
+        return {
+            "id": obj.external_id,
+            "name": obj.name,
+            "slug": obj.slug,
+        }
 
     @classmethod
     def get_tag(cls, tag_id):


### PR DESCRIPTION
## Proposed Changes

- Added external Id for get_tag method, needed for clone questionnaire to work correctly as questionnaire viewset was only returning slug and name.

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced questionnaire data now returns a unique identifier along with existing information for improved distinction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->