### PR TITLE
updated specs for desc

### DIFF
--- a/care/emr/resources/questionnaire/spec.py
+++ b/care/emr/resources/questionnaire/spec.py
@@ -183,7 +183,7 @@ class QuestionnaireWriteSpec(QuestionnaireBaseSpec):
     version: str = Field("1.0", frozen=True, description="Version of the questionnaire")
     slug: str | None = Field(None, min_length=5, max_length=25, pattern=r"^[-\w]+$")
     title: str
-    description: str = ""
+    description: str | None = None
     type: str = "custom"
     status: QuestionnaireStatus
     subject_type: SubjectType
@@ -267,7 +267,7 @@ class QuestionnaireReadSpec(QuestionnaireBaseSpec):
     slug: str | None = None
     version: str
     title: str
-    description: str = ""
+    description: str | None = None
     status: QuestionnaireStatus
     subject_type: SubjectType
     styling_metadata: dict

--- a/care/emr/tests/test_questionnaire_api.py
+++ b/care/emr/tests/test_questionnaire_api.py
@@ -660,6 +660,7 @@ class QuestionnairePermissionTests(QuestionnaireTestBase):
         self.client.force_authenticate(user=self.super_user)
 
         updated_data = self._create_questionnaire()
+        updated_data["description"] = ""
         updated_data["questions"] = [
             {
                 "link_id": "1",
@@ -678,6 +679,7 @@ class QuestionnairePermissionTests(QuestionnaireTestBase):
         self.assertEqual(
             response.json()["questions"][0]["text"], "Modified question text"
         )
+        self.assertEqual(response.json()["description"], "")
 
     # def test_active_questionnaire_modification_prevented(self):
     #     """


### PR DESCRIPTION
## Proposed Changes

- Fixes https://github.com/ohcnetwork/care_fe/issues/11537

## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The questionnaire description field now accepts a null value to indicate the absence of content, providing greater flexibility and accuracy in data submission. Updates to the description are validated more reliably, ensuring that changes are consistently reflected. These improvements enhance the overall reliability of questionnaire data interactions, offering a more precise and predictable experience during both creation and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->