### PR TITLE
Update Redis URL to use CERT_NONE for SSL certificate requirements

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -8,7 +8,7 @@ if [ -z "${DATABASE_URL}" ]; then
 fi
 
 if [ -z "${REDIS_URL}" ]; then
-  export REDIS_URL="rediss://:${REDIS_AUTH_TOKEN}@${REDIS_HOST}:${REDIS_PORT}/${REDIS_DATABASE}?ssl_cert_reqs=none"
+  export REDIS_URL="rediss://:${REDIS_AUTH_TOKEN}@${REDIS_HOST}:${REDIS_PORT}/${REDIS_DATABASE}?ssl_cert_reqs=CERT_NONE"
 fi
 
 


### PR DESCRIPTION
**Signed-off-by:** Areeb Ahmed [areebshariff@acm.org](mailto:areebshariff@acm.org)

## Summary of Changes
**Fixes:** #

- Addressed the ValueError for rediss URL by changing ?ssl_cert_reqs=`none` to `CERT_NONE`

<img width="705" alt="{A7C56A1F-12C8-4855-BDA0-BF126F95D158}" src="https://github.com/user-attachments/assets/6b2f7735-1789-412b-890d-b4b110fff596" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Adjusted the Redis connection setup to use an updated SSL certificate configuration, aligning with current security practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->