### PR TITLE
Allow none for endtime in FacilityLocationEncouterUpdate Spec

### DIFF
--- a/care/emr/resources/location/spec.py
+++ b/care/emr/resources/location/spec.py
@@ -173,7 +173,7 @@ class FacilityLocationEncounterUpdateSpec(FacilityLocationEncounterBaseSpec):
     status: LocationEncounterAvailabilityStatusChoices
 
     start_datetime: datetime.datetime
-    end_datetime: datetime.datetime | None
+    end_datetime: datetime.datetime | None = None
 
 
 class FacilityLocationEncounterListSpec(FacilityLocationEncounterBaseSpec):


### PR DESCRIPTION
## Proposed Changes

- There's already validation logic to check when end_datetime isn't present for other statuses like planned/completed etc. However for active, end time isn't required.

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Facility encounter updates now offer greater flexibility by allowing the end date to be omitted when not provided, simplifying record management for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->