### PR TITLE
Exclude deleted users in token booking's available users API

### DIFF
--- a/care/emr/api/viewsets/scheduling/booking.py
+++ b/care/emr/api/viewsets/scheduling/booking.py
@@ -169,7 +169,8 @@ class TokenBookingViewSet(
         facility_users = FacilityOrganizationUser.objects.filter(
             organization__facility=facility,
             user_id__in=SchedulableUserResource.objects.filter(
-                facility=facility
+                facility=facility,
+                user__deleted=False,
             ).values("user_id"),
         )
 

--- a/care/emr/tests/test_booking_api.py
+++ b/care/emr/tests/test_booking_api.py
@@ -396,7 +396,7 @@ class TestBookingViewSet(CareAPITestBase):
             kwargs={"facility_external_id": self.facility.external_id},
         )
         response = self.client.get(available_users_url)
-        self.assertContains(response, self.user.username)
+        self.assertContains(response, self.user.external_id)
         self.assertNotContains(response, deleted_user.external_id)
 
     def test_list_booking_for_user_with_schedules_in_multiple_facilities(self):

--- a/care/emr/tests/test_booking_api.py
+++ b/care/emr/tests/test_booking_api.py
@@ -385,14 +385,19 @@ class TestBookingViewSet(CareAPITestBase):
         )
 
     def test_list_available_users(self):
-        """Users can list available schedulable users."""
+        """Users can list available schedulable users and ensure deleted users are not listed"""
+        deleted_user = self.create_user()
+        self.create_resource(user=deleted_user)
+        deleted_user.deleted = True
+        deleted_user.save()
+
         available_users_url = reverse(
             "appointments-available-users",
             kwargs={"facility_external_id": self.facility.external_id},
         )
         response = self.client.get(available_users_url)
-        self.assertEqual(response.status_code, 200)
-        self.assertGreaterEqual(len(response.data["users"]), 1)
+        self.assertContains(response, self.user.username)
+        self.assertNotContains(response, deleted_user.external_id)
 
     def test_list_booking_for_user_with_schedules_in_multiple_facilities(self):
         """Appointments for a user with schedules in multiple facilities are filtered correctly."""


### PR DESCRIPTION
## Proposed Changes

- Exclude deleted users in token booking's available users API

## Merge Checklist

- [x] Tests added/fixed
- [x] Linting Complete

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the scheduling functionality to ensure that only active users are displayed, effectively excluding any users marked as deleted.

- **Tests**
  - Revised tests to verify that deleted users are not included in the available user listings for scheduling functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->