### PR TITLE
Fix typo in class name

### DIFF
--- a/care/emr/utils/file_manager.py
+++ b/care/emr/utils/file_manager.py
@@ -3,13 +3,13 @@ import boto3
 from care.utils.csp.config import get_client_config
 
 
-class FileManger:
+class FileManager:
     """
     A utility class to manage all file management related operations
     """
 
 
-class S3FilesManager(FileManger):
+class S3FilesManager(FileManager):
     bucket_type = None
 
     def __init__(self, bucket_type):


### PR DESCRIPTION
Correct Manager spelling.

Edit: this will not break our develop :')

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins