### PR TITLE
Update facility org cache in add/remove managing org

### DIFF
--- a/care/emr/api/viewsets/device.py
+++ b/care/emr/api/viewsets/device.py
@@ -265,7 +265,9 @@ class DeviceViewSet(EMRModelViewSet):
         ).exists():
             raise ValidationError("Organization is already associated with this device")
         device.managing_organization = organization
-        device.save(update_fields=["managing_organization"])
+        device.save(
+            update_fields=["managing_organization", "facility_organization_cache"]
+        )
         return Response({})
 
     @action(detail=True, methods=["POST"])
@@ -287,7 +289,9 @@ class DeviceViewSet(EMRModelViewSet):
             )
 
         device.managing_organization = None
-        device.save(update_fields=["managing_organization"])
+        device.save(
+            update_fields=["managing_organization", "facility_organization_cache"]
+        )
         return Response({})
 
 

--- a/care/emr/tests/test_device_api.py
+++ b/care/emr/tests/test_device_api.py
@@ -469,6 +469,12 @@ class TestDeviceViewSet(DeviceBaseTest):
             Device.objects.get(external_id=self.device["id"]).managing_organization,
             self.managing_org,
         )
+        self.assertIn(
+            self.managing_org.id,
+            Device.objects.get(
+                external_id=self.device["id"]
+            ).facility_organization_cache,
+        )
 
         response = self.client.post(
             self.add_url,
@@ -509,6 +515,12 @@ class TestDeviceViewSet(DeviceBaseTest):
         self.assertEqual(response.status_code, 200)
         self.assertIsNone(
             Device.objects.get(external_id=self.device["id"]).managing_organization
+        )
+        self.assertNotIn(
+            self.managing_org.id,
+            Device.objects.get(
+                external_id=self.device["id"]
+            ).facility_organization_cache,
         )
 
     def test_remove_managing_organization_without_permissions(self):


### PR DESCRIPTION
## Proposed Changes

- Minor edit to allow to ensure facility org cache updates when managing org is added/edited

## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that when an organization's association on a device is added or removed, all relevant organization details update simultaneously for improved data consistency.
- **Tests**
  - Enhanced tests now validate that organization changes are correctly reflected, providing greater confidence in the device’s organizational management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->