### PR TITLE
Add timezone awareness validation for start and end dates in PeriodSpec

### DIFF
--- a/care/emr/resources/base.py
+++ b/care/emr/resources/base.py
@@ -2,6 +2,7 @@ import datetime
 from typing import Annotated, Union
 
 import phonenumbers
+from django.utils.timezone import is_naive
 from pydantic import BaseModel, model_validator
 from pydantic_extra_types.phone_numbers import PhoneNumberValidator
 
@@ -167,6 +168,10 @@ class PeriodSpec(BaseModel):
 
     @model_validator(mode="after")
     def validate_period(self):
+        if self.start and is_naive(self.start):
+            raise ValueError("Start Date must be timezone aware")
+        if self.end and is_naive(self.end):
+            raise ValueError("End Date must be timezone aware")
         if (self.start and self.end) and (self.start > self.end):
             raise ValueError("Start Date cannot be greater than End Date")
         return self


### PR DESCRIPTION
## Proposed Changes

- Add timezone awareness validation for start and end dates in PeriodSpec
- fixes https://github.com/ohcnetwork/roadmap/issues/67

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced validation for date inputs by requiring start and end dates to include complete timezone information. Users will now receive clear error feedback when dates lack proper timezone details, ensuring improved data accuracy and preventing potential scheduling inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->