### PR TITLE
Fix test cases for period spec

### DIFF
--- a/care/emr/tests/test_consent_api.py
+++ b/care/emr/tests/test_consent_api.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import timedelta
+from datetime import timedelta, timezone
 from secrets import choice
 
 from django.forms import model_to_dict
@@ -47,7 +47,9 @@ class TestConsentViewSet(CareAPITestBase):
         return baker.make(Consent, encounter=encounter, **data)
 
     def generate_data_for_consent(self, encounter, **kwargs):
-        start = self.fake.date_time_this_year()
+        start = self.fake.date_time_this_year(
+            tzinfo=timezone(timedelta(hours=5, minutes=30))
+        )
         end = start + timedelta(days=1)
         date = start
 
@@ -139,7 +141,9 @@ class TestConsentViewSet(CareAPITestBase):
         encounter = self.create_encounter(
             patient=self.patient, facility=self.facility, organization=self.organization
         )
-        start = self.fake.date_time_this_year()
+        start = self.fake.date_time_this_year(
+            tzinfo=timezone(timedelta(hours=5, minutes=30))
+        )
         end = start + timedelta(days=1)
         date = end + timedelta(hours=1)
         data = self.generate_data_for_consent(


### PR DESCRIPTION
## Proposed Changes

- pass tzinfo while faking datetime, using a specific offset because if we pass UTC(00:00) `<timestamp>+00:00` the response is formatted and returned as `<timestamp>Z`

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the handling of date and time in the consent process to use timezone-aware values (UTC+5:30). This improvement ensures that date comparisons and validations are performed more accurately and consistently, reducing discrepancies linked to timezone differences. As a result, the system now provides more reliable and efficient processing of consent information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->