### PR TITLE
Prevent duplicate users in scheduling's available users API

### DIFF
--- a/care/emr/api/viewsets/scheduling/booking.py
+++ b/care/emr/api/viewsets/scheduling/booking.py
@@ -30,7 +30,7 @@ from care.emr.resources.scheduling.slot.spec import (
     TokenBookingWriteSpec,
 )
 from care.emr.resources.user.spec import UserSpec
-from care.facility.models import Facility, FacilityOrganizationUser
+from care.facility.models import Facility
 from care.security.authorization import AuthorizationController
 
 
@@ -166,19 +166,16 @@ class TokenBookingViewSet(
     @action(detail=False, methods=["GET"])
     def available_users(self, request, *args, **kwargs):
         facility = self.get_facility_obj()
-        facility_users = FacilityOrganizationUser.objects.filter(
-            organization__facility=facility,
-            user_id__in=SchedulableUserResource.objects.filter(
-                facility=facility,
-                user__deleted=False,
-            ).values("user_id"),
-        ).distinct("user_id")
+        user_resources = SchedulableUserResource.objects.filter(
+            facility=facility,
+            user__deleted=False,
+        )
 
         return Response(
             {
                 "users": [
-                    UserSpec.serialize(facility_user.user).to_json()
-                    for facility_user in facility_users
+                    UserSpec.serialize(user_resource.user).to_json()
+                    for user_resource in user_resources
                 ]
             }
         )

--- a/care/emr/api/viewsets/scheduling/booking.py
+++ b/care/emr/api/viewsets/scheduling/booking.py
@@ -172,7 +172,7 @@ class TokenBookingViewSet(
                 facility=facility,
                 user__deleted=False,
             ).values("user_id"),
-        )
+        ).distinct("user_id")
 
         return Response(
             {

--- a/care/emr/tests/test_booking_api.py
+++ b/care/emr/tests/test_booking_api.py
@@ -11,6 +11,7 @@ from care.emr.models import (
     TokenBooking,
     TokenSlot,
 )
+from care.emr.models.organization import FacilityOrganizationUser
 from care.emr.resources.scheduling.schedule.spec import SlotTypeOptions
 from care.emr.resources.scheduling.slot.spec import (
     CANCELLED_STATUS_CHOICES,
@@ -385,18 +386,35 @@ class TestBookingViewSet(CareAPITestBase):
         )
 
     def test_list_available_users(self):
-        """Users can list available schedulable users and ensure deleted users are not listed"""
+        """Users can list available schedulable users and ensure deleted users are not listed and are distinct"""
+
+        # Create a deleted user and a schedulable user resource for it
         deleted_user = self.create_user()
         self.create_resource(user=deleted_user)
         deleted_user.deleted = True
         deleted_user.save()
+
+        # Attach user to multiple FacilityOrganization
+        self.attach_role_facility_organization_user(
+            organization=self.create_facility_organization(facility=self.facility),
+            user=self.user,
+            role=self.create_role(),
+        )
+
+        # Assert that user is linked to the same facility under two organizations
+        self.assertEqual(
+            FacilityOrganizationUser.objects.filter(
+                organization__facility=self.facility, user=self.user
+            ).count(),
+            2,
+        )
 
         available_users_url = reverse(
             "appointments-available-users",
             kwargs={"facility_external_id": self.facility.external_id},
         )
         response = self.client.get(available_users_url)
-        self.assertContains(response, self.user.external_id)
+        self.assertContains(response, self.user.external_id, count=1)
         self.assertNotContains(response, deleted_user.external_id)
 
     def test_list_booking_for_user_with_schedules_in_multiple_facilities(self):

--- a/care/emr/tests/test_booking_api.py
+++ b/care/emr/tests/test_booking_api.py
@@ -11,7 +11,6 @@ from care.emr.models import (
     TokenBooking,
     TokenSlot,
 )
-from care.emr.models.organization import FacilityOrganizationUser
 from care.emr.resources.scheduling.schedule.spec import SlotTypeOptions
 from care.emr.resources.scheduling.slot.spec import (
     CANCELLED_STATUS_CHOICES,
@@ -386,35 +385,18 @@ class TestBookingViewSet(CareAPITestBase):
         )
 
     def test_list_available_users(self):
-        """Users can list available schedulable users and ensure deleted users are not listed and are distinct"""
-
-        # Create a deleted user and a schedulable user resource for it
+        """Users can list available schedulable users and ensure deleted users are not listed"""
         deleted_user = self.create_user()
         self.create_resource(user=deleted_user)
         deleted_user.deleted = True
         deleted_user.save()
-
-        # Attach user to multiple FacilityOrganization
-        self.attach_role_facility_organization_user(
-            organization=self.create_facility_organization(facility=self.facility),
-            user=self.user,
-            role=self.create_role(),
-        )
-
-        # Assert that user is linked to the same facility under two organizations
-        self.assertEqual(
-            FacilityOrganizationUser.objects.filter(
-                organization__facility=self.facility, user=self.user
-            ).count(),
-            2,
-        )
 
         available_users_url = reverse(
             "appointments-available-users",
             kwargs={"facility_external_id": self.facility.external_id},
         )
         response = self.client.get(available_users_url)
-        self.assertContains(response, self.user.external_id, count=1)
+        self.assertContains(response, self.user.external_id)
         self.assertNotContains(response, deleted_user.external_id)
 
     def test_list_booking_for_user_with_schedules_in_multiple_facilities(self):


### PR DESCRIPTION
## Proposed Changes

- Perform distinct on `user_id` for available users query.

### Associated Issue

- See comment: https://github.com/ohcnetwork/care_fe/issues/11358#issuecomment-2785425019
- Fixes https://github.com/ohcnetwork/care_fe/issues/11358


## Merge Checklist

- [x] Tests added/fixed
- [x] Linting Complete

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified the logic for retrieving available users for scheduling, resulting in a more streamlined and efficient experience when viewing schedulable users. No visible changes to the user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->