### PR TITLE
fixed encounter update for not updating discharge summary advice with null

### DIFF
--- a/care/emr/resources/encounter/spec.py
+++ b/care/emr/resources/encounter/spec.py
@@ -99,6 +99,8 @@ class EncounterUpdateSpec(EncounterSpecBase):
             obj.encounter_class_history["history"].append(
                 {"status": self.status, "moved_at": str(timezone.now())}
             )
+        if self.discharge_summary_advice is None and is_update:
+            obj.discharge_summary_advice = None
 
 
 class EncounterListSpec(EncounterSpecBase):


### PR DESCRIPTION
## Proposed Changes

- If a update request is sent to encounter with discharge summary advice as null , backend was ignoring it (as none is default value for it and we exclude default for update)

### Associated Issue

- Link to issue here, explain how the proposed solution will solve the reported issue/ feature request.

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Encounter updates now properly clear the optional discharge advice when no value is provided, ensuring consistent and reliable record updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->