### PR TITLE
Allow doctors and nurses to associate devices to encounters

### DIFF
--- a/care/emr/api/viewsets/device.py
+++ b/care/emr/api/viewsets/device.py
@@ -163,7 +163,10 @@ class DeviceViewSet(EMRModelViewSet):
         if encounter and encounter.facility_id != facility.id:
             raise ValidationError("Encounter is not part of given facility")
 
-        self.authorize_update(None, device)
+        if not AuthorizationController.call(
+            "can_manage_device_associations_to_encounters", self.request.user, device
+        ):
+            raise PermissionDenied("You do not have permission to associate device")
 
         if encounter and not AuthorizationController.call(
             "can_update_encounter_obj", self.request.user, encounter

--- a/care/emr/tests/test_device_api.py
+++ b/care/emr/tests/test_device_api.py
@@ -196,7 +196,9 @@ class TestDeviceViewSet(DeviceBaseTest):
             self.patient, self.facility, self.facility.default_internal_organization
         )
         # Only encounter permission attached (missing device permission).
-        self.add_permissions([DevicePermissions.can_manage_devices.name])
+        self.add_permissions(
+            [DevicePermissions.can_manage_device_associations_to_encounters.name]
+        )
         url = self.get_associate_encounter_url(device)
         data = {"encounter": encounter.external_id}
         response = self.client.post(url, data=data, format="json")
@@ -248,7 +250,7 @@ class TestDeviceViewSet(DeviceBaseTest):
         self.add_permissions(
             [
                 EncounterPermissions.can_write_encounter.name,
-                DevicePermissions.can_manage_devices.name,
+                DevicePermissions.can_manage_device_associations_to_encounters.name,
             ]
         )
         url = self.get_associate_encounter_url(device)
@@ -267,7 +269,7 @@ class TestDeviceViewSet(DeviceBaseTest):
         self.add_permissions(
             [
                 EncounterPermissions.can_write_encounter.name,
-                DevicePermissions.can_manage_devices.name,
+                DevicePermissions.can_manage_device_associations_to_encounters.name,
             ]
         )
         url = self.get_associate_encounter_url(device)
@@ -290,7 +292,7 @@ class TestDeviceViewSet(DeviceBaseTest):
         self.add_permissions(
             [
                 EncounterPermissions.can_write_encounter.name,
-                DevicePermissions.can_manage_devices.name,
+                DevicePermissions.can_manage_device_associations_to_encounters.name,
             ]
         )
         url = self.get_associate_encounter_url(device)
@@ -410,7 +412,7 @@ class TestDeviceViewSet(DeviceBaseTest):
         self.add_permissions(
             [
                 EncounterPermissions.can_write_encounter.name,
-                DevicePermissions.can_manage_devices.name,
+                DevicePermissions.can_manage_device_associations_to_encounters.name,
             ]
         )
         associate_url = self.get_associate_encounter_url(device)

--- a/care/security/authorization/device.py
+++ b/care/security/authorization/device.py
@@ -37,5 +37,12 @@ class DeviceAccess(AuthorizationHandler):
             device.facility_organization_cache,
         )
 
+    def can_manage_device_associations_to_encounters(self, user, device):
+        return self.check_permission_in_facility_organization(
+            [DevicePermissions.can_manage_device_associations_to_encounters.name],
+            user,
+            device.facility_organization_cache,
+        )
+
 
 AuthorizationController.register_internal_controller(DeviceAccess)

--- a/care/security/permissions/device.py
+++ b/care/security/permissions/device.py
@@ -17,9 +17,15 @@ class DevicePermissions(enum.Enum):
         PermissionContext.FACILITY,
         [STAFF_ROLE, ADMIN_ROLE, DOCTOR_ROLE, NURSE_ROLE, FACILITY_ADMIN_ROLE],
     )
+    can_manage_device_associations_to_encounters = Permission(
+        "Can Manage Device Associations to Encounters",
+        "",
+        PermissionContext.FACILITY,
+        [STAFF_ROLE, ADMIN_ROLE, DOCTOR_ROLE, NURSE_ROLE, FACILITY_ADMIN_ROLE],
+    )
     can_manage_devices = Permission(
         "Can Manage Devices on Facility",
         "",
         PermissionContext.FACILITY,
-        [STAFF_ROLE, ADMIN_ROLE, DOCTOR_ROLE, NURSE_ROLE, FACILITY_ADMIN_ROLE],
+        [STAFF_ROLE, ADMIN_ROLE, FACILITY_ADMIN_ROLE],
     )

--- a/care/security/permissions/device.py
+++ b/care/security/permissions/device.py
@@ -21,5 +21,5 @@ class DevicePermissions(enum.Enum):
         "Can Manage Devices on Facility",
         "",
         PermissionContext.FACILITY,
-        [STAFF_ROLE, ADMIN_ROLE, FACILITY_ADMIN_ROLE],
+        [STAFF_ROLE, ADMIN_ROLE, DOCTOR_ROLE, NURSE_ROLE, FACILITY_ADMIN_ROLE],
     )


### PR DESCRIPTION
Expand device management permissions to include doctors and nurses

- closes https://github.com/ohcnetwork/roadmap/issues/86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded device management permissions to allow doctors and nurses to manage device associations to encounters within a facility.
  - Introduced more granular control for managing device-encounter associations, improving security and role-based access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->