### PR TITLE
Fix 404 error for usernames with dots in user API

### DIFF
--- a/care/emr/api/viewsets/user.py
+++ b/care/emr/api/viewsets/user.py
@@ -42,6 +42,7 @@ class UserViewSet(EMRModelViewSet):
     pydantic_read_model = UserSpec
     pydantic_retrieve_model = UserRetrieveSpec
     lookup_field = "username"
+    lookup_value_regex = "[^/]+"
     filterset_class = UserFilter
     filter_backends = [filters.DjangoFilterBackend, drf_filters.SearchFilter]
     search_fields = ["first_name", "last_name", "username"]


### PR DESCRIPTION
Adjust the regex for username lookup to handle dots, preventing 404 errors for such usernames.

original regex: `[^/.]+`

to dig deeper: https://www.django-rest-framework.org/api-guide/format-suffixes/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved username handling by restricting invalid characters in user-related endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->