### PR TITLE
Add validations for facility organization deletion

### DIFF
--- a/care/emr/tests/test_facility_org_api.py
+++ b/care/emr/tests/test_facility_org_api.py
@@ -54,6 +54,21 @@ class FacilityOrganizationDeleteValidationTests(CareAPITestBase):
         ):
             org_user_role.refresh_from_db()
 
+    def test_delete_root_facility_organization(self):
+        self.attach_role_facility_organization_user(
+            self.facility_root_org, self.user, self.manage_role
+        )
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.delete(self._get_url(self.facility_root_org.external_id))
+
+        self.assertEqual(response.status_code, 400, f"Response: {response.data}")
+        self.assertContains(
+            response,
+            "Cannot delete root organization",
+            status_code=400,
+        )
+
     def test_delete_facility_organization_without_permission(self):
         facility_org = self.create_facility_organization(
             facility=self.facility, parent=self.facility_root_org

--- a/care/emr/tests/test_facility_org_api.py
+++ b/care/emr/tests/test_facility_org_api.py
@@ -1,0 +1,135 @@
+from django.urls import reverse
+
+from care.security.permissions.facility_organization import (
+    FacilityOrganizationPermissions,
+)
+from care.utils.tests.base import CareAPITestBase
+
+
+class FacilityOrganizationDeleteValidationTests(CareAPITestBase):
+    def setUp(self):
+        self.super_user = self.create_super_user()
+        self.user = self.create_user()
+        self.facility = self.create_facility(user=self.user)
+        self.facility_root_org = self.facility.default_internal_organization
+        self.manage_role = self.create_role_with_permissions(
+            permissions=[
+                FacilityOrganizationPermissions.can_view_facility_organization.name,
+                FacilityOrganizationPermissions.can_delete_facility_organization.name,
+            ]
+        )
+
+    def _get_url(self, org_id):
+        return reverse(
+            "facility-organization-detail",
+            kwargs={
+                "facility_external_id": self.facility.external_id,
+                "external_id": org_id,
+            },
+        )
+
+    def test_delete_facility_organization(self):
+        facility_org = self.create_facility_organization(
+            facility=self.facility, parent=self.facility_root_org
+        )
+
+        org_user_role = self.attach_role_facility_organization_user(
+            facility_org, self.user, self.manage_role
+        )
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.delete(self._get_url(facility_org.external_id))
+
+        self.assertEqual(response.status_code, 204, f"Response: {response.data}")
+
+        facility_org.refresh_from_db()
+        self.assertEqual(
+            facility_org.deleted,
+            True,
+            "Facility organization was not marked as deleted",
+        )
+
+        with self.assertRaises(
+            org_user_role.DoesNotExist, msg="Organization user role was not deleted"
+        ):
+            org_user_role.refresh_from_db()
+
+    def test_delete_facility_organization_without_permission(self):
+        facility_org = self.create_facility_organization(
+            facility=self.facility, parent=self.facility_root_org
+        )
+
+        limited_role = self.create_role_with_permissions(
+            permissions=[
+                FacilityOrganizationPermissions.can_view_facility_organization.name,
+            ]
+        )
+        self.attach_role_facility_organization_user(
+            facility_org, self.user, limited_role
+        )
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.delete(self._get_url(facility_org.external_id))
+
+        self.assertEqual(response.status_code, 403, f"Response: {response.data}")
+
+        self.assertContains(
+            response,
+            "User does not have the required permissions to delete this organization",
+            status_code=403,
+        )
+
+        facility_org.refresh_from_db()
+        self.assertEqual(
+            facility_org.deleted,
+            False,
+            "Facility organization was marked as deleted without permission",
+        )
+
+    def test_delete_facility_organization_with_members(self):
+        facility_org = self.create_facility_organization(
+            facility=self.facility, parent=self.facility_root_org
+        )
+
+        member_role = self.create_role_with_permissions(permissions=[])
+
+        self.attach_role_facility_organization_user(
+            facility_org, self.create_user(), member_role
+        )
+
+        self.attach_role_facility_organization_user(
+            facility_org, self.user, self.manage_role
+        )
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.delete(self._get_url(facility_org.external_id))
+
+        self.assertEqual(response.status_code, 400, f"Response: {response.data}")
+
+        self.assertContains(
+            response,
+            "Cannot delete organization with users",
+            status_code=400,
+        )
+
+    def test_delete_facility_organization_with_children(self):
+        facility_org = self.create_facility_organization(
+            facility=self.facility, parent=self.facility_root_org
+        )
+
+        self.create_facility_organization(facility=self.facility, parent=facility_org)
+
+        self.attach_role_facility_organization_user(
+            facility_org, self.user, self.manage_role
+        )
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.delete(self._get_url(facility_org.external_id))
+
+        self.assertEqual(response.status_code, 400, f"Response: {response.data}")
+
+        self.assertContains(
+            response,
+            "Cannot delete organization with children",
+            status_code=400,
+        )

--- a/care/utils/tests/base.py
+++ b/care/utils/tests/base.py
@@ -1,6 +1,7 @@
 import sys
 from unittest.mock import MagicMock
 
+from django.forms.models import model_to_dict
 from faker import Faker
 from model_bakery import baker
 from rest_framework.test import APITestCase
@@ -58,10 +59,14 @@ class CareAPITestBase(APITestCase):
 
         role = baker.make(RoleModel, name=role_name or self.fake.name())
 
+        bulk = []
         for permission in permissions:
-            RolePermission.objects.create(
-                role=role, permission=baker.make(PermissionModel, slug=permission)
+            permission_obj, _ = PermissionModel.objects.get_or_create(
+                slug=permission,
+                defaults=model_to_dict(baker.prepare(PermissionModel, slug=permission)),
             )
+            bulk.append(RolePermission(role=role, permission=permission_obj))
+        RolePermission.objects.bulk_create(bulk)
         return role
 
     def create_patient(self, **kwargs):
@@ -92,9 +97,11 @@ class CareAPITestBase(APITestCase):
         return encounter
 
     def attach_role_organization_user(self, organization, user, role):
-        OrganizationUser.objects.create(organization=organization, user=user, role=role)
+        return OrganizationUser.objects.create(
+            organization=organization, user=user, role=role
+        )
 
     def attach_role_facility_organization_user(self, organization, user, role):
-        FacilityOrganizationUser.objects.create(
+        return FacilityOrganizationUser.objects.create(
             organization=organization, user=user, role=role
         )


### PR DESCRIPTION
Implement validation checks to prevent deletion of root organizations, organizations with children, and organizations that have users associated with them. Update error messages and add tests.

- closes https://github.com/ohcnetwork/roadmap/issues/72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messages and validation when attempting to delete facility organizations, including clearer feedback if the organization has associated users or child organizations.
- **New Features**
  - Added a soft-delete mechanism for facility organizations, ensuring related user roles are also cleaned up upon deletion.
- **Tests**
  - Introduced comprehensive tests to verify correct deletion behavior, permission checks, and validation for facility organizations.
- **Refactor**
  - Enhanced internal utilities for role and permission management to improve reliability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->