### PR TITLE
Fixes `parent` obj. not being saved when setting `has_children` for `FaciityLocation`

### DIFF
--- a/care/emr/models/location.py
+++ b/care/emr/models/location.py
@@ -113,6 +113,7 @@ class FacilityLocation(EMRBaseModel):
                     self.root_location = self.parent.root_location
                 if not self.parent.has_children:
                     self.parent.has_children = True
+                    self.parent.save(update_fields=["has_children"])
         else:
             self.cached_parent_json = {}
         if not self.sort_index:


### PR DESCRIPTION


## Proposed Changes

- Fixes `parent` obj. not being saved when setting `has_children` for `FaciityLocation`

## Merge Checklist

- [ ] Tests added/fixed
- [x] Linting Complete

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that parent locations immediately reflect updates when a new child location is added. The parent’s status is now saved without delay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->