### PR TITLE
Refactor mock for validate_valueset and enhance Celery error logging

### DIFF
--- a/care/utils/tests/base.py
+++ b/care/utils/tests/base.py
@@ -1,5 +1,4 @@
 import sys
-from unittest.mock import MagicMock
 
 from faker import Faker
 from model_bakery import baker
@@ -8,13 +7,10 @@ from rest_framework.test import APITestCase
 from care.emr.models.organization import FacilityOrganizationUser, OrganizationUser
 
 # Global mocking, since the types are loaded when specs load, mocking using patch was not working as the validations were already loaded.
-sys.modules["care.emr.utils.valueset_coding_type"].validate_valueset = MagicMock(
-    return_value={
-        "display": "Test Value",
-        "system": "http://test_system.care/test",
-        "code": "123",
-    }
-)
+# TODO: figure out a more customizeable approach to mock this
+import care.emr.utils.valueset_coding_type  # noqa  # isort:skip
+
+sys.modules["care.emr.utils.valueset_coding_type"].validate_valueset = lambda f, s, c: c
 
 
 class CareAPITestBase(APITestCase):

--- a/care/utils/tests/base.py
+++ b/care/utils/tests/base.py
@@ -1,5 +1,4 @@
 import sys
-
 from secrets import choice
 
 from faker import Faker

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -82,6 +82,10 @@ LOGGING = {
             "handlers": ["console"],
             "level": "ERROR",
         },
+        "celery": {
+            "handlers": ["console"],
+            "level": "ERROR",
+        },
     },
     "root": {"level": "INFO", "handlers": ["console"]},
 }


### PR DESCRIPTION
Refactor the mock for `validate_valueset` in tests to improve customization and add error logging for Celery to enhance error tracking.

- Fixes the test failure when the module was not imported or a different code was used
- hides the celery eager mode logs in test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated test logging configuration to include a dedicated logger for Celery tasks, ensuring error messages are properly captured during testing.  
- **Tests**
	- Enhanced test utilities by refining the mocking approach for better maintainability and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->