### PR TITLE
Prevent deletion of organizations with associated encounters, locations, or devices

### DIFF
--- a/care/emr/api/viewsets/facility_organization.py
+++ b/care/emr/api/viewsets/facility_organization.py
@@ -111,7 +111,7 @@ class FacilityOrganizationViewSet(EMRModelViewSet):
         if FacilityLocationOrganization.objects.filter(organization=instance).exists():
             raise ValidationError("Cannot delete organization with locations")
 
-        if Device.objects.filter(organization=instance).exists():
+        if Device.objects.filter(managing_organization=instance).exists():
             raise ValidationError("Cannot delete organization with devices")
 
         if self.request.user.is_superuser:

--- a/care/emr/api/viewsets/facility_organization.py
+++ b/care/emr/api/viewsets/facility_organization.py
@@ -8,6 +8,9 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 
 from care.emr.api.viewsets.base import EMRModelViewSet
+from care.emr.models.device import Device
+from care.emr.models.encounter import EncounterOrganization
+from care.emr.models.location import FacilityLocationOrganization
 from care.emr.models.organization import FacilityOrganization, FacilityOrganizationUser
 from care.emr.resources.facility_organization.facility_orgnization_user_spec import (
     FacilityOrganizationUserReadSpec,
@@ -101,6 +104,15 @@ class FacilityOrganizationViewSet(EMRModelViewSet):
             .exists()
         ):
             raise ValidationError("Cannot delete organization with users")
+
+        if EncounterOrganization.objects.filter(organization=instance).exists():
+            raise ValidationError("Cannot delete organization with encounters")
+
+        if FacilityLocationOrganization.objects.filter(organization=instance).exists():
+            raise ValidationError("Cannot delete organization with locations")
+
+        if Device.objects.filter(organization=instance).exists():
+            raise ValidationError("Cannot delete organization with devices")
 
         if self.request.user.is_superuser:
             return


### PR DESCRIPTION
Implement validation to ensure organizations cannot be deleted if they have associated encounters, locations, or devices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation when deleting a facility organization to prevent deletion if it is linked to encounters, facility locations, or devices.
- **New Features**
  - Additional safeguards added to ensure organizations cannot be deleted if they have related records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->