### PR TITLE
Management command to update `FacilityLocation` objects that has `has_children=False` but actually has children objects

### DIFF
--- a/care/emr/management/commands/fix_parent_locations_has_children.py
+++ b/care/emr/management/commands/fix_parent_locations_has_children.py
@@ -21,6 +21,6 @@ class Command(BaseCommand):
         ).filter(children_count__gt=0, has_children=False)
         count = queryset.update(has_children=True)
         logger.info(
-            "Fixed %d FacilityLocation(s) objects where has_children was never set to true but actually had children instances",
+            "Fixed %d FacilityLocation objects where has_children was never set to true but actually had children instances",
             count,
         )

--- a/care/emr/management/commands/fix_parent_locations_has_children.py
+++ b/care/emr/management/commands/fix_parent_locations_has_children.py
@@ -1,0 +1,26 @@
+import logging
+
+from django.core.management.base import BaseCommand
+from django.db.models import Count, Q
+
+from care.emr.models.location import FacilityLocation
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """ """
+
+    help = "Fixes FacilityLocation's has_children being False for parent locations with children"
+
+    def handle(self, *args, **options):
+        queryset = FacilityLocation.objects.annotate(
+            children_count=Count(
+                "facilitylocation", filter=Q(facilitylocation__deleted=False)
+            )
+        ).filter(children_count__gt=0, has_children=False)
+        count = queryset.update(has_children=True)
+        logger.info(
+            "Fixed %d FacilityLocation(s) objects where has_children was never set to true but actually had children instances",
+            count,
+        )


### PR DESCRIPTION
## Proposed Changes

- Added a management command to update `FacilityLocation` objects that has `has_children=False` but actually has children objects

### Associated Issue

- Follow up of #3003

## Merge Checklist

- [ ] Tests added/fixed
- [x] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a management command to correct the "has_children" status for parent locations with child records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->