### PR TITLE
Add validation for inactive questionnaires during submission

### DIFF
--- a/care/emr/resources/questionnaire/utils.py
+++ b/care/emr/resources/questionnaire/utils.py
@@ -426,6 +426,11 @@ def handle_response(questionnaire_obj: Questionnaire, results, user):  # noqa PL
     """
     Generate observations and questionnaire responses after validation
     """
+    if questionnaire_obj.status != "active":
+        raise ValidationError(
+            {"type": "questionnaire_inactive", "msg": "Questionnaire is inactive"}
+        )
+
     # Construct questionnaire response
 
     if questionnaire_obj.subject_type == "patient":


### PR DESCRIPTION
- Add validation to prevent submission of responses to inactive questionnaires

- Add tests

- fixes https://github.com/ohcnetwork/roadmap/issues/102
- closes https://github.com/ohcnetwork/roadmap/issues/91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Submissions to inactive questionnaires are now correctly rejected with an appropriate error message.

- **Tests**
  - Added a test to verify that responses cannot be submitted to inactive questionnaires.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->