### PR TITLE
Add a validation check during consent creation

### DIFF
--- a/care/emr/resources/consent/spec.py
+++ b/care/emr/resources/consent/spec.py
@@ -74,9 +74,9 @@ class ConsentBaseSpec(EMRResource):
 class ConsentCreateSpec(ConsentBaseSpec):
     @model_validator(mode="after")
     def validate_period_and_date(self):
-        if self.period.end and self.period.end <= self.date:
+        if self.period.start and self.period.start < self.date:
             raise ValidationError(
-                "Consent date cannot be greater than the end of the period"
+                "Start of the period cannot be before than the Consent date"
             )
 
     def perform_extra_deserialization(self, is_update, obj):


### PR DESCRIPTION
Related FE : https://github.com/ohcnetwork/care_fe/pull/12248
## Proposed Changes

- Implemented a validation error for consent creation to ensure the start of the period is not earlier than the consent date
- The proposed solution check if the start date is less than consent date or not.


## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins
