### PR TITLE
Test cases added for the Note Message Api 

### DIFF
--- a/care/emr/api/viewsets/notes.py
+++ b/care/emr/api/viewsets/notes.py
@@ -1,5 +1,5 @@
 from django_filters import rest_framework as filters
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import PermissionDenied,ValidationError
 from rest_framework.generics import get_object_or_404
 
 from care.emr.api.viewsets.base import (
@@ -78,7 +78,7 @@ class NoteThreadViewSet(
     def perform_create(self, instance):
         instance.patient = self.get_patient()
         if instance.encounter and instance.encounter.patient != instance.patient:
-            raise ValueError("Patient Mismatch")
+            raise ValidationError("Patient Mismatch")
         super().perform_create(instance)
 
     def get_object(self):
@@ -120,6 +120,17 @@ class NoteMessageViewSet(
         instance.thread = get_object_or_404(
             NoteThread, external_id=self.kwargs["thread_external_id"]
         )
+        if instance.thread.encounter and instance.thread.encounter.status == "completed":
+            raise ValidationError("Cannot add note to completed encounter")
+
+        if encounter_id := self.request.data.get('encounter'):
+            encounter = get_object_or_404(Encounter, external_id=encounter_id)
+            if encounter.status == "completed":
+                raise ValidationError("Cannot add note to completed encounter")
+            if encounter.patient != instance.thread.patient:
+                raise ValidationError("Patient Mismatch")
+            instance.encounter = encounter
+        instance.patient = instance.thread.patient
         super().perform_create(instance)
 
     def authorize_update(self, request_obj, model_instance):

--- a/care/emr/api/viewsets/notes.py
+++ b/care/emr/api/viewsets/notes.py
@@ -1,5 +1,5 @@
 from django_filters import rest_framework as filters
-from rest_framework.exceptions import PermissionDenied,ValidationError
+from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.generics import get_object_or_404
 
 from care.emr.api.viewsets.base import (
@@ -120,7 +120,7 @@ class NoteMessageViewSet(
         instance.thread = get_object_or_404(
             NoteThread, external_id=self.kwargs["thread_external_id"]
         )
-        if encounter_id := self.request.data.get('encounter'):
+        if encounter_id := self.request.data.get("encounter"):
             encounter = get_object_or_404(Encounter, external_id=encounter_id)
             if encounter.patient != instance.thread.patient:
                 raise ValidationError("Patient Mismatch")

--- a/care/emr/api/viewsets/notes.py
+++ b/care/emr/api/viewsets/notes.py
@@ -120,13 +120,8 @@ class NoteMessageViewSet(
         instance.thread = get_object_or_404(
             NoteThread, external_id=self.kwargs["thread_external_id"]
         )
-        if instance.thread.encounter and instance.thread.encounter.status == "completed":
-            raise ValidationError("Cannot add note to completed encounter")
-
         if encounter_id := self.request.data.get('encounter'):
             encounter = get_object_or_404(Encounter, external_id=encounter_id)
-            if encounter.status == "completed":
-                raise ValidationError("Cannot add note to completed encounter")
             if encounter.patient != instance.thread.patient:
                 raise ValidationError("Patient Mismatch")
             instance.encounter = encounter

--- a/care/emr/tests/test_notes_api.py
+++ b/care/emr/tests/test_notes_api.py
@@ -251,3 +251,137 @@ class NoteMessageApiTestCase(CareAPITestBase):
         response = self.client.get(url, format="json")
         self.assertEqual(response.status_code, 200, response.data)
         self.assertContains(response, note.message, status_code=200)
+
+    def test_list_notes_on_thread_without_permission(self):
+        thread = self._create_thread()
+        self._create_note(thread)
+        url = self._get_note_list_url(thread.external_id)
+        response = self.client.get(url, format="json")
+        self.assertEqual(response.status_code, 403, response.data)
+        self.assertContains(response, "Permission denied to user", status_code=403)
+
+    def test_list_notes_on_encounter(self):
+        role=self.create_role_with_permissions(
+            permissions=[
+                PatientPermissions.can_view_clinical_data.name,
+                EncounterPermissions.can_read_encounter.name,
+            ]
+        )
+        self.attach_role_facility_organization_user(
+            self.facility_organization, self.user, role
+        )
+        thread=self._create_thread(encounter=self.encounter)
+        url=f"{self._get_note_list_url(thread.external_id)}?encounter={self.encounter.external_id}"
+        note=self._create_note(thread)
+        response=self.client.get(url, format="json")
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertContains(response, note.message, status_code=200)
+
+    def test_create_note_on_encounter_with_permission(self):
+        role = self.create_role_with_permissions(
+            permissions=[EncounterPermissions.can_write_encounter.name]
+        )
+        self.attach_role_facility_organization_user(
+            self.facility_organization, self.user, role
+        )
+        thread = self._create_thread(encounter=self.encounter)
+        url = self._get_note_list_url(thread.external_id)
+        data = {
+            "message": "Test Note",
+            "encounter": self.encounter.external_id
+            }
+        response = self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertContains(response, data["message"], status_code=200)
+
+    def test_create_note_on_encounter_without_permission(self):
+        thread=self._create_thread(encounter=self.encounter)
+        url=self._get_note_list_url(thread.external_id)
+        data = {
+            "message": "Test Note",
+            "encounter": self.encounter.external_id
+        }
+        response=self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, 403, response.data)
+        self.assertContains(response, "You do not have permission for this action", status_code=403)
+
+    def test_create_note_on_encounter_with_patient_mismatch(self):
+        role = self.create_role_with_permissions(
+            permissions=[EncounterPermissions.can_write_encounter.name]
+        )
+        self.attach_role_facility_organization_user(
+            self.facility_organization, self.user, role
+        )
+        thread = self._create_thread(encounter=self.encounter)
+        url = self._get_note_list_url(thread.external_id)
+        encounter = self.create_encounter(
+            patient=self.create_patient(),
+            facility=self.facility,
+            organization=self.facility_organization,
+        )
+        data = {
+            "message": "Test Note",
+            "encounter": encounter.external_id
+        }
+        response = self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertContains(response, "Patient Mismatch", status_code=400)
+
+    def test_create_note_on_thread(self):   
+        role = self.create_role_with_permissions(
+            permissions=[PatientPermissions.can_write_patient.name]
+        )
+        self.attach_role_facility_organization_user(
+            self.facility_organization, self.user, role
+        )
+        thread = self._create_thread()
+        url = self._get_note_list_url(thread.external_id)
+        data = {"message": "Test Note"}
+        response = self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertContains(response, data["message"], status_code=200)
+
+    def test_create_note_on_thread_without_permission(self):
+        thread = self._create_thread()
+        url = self._get_note_list_url(thread.external_id)
+        data = {"message": "Test Note"}
+        response = self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, 403, response.data)
+        self.assertContains(response, "You do not have permission for this action", status_code=403)
+
+
+    def test_update_note(self):
+        role = self.create_role_with_permissions(
+            permissions=[
+                PatientPermissions.can_view_clinical_data.name,
+                PatientPermissions.can_write_patient.name,
+            ]
+        )
+        self.attach_role_facility_organization_user(
+            self.facility_organization, self.user, role
+        )
+        thread = self._create_thread()
+        note = self._create_note(thread)
+        url = self._get_note_detail_url(thread.external_id, note.external_id)
+        data = {
+            "message": "Updated Note",
+            "created_date": note.created_date.isoformat(),
+            "modified_date": note.modified_date.isoformat(),
+        }
+        response = self.client.put(url, data, format="json")
+        self.assertEqual(response.status_code, 200, response.data)
+        note.refresh_from_db()
+        self.assertEqual(note.message, data["message"])
+
+    def test_update_note_without_permission(self):
+        thread=self._create_thread()
+        note=self._create_note(thread)
+        url=self._get_note_detail_url(thread.external_id, note.external_id)
+        data = {
+            "message": "Updated Note",
+            "created_date": note.created_date.isoformat(),
+            "modified_date": note.modified_date.isoformat(),
+        }
+        response = self.client.put(url, data, format="json")
+        self.assertEqual(response.status_code, 403, response.data)
+        self.assertContains(response, "Permission denied to user", status_code=403)

--- a/care/emr/tests/test_notes_api.py
+++ b/care/emr/tests/test_notes_api.py
@@ -1,0 +1,253 @@
+from django.urls import reverse
+from model_bakery import baker
+
+from care.emr.models.notes import NoteMessage, NoteThread
+from care.security.permissions.encounter import EncounterPermissions
+from care.security.permissions.patient import PatientPermissions
+from care.utils.tests.base import CareAPITestBase
+
+
+class NoteThreadApiTestCase(CareAPITestBase):
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user()
+        self.facility = self.create_facility(user=self.user)
+        self.facility_organization = self.create_facility_organization(
+            facility=self.facility
+        )
+        self.patient = self.create_patient()
+        self.encounter = self.create_encounter(
+            patient=self.patient,
+            facility=self.facility,
+            organization=self.facility_organization,
+        )
+        self.client.force_authenticate(user=self.user)
+
+    def _get_thread_list_url(self):
+        return reverse(
+            "thread-list",
+            kwargs={"patient_external_id": self.patient.external_id},
+        )
+
+    def _get_thread_detail_url(self, thread_external_id):
+        return reverse(
+            "thread-detail",
+            kwargs={
+                "patient_external_id": self.patient.external_id,
+                "external_id": thread_external_id,
+            },
+        )
+
+    def _create_thread(self, encounter=None):
+        return baker.make(
+            NoteThread,
+            patient=self.patient,
+            encounter=encounter,
+            _fill_optional=True,
+        )
+
+    def test_list_threads_on_patient(self):
+        role = self.create_role_with_permissions(
+            permissions=[PatientPermissions.can_view_clinical_data.name]
+        )
+        self.attach_role_facility_organization_user(
+            self.facility_organization, self.user, role
+        )
+        url = self._get_thread_list_url()
+        thread = self._create_thread()
+        response = self.client.get(url, format="json")
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertContains(response, thread.title, status_code=200)
+
+    def test_list_threads_on_patient_without_permission(self):
+        url = self._get_thread_list_url()
+        self._create_thread()
+        response = self.client.get(url, format="json")
+        self.assertEqual(response.status_code, 403, response.data)
+        self.assertContains(response, "Permission denied to user", status_code=403)
+
+    def test_list_threads_on_encounter(self):
+        role = self.create_role_with_permissions(
+            permissions=[
+                PatientPermissions.can_view_clinical_data.name,
+                EncounterPermissions.can_read_encounter.name,
+            ]
+        )
+        self.attach_role_facility_organization_user(
+            self.facility_organization, self.user, role
+        )
+        url = f"{self._get_thread_list_url()}?encounter={self.encounter.external_id}"
+        thread = self._create_thread(encounter=self.encounter)
+        response = self.client.get(url, format="json")
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertContains(response, thread.title, status_code=200)
+
+    def test_create_thread_on_patient(self):
+        role = self.create_role_with_permissions(
+            permissions=[PatientPermissions.can_write_patient.name]
+        )
+        self.attach_role_facility_organization_user(
+            self.facility_organization, self.user, role
+        )
+        url = self._get_thread_list_url()
+        data = {"title": "Test Thread"}
+        response = self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertContains(response, data["title"], status_code=200)
+
+    def test_create_thread_on_patient_without_permission(self):
+        url = self._get_thread_list_url()
+        data = {"title": "Test Thread"}
+        response = self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, 403, response.data)
+        self.assertContains(
+            response, "You do not have permission for this action", status_code=403
+        )
+
+    def test_create_thread_on_encounter_with_permission(self):
+        role = self.create_role_with_permissions(
+            permissions=[EncounterPermissions.can_write_encounter.name]
+        )
+        self.attach_role_facility_organization_user(
+            self.facility_organization, self.user, role
+        )
+        url = self._get_thread_list_url()
+        data = {
+            "title": "Test Thread",
+            "encounter": self.encounter.external_id,
+        }
+        response = self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertContains(response, data["title"], status_code=200)
+
+    def test_create_thread_on_encounter_without_permission(self):
+        url = self._get_thread_list_url()
+        data = {
+            "title": "Test Thread",
+            "encounter": self.encounter.external_id,
+        }
+        response = self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, 403, response.data)
+        self.assertContains(
+            response, "You do not have permission for this action", status_code=403
+        )
+
+    def test_create_thread_on_encounter_with_patient_mismatch(self):
+        role = self.create_role_with_permissions(
+            permissions=[EncounterPermissions.can_write_encounter.name]
+        )
+        self.attach_role_facility_organization_user(
+            self.facility_organization, self.user, role
+        )
+        url = self._get_thread_list_url()
+        encounter = self.create_encounter(
+            patient=self.create_patient(),
+            facility=self.facility,
+            organization=self.facility_organization,
+        )
+        data = {
+            "title": "Test Thread",
+            "encounter": encounter.external_id,
+        }
+        response = self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertContains(response, "Patient Mismatch", status_code=400)
+
+    def test_update_thread(self):
+        role = self.create_role_with_permissions(
+            permissions=[
+                PatientPermissions.can_view_clinical_data.name,
+                PatientPermissions.can_write_patient.name,
+            ]
+        )
+        self.attach_role_facility_organization_user(
+            self.facility_organization, self.user, role
+        )
+        thread = self._create_thread()
+        url = self._get_thread_detail_url(thread.external_id)
+        data = {
+            "title": "Updated Thread",
+            "created_date": thread.created_date.isoformat(),
+            "modified_date": thread.modified_date.isoformat(),
+        }
+        response = self.client.put(url, data, format="json")
+        self.assertEqual(response.status_code, 200, response.data)
+        thread.refresh_from_db()
+        self.assertEqual(thread.title, data["title"])
+
+    def test_update_thread_without_permission(self):
+        thread = self._create_thread()
+        url = self._get_thread_detail_url(thread.external_id)
+        data = {
+            "title": "Updated Thread",
+            "created_date": thread.created_date.isoformat(),
+            "modified_date": thread.modified_date.isoformat(),
+        }
+        response = self.client.put(url, data, format="json")
+        self.assertEqual(response.status_code, 403, response.data)
+        self.assertContains(response, "Permission denied to user", status_code=403)
+
+
+class NoteMessageApiTestCase(CareAPITestBase):
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user()
+        self.facility = self.create_facility(user=self.user)
+        self.facility_organization = self.create_facility_organization(
+            facility=self.facility
+        )
+        self.patient = self.create_patient()
+        self.encounter = self.create_encounter(
+            patient=self.patient,
+            facility=self.facility,
+            organization=self.facility_organization,
+        )
+        self.client.force_authenticate(user=self.user)
+
+    def _get_note_list_url(self, thread_external_id):
+        return reverse(
+            "note-list",
+            kwargs={
+                "patient_external_id": self.patient.external_id,
+                "thread_external_id": thread_external_id,
+            },
+        )
+
+    def _get_note_detail_url(self, thread_external_id, note_external_id):
+        return reverse(
+            "note-detail",
+            kwargs={
+                "patient_external_id": self.patient.external_id,
+                "thread_external_id": thread_external_id,
+                "external_id": note_external_id,
+            },
+        )
+
+    def _create_thread(self, encounter=None):
+        return baker.make(
+            NoteThread,
+            patient=self.patient,
+            encounter=encounter,
+            _fill_optional=True,
+        )
+
+    def _create_note(self, thread):
+        return baker.make(
+            NoteMessage,
+            thread=thread,
+            _fill_optional=True,
+        )
+
+    def test_list_notes_on_thread(self):
+        role = self.create_role_with_permissions(
+            permissions=[PatientPermissions.can_view_clinical_data.name]
+        )
+        self.attach_role_facility_organization_user(
+            self.facility_organization, self.user, role
+        )
+        thread = self._create_thread()
+        note = self._create_note(thread)
+        url = self._get_note_list_url(thread.external_id)
+        response = self.client.get(url, format="json")
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertContains(response, note.message, status_code=200)

--- a/care/emr/tests/test_notes_api.py
+++ b/care/emr/tests/test_notes_api.py
@@ -262,7 +262,7 @@ class NoteMessageApiTestCase(CareAPITestBase):
         self.assertContains(response, "Permission denied to user", status_code=403)
 
     def test_list_notes_on_encounter(self):
-        role=self.create_role_with_permissions(
+        role = self.create_role_with_permissions(
             permissions=[
                 PatientPermissions.can_view_clinical_data.name,
                 EncounterPermissions.can_read_encounter.name,
@@ -271,10 +271,10 @@ class NoteMessageApiTestCase(CareAPITestBase):
         self.attach_role_facility_organization_user(
             self.facility_organization, self.user, role
         )
-        thread=self._create_thread(encounter=self.encounter)
-        url=f"{self._get_note_list_url(thread.external_id)}?encounter={self.encounter.external_id}"
-        note=self._create_note(thread)
-        response=self.client.get(url, format="json")
+        thread = self._create_thread(encounter=self.encounter)
+        url = f"{self._get_note_list_url(thread.external_id)}?encounter={self.encounter.external_id}"
+        note = self._create_note(thread)
+        response = self.client.get(url, format="json")
         self.assertEqual(response.status_code, 200, response.data)
         self.assertContains(response, note.message, status_code=200)
 
@@ -287,29 +287,27 @@ class NoteMessageApiTestCase(CareAPITestBase):
         )
         thread = self._create_thread(encounter=self.encounter)
         url = self._get_note_list_url(thread.external_id)
-        data = {
-            "message": "Test Note",
-            "encounter": self.encounter.external_id
-            }
+        data = {"message": "Test Note", "encounter": self.encounter.external_id}
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, 200, response.data)
         self.assertContains(response, data["message"], status_code=200)
 
     def test_create_note_on_encounter_without_permission(self):
-        thread=self._create_thread(encounter=self.encounter)
-        url=self._get_note_list_url(thread.external_id)
-        data = {
-            "message": "Test Note",
-            "encounter": self.encounter.external_id
-        }
-        response=self.client.post(url, data, format="json")
+        thread = self._create_thread(encounter=self.encounter)
+        url = self._get_note_list_url(thread.external_id)
+        data = {"message": "Test Note", "encounter": self.encounter.external_id}
+        response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, 403, response.data)
-        self.assertContains(response, "You do not have permission for this action", status_code=403)
+        self.assertContains(
+            response, "You do not have permission for this action", status_code=403
+        )
 
     def test_create_note_on_encounter_with_patient_mismatch(self):
         role = self.create_role_with_permissions(
-            permissions=[EncounterPermissions.can_write_encounter.name,
-                         PatientPermissions.can_write_patient.name]
+            permissions=[
+                EncounterPermissions.can_write_encounter.name,
+                PatientPermissions.can_write_patient.name,
+            ]
         )
         self.attach_role_facility_organization_user(
             self.facility_organization, self.user, role
@@ -321,10 +319,7 @@ class NoteMessageApiTestCase(CareAPITestBase):
             organization=self.facility_organization,
         )
         url = self._get_note_list_url(thread.external_id)
-        data = {
-            "message": "Test Note",
-            "encounter": encounter.external_id
-        }
+        data = {"message": "Test Note", "encounter": encounter.external_id}
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, 400, response.data)
         self.assertContains(response, "Patient Mismatch", status_code=400)
@@ -349,8 +344,9 @@ class NoteMessageApiTestCase(CareAPITestBase):
         data = {"message": "Test Note"}
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, 403, response.data)
-        self.assertContains(response, "You do not have permission for this action", status_code=403)
-
+        self.assertContains(
+            response, "You do not have permission for this action", status_code=403
+        )
 
     def test_update_note(self):
         role = self.create_role_with_permissions(
@@ -376,9 +372,9 @@ class NoteMessageApiTestCase(CareAPITestBase):
         self.assertEqual(note.message, data["message"])
 
     def test_update_note_without_permission(self):
-        thread=self._create_thread()
-        note=self._create_note(thread)
-        url=self._get_note_detail_url(thread.external_id, note.external_id)
+        thread = self._create_thread()
+        note = self._create_note(thread)
+        url = self._get_note_detail_url(thread.external_id, note.external_id)
         data = {
             "message": "Updated Note",
             "created_date": note.created_date.isoformat(),
@@ -395,19 +391,19 @@ class NoteMessageApiTestCase(CareAPITestBase):
             organization=self.facility_organization,
         )
         role = self.create_role_with_permissions(
-            permissions=[EncounterPermissions.can_write_encounter.name,
-                        PatientPermissions.can_write_patient.name]
+            permissions=[
+                EncounterPermissions.can_write_encounter.name,
+                PatientPermissions.can_write_patient.name,
+            ]
         )
         self.attach_role_facility_organization_user(
             self.facility_organization, self.user, role
         )
-        encounter.status="completed"
+        encounter.status = "completed"
         encounter.save()
-        thread=self._create_thread(encounter=encounter)
+        thread = self._create_thread(encounter=encounter)
 
-        url=self._get_note_list_url(thread.external_id)
-        data = {
-            "message": "Late Note"
-            }
-        response=self.client.post(url, data, format="json")
+        url = self._get_note_list_url(thread.external_id)
+        data = {"message": "Late Note"}
+        response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, 403, response.data)

--- a/care/emr/tests/test_notes_api.py
+++ b/care/emr/tests/test_notes_api.py
@@ -235,6 +235,7 @@ class NoteMessageApiTestCase(CareAPITestBase):
         return baker.make(
             NoteMessage,
             thread=thread,
+            created_by=self.user,
             _fill_optional=True,
         )
 
@@ -307,18 +308,19 @@ class NoteMessageApiTestCase(CareAPITestBase):
 
     def test_create_note_on_encounter_with_patient_mismatch(self):
         role = self.create_role_with_permissions(
-            permissions=[EncounterPermissions.can_write_encounter.name]
+            permissions=[EncounterPermissions.can_write_encounter.name,
+                         PatientPermissions.can_write_patient.name]
         )
         self.attach_role_facility_organization_user(
             self.facility_organization, self.user, role
         )
-        thread = self._create_thread(encounter=self.encounter)
-        url = self._get_note_list_url(thread.external_id)
+        thread = self._create_thread()
         encounter = self.create_encounter(
             patient=self.create_patient(),
             facility=self.facility,
             organization=self.facility_organization,
         )
+        url = self._get_note_list_url(thread.external_id)
         data = {
             "message": "Test Note",
             "encounter": encounter.external_id
@@ -327,7 +329,7 @@ class NoteMessageApiTestCase(CareAPITestBase):
         self.assertEqual(response.status_code, 400, response.data)
         self.assertContains(response, "Patient Mismatch", status_code=400)
 
-    def test_create_note_on_thread(self):   
+    def test_create_note_on_thread(self):
         role = self.create_role_with_permissions(
             permissions=[PatientPermissions.can_write_patient.name]
         )
@@ -385,3 +387,27 @@ class NoteMessageApiTestCase(CareAPITestBase):
         response = self.client.put(url, data, format="json")
         self.assertEqual(response.status_code, 403, response.data)
         self.assertContains(response, "Permission denied to user", status_code=403)
+
+    def test_create_note_after_encounter_complete(self):
+        encounter = self.create_encounter(
+            patient=self.patient,
+            facility=self.facility,
+            organization=self.facility_organization,
+        )
+        role = self.create_role_with_permissions(
+            permissions=[EncounterPermissions.can_write_encounter.name,
+                        PatientPermissions.can_write_patient.name]
+        )
+        self.attach_role_facility_organization_user(
+            self.facility_organization, self.user, role
+        )
+        encounter.status="completed"
+        encounter.save()
+        thread=self._create_thread(encounter=encounter)
+
+        url=self._get_note_list_url(thread.external_id)
+        data = {
+            "message": "Late Note"
+            }
+        response=self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, 403, response.data)


### PR DESCRIPTION
## Proposed Changes

- Added test cases for the Note Message in NoteMessageApiTestCase 

### Associated Issue

- https://github.com/ohcnetwork/roadmap/issues/90



## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added comprehensive API tests for note threads and note messages, including permission checks, error handling, and data integrity validation.  
- **Bug Fixes**
  - Improved validation to ensure patient and encounter consistency when creating note threads and messages, enhancing data accuracy and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->