### PR TITLE
Prevent Users to cancel the appointment in 'In-consultation' status

### DIFF
--- a/care/emr/api/viewsets/scheduling/booking.py
+++ b/care/emr/api/viewsets/scheduling/booking.py
@@ -109,7 +109,7 @@ class TokenBookingViewSet(
     def cancel_appointment_handler(cls, instance, request_data, user):
         request_data = CancelBookingSpec(**request_data)
         if instance.status == BookingStatusChoices.in_consultation:
-            raise ValidationError("You cannot cancel an appointment In Consultation")
+            raise ValidationError("You cannot cancel an appointment In-Consultation")
         with transaction.atomic():
             if instance.status not in CANCELLED_STATUS_CHOICES:
                 # Free up the slot if it is not cancelled already

--- a/care/emr/api/viewsets/scheduling/booking.py
+++ b/care/emr/api/viewsets/scheduling/booking.py
@@ -5,7 +5,7 @@ from django_filters import CharFilter, DateFromToRangeFilter, FilterSet, UUIDFil
 from django_filters.rest_framework import DjangoFilterBackend
 from pydantic import UUID4, BaseModel
 from rest_framework.decorators import action
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 
@@ -108,6 +108,8 @@ class TokenBookingViewSet(
     @classmethod
     def cancel_appointment_handler(cls, instance, request_data, user):
         request_data = CancelBookingSpec(**request_data)
+        if instance.status == BookingStatusChoices.in_consultation:
+            raise ValidationError("You cannot cancel an appointment In Consultation")
         with transaction.atomic():
             if instance.status not in CANCELLED_STATUS_CHOICES:
                 # Free up the slot if it is not cancelled already


### PR DESCRIPTION
## Proposed Changes

- Implemented a check to prevent users from canceling appointments marked as 'In-consultation'.
- This is the corresponding FE issue : [#12135](https://github.com/ohcnetwork/care_fe/issues/12135)
- The proposed solution ensures that users are restricted from canceling appointments that are already in the 'In-consultation' status

Screenshot :
![Screenshot from 2025-05-11 18-32-33](https://github.com/user-attachments/assets/47baa8cf-4e7f-4f96-9860-77c66bd5dd3b)

## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Prevented cancellation of appointments that are currently in consultation, displaying a clear error message when attempted.

- **Tests**
	- Added tests to ensure appointments in consultation cannot be canceled by users or patients, and that the correct error message is returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->