### PR TITLE
Add validation for resource request assigned to user

### DIFF
--- a/care/emr/resources/resource_request/spec.py
+++ b/care/emr/resources/resource_request/spec.py
@@ -73,7 +73,7 @@ class ResourceRequestCreateSpec(ResourceRequestBaseSpec):
             if not FacilityOrganizationUser.objects.filter(
                 organization__facility__external_id=self.assigned_facility,
                 user__external_id=self.assigned_to,
-            ):
+            ).exists():
                 raise ValueError(
                     "Assigned user is not a member of the assigned facility"
                 )

--- a/care/emr/resources/resource_request/spec.py
+++ b/care/emr/resources/resource_request/spec.py
@@ -1,10 +1,11 @@
 import datetime
 from enum import Enum
 
-from pydantic import UUID4
+from pydantic import UUID4, model_validator
 from rest_framework.generics import get_object_or_404
 
 from care.emr.models import Patient
+from care.emr.models.organization import FacilityOrganizationUser
 from care.emr.models.resource_request import ResourceRequest, ResourceRequestComment
 from care.emr.resources.base import EMRResource
 from care.emr.resources.facility.spec import FacilityReadSpec
@@ -60,6 +61,23 @@ class ResourceRequestCreateSpec(ResourceRequestBaseSpec):
     assigned_facility: UUID4 | None = None
     related_patient: UUID4 | None = None
     assigned_to: UUID4 | None = None
+
+    @model_validator(mode="after")
+    def validate_assigned_to_user(self):
+        if self.assigned_to:
+            if not self.assigned_facility:
+                raise ValueError(
+                    "Assigned facility is required for assigning the request to a user"
+                )
+
+            if not FacilityOrganizationUser.objects.filter(
+                organization__facility__external_id=self.assigned_facility,
+                user__external_id=self.assigned_to,
+            ):
+                raise ValueError(
+                    "Assigned user is not a member of the assigned facility"
+                )
+        return self
 
     def perform_extra_deserialization(self, is_update, obj):
         if not is_update:

--- a/care/emr/tests/test_resource_request_api.py
+++ b/care/emr/tests/test_resource_request_api.py
@@ -1,0 +1,93 @@
+from django.urls import reverse
+
+from care.utils.tests.base import CareAPITestBase
+
+
+class TestResourceRequestViewSet(CareAPITestBase):
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user()
+        self.facility = self.create_facility(user=self.user)
+        self.organization = self.create_facility_organization(facility=self.facility)
+        self.patient = self.create_patient()
+        self.client.force_authenticate(user=self.user)
+        self.base_url = reverse("resource-request-list")
+
+    def _get_resource_request_url(self, resource_request_id):
+        """Helper to get the detail URL for a specific resource request."""
+        return reverse(
+            "resource-request-detail",
+            kwargs={"external_id": resource_request_id},
+        )
+
+    def create_resource_request(self, **kwargs):
+        from care.emr.models.resource_request import ResourceRequest
+
+        data = {
+            "origin_facility": self.facility,
+            "related_patient": self.patient,
+            "title": "Resource Request",
+            "status": "pending",
+            "category": "other",
+            "priority": 1,
+        }
+        data.update(kwargs)
+        return ResourceRequest.objects.create(**data)
+
+    def get_resource_request_data_from_instance(self, instance, **kwargs):
+        return {
+            "title": instance.title,
+            "status": instance.status,
+            "category": instance.category,
+            "emergency": instance.emergency,
+            "reason": instance.reason,
+            "referring_facility_contact_name": instance.referring_facility_contact_name,
+            "referring_facility_contact_number": instance.referring_facility_contact_number,
+            "priority": instance.priority,
+            "origin_facility": instance.origin_facility.external_id,
+            "assigned_facility": instance.external_id,
+            "assigned_to": instance.external_id,
+        }
+
+    def test_resource_request_assigned_to_user_outside_assigned_facility(self):
+        assigned_to_user = self.create_user()
+        assigned_facility = self.create_facility(user=assigned_to_user)
+        instance = self.create_resource_request(assigned_facility=assigned_facility)
+        url = self._get_resource_request_url(instance.external_id)
+        data = {
+            "title": instance.title,
+            "status": instance.status,
+            "category": instance.category,
+            "emergency": instance.emergency,
+            "reason": instance.reason,
+            "referring_facility_contact_name": instance.referring_facility_contact_name,
+            "referring_facility_contact_number": instance.referring_facility_contact_number,
+            "priority": instance.priority,
+            "origin_facility": instance.origin_facility.external_id,
+            "assigned_facility": assigned_facility.external_id,
+            "assigned_to": self.user.external_id,
+        }
+        res = self.client.put(url, data, "json")
+        error_msg = "Assigned user is not a member of the assigned facility"
+        self.assertContains(res, error_msg, status_code=400)
+
+    def test_resource_request_assigned_to_user_within_assigned_facility(self):
+        assigned_to_user = self.create_user()
+        assigned_facility = self.create_facility(user=assigned_to_user)
+        instance = self.create_resource_request(assigned_facility=assigned_facility)
+        url = self._get_resource_request_url(instance.external_id)
+        data = {
+            "title": instance.title,
+            "status": instance.status,
+            "category": instance.category,
+            "emergency": instance.emergency,
+            "reason": instance.reason,
+            "referring_facility_contact_name": instance.referring_facility_contact_name,
+            "referring_facility_contact_number": instance.referring_facility_contact_number,
+            "priority": instance.priority,
+            "origin_facility": instance.origin_facility.external_id,
+            "assigned_facility": assigned_facility.external_id,
+            "assigned_to": assigned_to_user.external_id,
+        }
+        res = self.client.put(url, data, "json")
+        self.assertEqual(res.status_code, 200)

--- a/care/emr/tests/test_resource_request_api.py
+++ b/care/emr/tests/test_resource_request_api.py
@@ -34,21 +34,6 @@ class TestResourceRequestViewSet(CareAPITestBase):
         data.update(kwargs)
         return ResourceRequest.objects.create(**data)
 
-    def get_resource_request_data_from_instance(self, instance, **kwargs):
-        return {
-            "title": instance.title,
-            "status": instance.status,
-            "category": instance.category,
-            "emergency": instance.emergency,
-            "reason": instance.reason,
-            "referring_facility_contact_name": instance.referring_facility_contact_name,
-            "referring_facility_contact_number": instance.referring_facility_contact_number,
-            "priority": instance.priority,
-            "origin_facility": instance.origin_facility.external_id,
-            "assigned_facility": instance.external_id,
-            "assigned_to": instance.external_id,
-        }
-
     def test_resource_request_assigned_to_user_outside_assigned_facility(self):
         assigned_to_user = self.create_user()
         assigned_facility = self.create_facility(user=assigned_to_user)


### PR DESCRIPTION
## Proposed Changes

- Add validation for resource request assigned to user to ensure the user belongs to the assigned to facility


## Merge Checklist

- [x] Tests added/fixed
- [x] Linting Complete

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved validation to ensure resource requests can only be assigned to users who belong to the assigned facility. Assignments to users outside the facility will trigger an error.
- **Tests**
  - Added tests verifying that resource request assignments fail when the user is outside the assigned facility and succeed when the user is within the facility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->