### PR TITLE
added reschedule permission

### DIFF
--- a/care/emr/api/viewsets/scheduling/booking.py
+++ b/care/emr/api/viewsets/scheduling/booking.py
@@ -135,9 +135,11 @@ class TokenBookingViewSet(
         facility = self.get_facility_obj()
         self.authorize_update({}, existing_booking)
         if not AuthorizationController.call(
-            "can_create_appointment", self.request.user, facility
+            "can_reschedule_appointment", self.request.user, facility
         ):
-            raise PermissionDenied("You do not have permission to create appointments")
+            raise PermissionDenied(
+                "You do not have permission to reschedule appointments"
+            )
         new_slot = get_object_or_404(
             TokenSlot,
             external_id=request_data.new_slot,

--- a/care/emr/tests/test_booking_api.py
+++ b/care/emr/tests/test_booking_api.py
@@ -336,6 +336,7 @@ class TestBookingViewSet(CareAPITestBase):
             UserSchedulePermissions.can_write_user_booking.name,
             UserSchedulePermissions.can_list_user_booking.name,
             UserSchedulePermissions.can_create_appointment.name,
+            UserSchedulePermissions.can_reschedule_appointment.name,
         ]
         role = self.create_role_with_permissions(permissions)
         self.attach_role_facility_organization_user(self.organization, self.user, role)
@@ -358,6 +359,7 @@ class TestBookingViewSet(CareAPITestBase):
         permissions = [
             UserSchedulePermissions.can_write_user_booking.name,
             UserSchedulePermissions.can_list_user_booking.name,
+            UserSchedulePermissions.can_create_appointment.name,
         ]
         role = self.create_role_with_permissions(permissions)
         self.attach_role_facility_organization_user(self.organization, self.user, role)
@@ -376,7 +378,7 @@ class TestBookingViewSet(CareAPITestBase):
         self.assertContains(
             response,
             status_code=403,
-            text="You do not have permission to create appointments",
+            text="You do not have permission to reschedule appointments",
         )
 
     def test_reschedule_booking_with_slot_in_past(self):
@@ -385,6 +387,7 @@ class TestBookingViewSet(CareAPITestBase):
             UserSchedulePermissions.can_write_user_booking.name,
             UserSchedulePermissions.can_list_user_booking.name,
             UserSchedulePermissions.can_create_appointment.name,
+            UserSchedulePermissions.can_reschedule_appointment.name,
         ]
         role = self.create_role_with_permissions(permissions)
         self.attach_role_facility_organization_user(self.organization, self.user, role)

--- a/care/security/authorization/user_schedule.py
+++ b/care/security/authorization/user_schedule.py
@@ -17,10 +17,20 @@ class UserScheduleAccess(AuthorizationHandler):
 
     def can_create_appointment(self, user, facility):
         """
-        Check if the user has permission to list schedules in a facility
+        Check if the user has permission to create schedules in a facility
         """
         return self.check_permission_in_facility_organization(
             [UserSchedulePermissions.can_create_appointment.name],
+            user,
+            facility=facility,
+        )
+
+    def can_reschedule_appointment(self, user, facility):
+        """
+        Check if the user has permission to re-schedule in a facility
+        """
+        return self.check_permission_in_facility_organization(
+            [UserSchedulePermissions.can_reschedule_appointment.name],
             user,
             facility=facility,
         )

--- a/care/security/permissions/user_schedule.py
+++ b/care/security/permissions/user_schedule.py
@@ -69,3 +69,16 @@ class UserSchedulePermissions(enum.Enum):
             ADMINISTRATOR,
         ],
     )
+    can_reschedule_appointment = Permission(
+        "Can reschedule appointment on facility",
+        "",
+        PermissionContext.FACILITY,
+        [
+            DOCTOR_ROLE,
+            STAFF_ROLE,
+            NURSE_ROLE,
+            ADMINISTRATOR,
+            FACILITY_ADMIN_ROLE,
+            ADMIN_ROLE,
+        ],
+    )


### PR DESCRIPTION
## Proposed Changes

- Move reschedule permission as a seprate permission

### Associated Issue

- closes https://github.com/ohcnetwork/roadmap/issues/58

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new permission to control which users can reschedule appointments within a facility.

- **Bug Fixes**
  - Updated permission checks and error messages to accurately reflect rescheduling permissions.

- **Documentation**
  - Improved docstring to clarify the behavior of appointment creation permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->