### PR TITLE
added validation for no nesting inside role facility org

### DIFF
--- a/care/emr/api/viewsets/facility_organization.py
+++ b/care/emr/api/viewsets/facility_organization.py
@@ -59,6 +59,10 @@ class FacilityOrganizationViewSet(EMRModelViewSet):
                 raise PermissionDenied(
                     "Cannot create organizations under root organization"
                 )
+            if parent.org_type == "role":
+                raise PermissionDenied(
+                    "Cannot create nested facility organizations under 'role' type facility organization"
+                )
             if (
                 model_obj is None
                 and parent.level_cache >= settings.FACILITY_ORGANIZATION_MAX_DEPTH


### PR DESCRIPTION
## Proposed Changes

- added validation for no nesting inside role facility org

### Associated Issue

- Fixes a part of https://github.com/ohcnetwork/roadmap/issues/104

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation to prevent creating nested facility organizations under a parent organization of type "role". Users will now see an error if they attempt this action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->