### PR TITLE
Fix device list filters for super user

### DIFF
--- a/care/emr/api/viewsets/device.py
+++ b/care/emr/api/viewsets/device.py
@@ -117,14 +117,17 @@ class DeviceViewSet(EMRModelViewSet):
         """
         queryset = Device.objects.all()
 
-        if self.request.user.is_superuser:
-            return queryset
-
         facility = self.get_facility_obj()
+        facility_organizations = FacilityOrganization.objects.filter(
+            facility=facility
+        ).values_list("id", flat=True)
 
-        users_facility_organizations = FacilityOrganizationUser.objects.filter(
-            organization__facility=facility, user=self.request.user
-        ).values_list("organization_id", flat=True)
+        if self.request.user.is_superuser:
+            users_facility_organizations = facility_organizations
+        else:
+            users_facility_organizations = FacilityOrganizationUser.objects.filter(
+                organization_id__in=facility_organizations, user=self.request.user
+            ).values_list("organization_id", flat=True)
 
         if "location" in self.request.GET:
             location = get_object_or_404(


### PR DESCRIPTION
## Proposed Changes

- fixes https://github.com/ohcnetwork/roadmap/issues/114

## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved device listing to ensure both regular and super users only see devices associated with the selected facility.

- **Tests**
  - Enhanced test coverage to verify device listing is correctly scoped by facility for all user types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->