### PR TITLE
fix issue with enable when for boolean values

### DIFF
--- a/care/emr/resources/questionnaire/utils.py
+++ b/care/emr/resources/questionnaire/utils.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, time
+from datetime import datetime
 from urllib.parse import urlparse
 
 from dateutil.parser import isoparse
@@ -106,29 +106,21 @@ def validate_data(values, value_type, questionnaire_ref):  # noqa PLR0912
     return errors
 
 
-def normalize_value(value):  # noqa PLR0911
+def normalize_boolean_value(value):
+    """
+    Convert strings like 'true', 'false', '1', '0' , 'yes','no' to proper boolean values.
+
+    This helps when comparing condition values in `enable_when`, where
+    answers may come as strings but actually mean True or False.
+
+    If the value doesn't look like a boolean, return it as-is.
+    """
     if isinstance(value, str):
-        val = value.strip()
-        if val.lower() in ["true", "1"]:
+        val = value.strip().lower()
+        if val in ["true", "1", "yes"]:
             return True
-        if val.lower() in ["false", "0"]:
+        if val in ["false", "0", "no"]:
             return False
-        try:
-            if "." not in val:
-                return int(val)
-        except ValueError:
-            pass
-        try:
-            return float(val)
-        except ValueError:
-            pass
-        try:
-            parsed = isoparse(val)
-            if parsed.time() == time.min:
-                return parsed.date()
-            return parsed
-        except Exception:
-            return val.strip()
     return value
 
 
@@ -162,9 +154,9 @@ def is_question_enabled(question, responses, questionnaire_obj):  # noqa PLR0912
         else:
             condition_value = responses[condition_question_id].values[0].value
 
-        condition_value = normalize_value(condition_value)
+        condition_value = normalize_boolean_value(condition_value)
         operator = condition["operator"]
-        expected_answer = normalize_value(condition["answer"])
+        expected_answer = normalize_boolean_value(condition["answer"])
 
         # Evaluate the condition based on the operator.
         if operator == "exists":

--- a/care/emr/resources/questionnaire/utils.py
+++ b/care/emr/resources/questionnaire/utils.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, time
 from urllib.parse import urlparse
 
 from dateutil.parser import isoparse
@@ -106,6 +106,32 @@ def validate_data(values, value_type, questionnaire_ref):  # noqa PLR0912
     return errors
 
 
+def normalize_value(value):  # noqa PLR0911
+    if isinstance(value, str):
+        val = value.strip()
+        if val.lower() in ["true", "1"]:
+            return True
+        if val.lower() in ["false", "0"]:
+            return False
+        try:
+            if "." not in val:
+                return int(val)
+        except ValueError:
+            pass
+        try:
+            return float(val)
+        except ValueError:
+            pass
+        try:
+            parsed = isoparse(val)
+            if parsed.time() == time.min:
+                return parsed.date()
+            return parsed
+        except Exception:
+            return val.strip()
+    return value
+
+
 def is_question_enabled(question, responses, questionnaire_obj):  # noqa PLR0912
     """
     Check if a question should be enabled based on its enable_when conditions.
@@ -136,8 +162,9 @@ def is_question_enabled(question, responses, questionnaire_obj):  # noqa PLR0912
         else:
             condition_value = responses[condition_question_id].values[0].value
 
+        condition_value = normalize_value(condition_value)
         operator = condition["operator"]
-        expected_answer = condition["answer"]
+        expected_answer = normalize_value(condition["answer"])
 
         # Evaluate the condition based on the operator.
         if operator == "exists":

--- a/care/emr/resources/questionnaire/utils.py
+++ b/care/emr/resources/questionnaire/utils.py
@@ -15,6 +15,9 @@ from care.emr.registries.care_valueset.care_valueset import validate_valueset
 from care.emr.resources.observation.spec import ObservationSpec, ObservationStatus
 from care.emr.resources.questionnaire.spec import QuestionType
 
+BOOLEAN_TRUE_STRINGS = ("true", "on", "ok", "y", "yes", "1")
+BOOLEAN_FALSE_STRINGS = ("false", "off", "no", "n", "0")
+
 
 def create_responses_mapping(results_list):
     """
@@ -108,7 +111,7 @@ def validate_data(values, value_type, questionnaire_ref):  # noqa PLR0912
 
 def normalize_boolean_value(value):
     """
-    Convert strings like 'true', 'false', '1', '0' , 'yes','no' to proper boolean values.
+    Convert BOOLEAN_TRUE_STRING and BOOLEAN_FALSE_STRING to proper boolean values.
 
     This helps when comparing condition values in `enable_when`, where
     answers may come as strings but actually mean True or False.
@@ -117,9 +120,9 @@ def normalize_boolean_value(value):
     """
     if isinstance(value, str):
         val = value.strip().lower()
-        if val in ["true", "1", "yes"]:
+        if val in BOOLEAN_TRUE_STRINGS:
             return True
-        if val in ["false", "0", "no"]:
+        if val in BOOLEAN_FALSE_STRINGS:
             return False
     return value
 


### PR DESCRIPTION
## Proposed Changes

- added normalization before comparing values

### Associated Issue

- Fixes https://github.com/ohcnetwork/roadmap/issues/115

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved questionnaire behavior to recognize boolean values submitted as strings for conditional question display.
- **Tests**
  - Added tests ensuring questions enable correctly when boolean answers are provided as strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->