### PR TITLE
Support for rescheduling booking to another schedulable user resource within same facility

### DIFF
--- a/care/emr/api/viewsets/scheduling/booking.py
+++ b/care/emr/api/viewsets/scheduling/booking.py
@@ -143,7 +143,7 @@ class TokenBookingViewSet(
         new_slot = get_object_or_404(
             TokenSlot,
             external_id=request_data.new_slot,
-            resource=existing_booking.token_slot.resource,
+            resource__facility_id=facility.id,
         )
         with transaction.atomic():
             self.cancel_appointment_handler(

--- a/care/emr/tests/test_booking_api.py
+++ b/care/emr/tests/test_booking_api.py
@@ -382,6 +382,59 @@ class TestBookingViewSet(CareAPITestBase):
             text="You do not have permission to reschedule appointments",
         )
 
+    def test_reschedule_booking_to_another_user_resource_of_same_facility(self):
+        """Users can reschedule bookings via the re-schedule endpoint with another user resource of same facility."""
+        permissions = [
+            UserSchedulePermissions.can_write_user_booking.name,
+            UserSchedulePermissions.can_list_user_booking.name,
+            UserSchedulePermissions.can_create_appointment.name,
+            UserSchedulePermissions.can_reschedule_appointment.name,
+        ]
+        role = self.create_role_with_permissions(permissions)
+        self.attach_role_facility_organization_user(self.organization, self.user, role)
+
+        new_user = self.create_user()
+        new_resource = self.create_resource(user=new_user, facility=self.facility)
+        new_slot = self.create_slot(resource=new_resource)
+        booking = self.create_booking()
+        reschedule_url = reverse(
+            "appointments-reschedule",
+            kwargs={
+                "facility_external_id": self.facility.external_id,
+                "external_id": booking.external_id,
+            },
+        )
+        data = {"new_slot": new_slot.external_id}
+        response = self.client.post(reschedule_url, data, format="json")
+        self.assertEqual(response.status_code, 200)
+
+    def test_reschedule_booking_to_another_user_resource_of_another_facility(self):
+        """Users cannot reschedule bookings via the re-schedule endpoint with another user resource of different facility."""
+        permissions = [
+            UserSchedulePermissions.can_write_user_booking.name,
+            UserSchedulePermissions.can_list_user_booking.name,
+            UserSchedulePermissions.can_create_appointment.name,
+            UserSchedulePermissions.can_reschedule_appointment.name,
+        ]
+        role = self.create_role_with_permissions(permissions)
+        self.attach_role_facility_organization_user(self.organization, self.user, role)
+
+        new_user = self.create_user()
+        new_facility = self.create_facility(user=self.user)
+        new_resource = self.create_resource(user=new_user, facility=new_facility)
+        new_slot = self.create_slot(resource=new_resource)
+        booking = self.create_booking()
+        reschedule_url = reverse(
+            "appointments-reschedule",
+            kwargs={
+                "facility_external_id": self.facility.external_id,
+                "external_id": booking.external_id,
+            },
+        )
+        data = {"new_slot": new_slot.external_id}
+        response = self.client.post(reschedule_url, data, format="json")
+        self.assertEqual(response.status_code, 404)
+
     def test_reschedule_booking_with_slot_in_past(self):
         """Users cannot reschedule bookings to slots that are in the past."""
         permissions = [


### PR DESCRIPTION


## Proposed Changes

- Removed restriction that prevented rescheduling bookings to another user.
- Added restriction to prevent rescheduling bookings to users of different facility.

### Associated Issue

- https://github.com/ohcnetwork/roadmap/issues/116

## Merge Checklist

- [x] Tests added/fixed
- [x] Linting Complete

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved booking rescheduling to allow selecting slots from any resource within the same facility, while preventing rescheduling to resources in other facilities.

- **Tests**
  - Added tests to ensure bookings can be rescheduled to different resources within the same facility, and to confirm that cross-facility rescheduling is not permitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->