### PR TITLE
Monthly filtering in Schedules and Exceptions

### DIFF
--- a/care/emr/api/viewsets/scheduling/availability_exceptions.py
+++ b/care/emr/api/viewsets/scheduling/availability_exceptions.py
@@ -1,4 +1,4 @@
-from django_filters import FilterSet, UUIDFilter
+from django_filters import DateTimeFilter, FilterSet, UUIDFilter
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.generics import get_object_or_404
@@ -16,6 +16,8 @@ from care.users.models import User
 
 class AvailabilityExceptionFilters(FilterSet):
     user = UUIDFilter(field_name="resource__user__external_id")
+    valid_from = DateTimeFilter(field_name="valid_to", lookup_expr="gte")
+    valid_to = DateTimeFilter(field_name="valid_from", lookup_expr="lte")
 
 
 class AvailabilityExceptionsViewSet(EMRModelViewSet):

--- a/care/emr/api/viewsets/scheduling/availability_exceptions.py
+++ b/care/emr/api/viewsets/scheduling/availability_exceptions.py
@@ -1,4 +1,4 @@
-from django_filters import DateTimeFilter, FilterSet, UUIDFilter
+from django_filters import DateFilter, FilterSet, UUIDFilter
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.generics import get_object_or_404
@@ -16,8 +16,8 @@ from care.users.models import User
 
 class AvailabilityExceptionFilters(FilterSet):
     user = UUIDFilter(field_name="resource__user__external_id")
-    valid_from = DateTimeFilter(field_name="valid_to", lookup_expr="gte")
-    valid_to = DateTimeFilter(field_name="valid_from", lookup_expr="lte")
+    valid_from = DateFilter(field_name="valid_to", lookup_expr="gte")
+    valid_to = DateFilter(field_name="valid_from", lookup_expr="lte")
 
 
 class AvailabilityExceptionsViewSet(EMRModelViewSet):

--- a/care/emr/api/viewsets/scheduling/schedule.py
+++ b/care/emr/api/viewsets/scheduling/schedule.py
@@ -1,6 +1,6 @@
 from django.db import transaction
 from django.utils import timezone
-from django_filters import FilterSet, UUIDFilter
+from django_filters import DateTimeFilter, FilterSet, UUIDFilter
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.generics import get_object_or_404
@@ -29,6 +29,8 @@ from care.utils.lock import Lock
 
 class ScheduleFilters(FilterSet):
     user = UUIDFilter(field_name="resource__user__external_id")
+    valid_from = DateTimeFilter(field_name="valid_to", lookup_expr="gte")
+    valid_to = DateTimeFilter(field_name="valid_from", lookup_expr="lte")
 
 
 class ScheduleViewSet(EMRModelViewSet):

--- a/care/emr/tests/test_schedule_api.py
+++ b/care/emr/tests/test_schedule_api.py
@@ -157,6 +157,45 @@ class TestScheduleViewSet(CareAPITestBase):
         response = self.client.get(self.base_url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_list_schedule_filtered_by_month_range(self):
+        """Test various valid_from and valid_to edge cases"""
+
+        permissions = [UserSchedulePermissions.can_list_user_schedule.name]
+        role = self.create_role_with_permissions(permissions)
+        self.attach_role_facility_organization_user(self.organization, self.user, role)
+
+        filter_from = datetime(2025, 6, 1, 0, 0, tzinfo=UTC)
+        filter_to = datetime(2025, 6, 30, 23, 59, tzinfo=UTC)
+
+        schedule_1 = self.create_schedule(valid_from=filter_from, valid_to=filter_to)
+
+        schedule_2 = self.create_schedule(
+            valid_from=filter_from - timedelta(days=5), valid_to=filter_to
+        )
+
+        schedule_3 = self.create_schedule(
+            valid_from=filter_from, valid_to=filter_to + timedelta(days=5)
+        )
+
+        schedule_4 = self.create_schedule(
+            valid_from=filter_to + timedelta(days=2),
+            valid_to=filter_to + timedelta(days=20),
+        )
+
+        response = self.client.get(
+            self.base_url,
+            {
+                "valid_from": filter_from.isoformat(),
+                "valid_to": filter_to.isoformat(),
+            },
+            format="json",
+        )
+
+        self.assertContains(response, str(schedule_1.external_id), status_code=200)
+        self.assertContains(response, str(schedule_2.external_id), status_code=200)
+        self.assertContains(response, str(schedule_3.external_id), status_code=200)
+        self.assertNotContains(response, str(schedule_4.external_id), status_code=200)
+
     def test_create_schedule_with_permissions(self):
         """Users with can_write_user_schedule permission can create schedules."""
         permissions = [UserSchedulePermissions.can_write_user_schedule.name]
@@ -480,8 +519,10 @@ class TestAvailabilityExceptionsViewSet(CareAPITestBase):
     def create_exception(self, **kwargs):
         from care.emr.models import AvailabilityException
 
-        valid_from = datetime.now(UTC).date()
-        valid_to = (datetime.now(UTC) + timedelta(days=1)).date()
+        valid_from = kwargs.get("valid_from", datetime.now(UTC).date())
+        valid_to = kwargs.get(
+            "valid_to", (datetime.now(UTC) + timedelta(days=1)).date()
+        )
         return AvailabilityException.objects.create(
             resource=self.resource,
             valid_from=valid_from,
@@ -519,6 +560,49 @@ class TestAvailabilityExceptionsViewSet(CareAPITestBase):
         """Users without can_list_user_schedule permission cannot list exceptions."""
         response = self.client.get(self.base_url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_list_exceptions_filtered_by_month_range(self):
+        """Test various valid_from and valid_to edge cases"""
+
+        permissions = [UserSchedulePermissions.can_list_user_schedule.name]
+        role = self.create_role_with_permissions(permissions)
+        self.attach_role_facility_organization_user(self.organization, self.user, role)
+
+        filter_from = datetime(2025, 6, 1, 0, 0, tzinfo=UTC)
+        filter_to = datetime(2025, 6, 30, 23, 59, tzinfo=UTC)
+
+        exception_1 = self.create_exception(
+            valid_from=filter_from.date(), valid_to=filter_to.date()
+        )
+
+        exception_2 = self.create_exception(
+            valid_from=(filter_from - timedelta(days=5)).date(),
+            valid_to=filter_to.date(),
+        )
+
+        exception_3 = self.create_exception(
+            valid_from=filter_from.date(),
+            valid_to=(filter_to + timedelta(days=5)).date(),
+        )
+
+        exception_4 = self.create_exception(
+            valid_from=(filter_to + timedelta(days=5)).date(),
+            valid_to=(filter_to + timedelta(days=25)).date(),
+        )
+
+        response = self.client.get(
+            self.base_url,
+            {
+                "valid_from": filter_from.isoformat(),
+                "valid_to": filter_to.isoformat(),
+            },
+            format="json",
+        )
+
+        self.assertContains(response, str(exception_1.external_id), status_code=200)
+        self.assertContains(response, str(exception_2.external_id), status_code=200)
+        self.assertContains(response, str(exception_3.external_id), status_code=200)
+        self.assertNotContains(response, str(exception_4.external_id), status_code=200)
 
     def test_create_exception_with_permissions(self):
         """Users with can_write_user_schedule permission can create exceptions."""

--- a/care/emr/tests/test_schedule_api.py
+++ b/care/emr/tests/test_schedule_api.py
@@ -165,19 +165,19 @@ class TestScheduleViewSet(CareAPITestBase):
         self.attach_role_facility_organization_user(self.organization, self.user, role)
 
         filter_from = datetime(2025, 6, 1, 0, 0, tzinfo=UTC)
-        filter_to = datetime(2025, 6, 30, 23, 59, tzinfo=UTC)
+        filter_to = filter_from + timedelta(days=29)
 
-        schedule_1 = self.create_schedule(valid_from=filter_from, valid_to=filter_to)
+        within_range = self.create_schedule(valid_from=filter_from, valid_to=filter_to)
 
-        schedule_2 = self.create_schedule(
+        left_overlap = self.create_schedule(
             valid_from=filter_from - timedelta(days=5), valid_to=filter_to
         )
 
-        schedule_3 = self.create_schedule(
+        right_overlap = self.create_schedule(
             valid_from=filter_from, valid_to=filter_to + timedelta(days=5)
         )
 
-        schedule_4 = self.create_schedule(
+        outside_range = self.create_schedule(
             valid_from=filter_to + timedelta(days=2),
             valid_to=filter_to + timedelta(days=20),
         )
@@ -191,10 +191,12 @@ class TestScheduleViewSet(CareAPITestBase):
             format="json",
         )
 
-        self.assertContains(response, str(schedule_1.external_id), status_code=200)
-        self.assertContains(response, str(schedule_2.external_id), status_code=200)
-        self.assertContains(response, str(schedule_3.external_id), status_code=200)
-        self.assertNotContains(response, str(schedule_4.external_id), status_code=200)
+        self.assertContains(response, str(within_range.external_id), status_code=200)
+        self.assertContains(response, str(left_overlap.external_id), status_code=200)
+        self.assertContains(response, str(right_overlap.external_id), status_code=200)
+        self.assertNotContains(
+            response, str(outside_range.external_id), status_code=200
+        )
 
     def test_create_schedule_with_permissions(self):
         """Users with can_write_user_schedule permission can create schedules."""
@@ -568,26 +570,24 @@ class TestAvailabilityExceptionsViewSet(CareAPITestBase):
         role = self.create_role_with_permissions(permissions)
         self.attach_role_facility_organization_user(self.organization, self.user, role)
 
-        filter_from = datetime(2025, 6, 1, 0, 0, tzinfo=UTC)
-        filter_to = datetime(2025, 6, 30, 23, 59, tzinfo=UTC)
+        filter_from = datetime(2025, 6, 1).date()
+        filter_to = filter_from + timedelta(days=29)
 
-        exception_1 = self.create_exception(
-            valid_from=filter_from.date(), valid_to=filter_to.date()
+        within_range = self.create_exception(valid_from=filter_from, valid_to=filter_to)
+
+        left_overlap = self.create_exception(
+            valid_from=filter_from - timedelta(days=5),
+            valid_to=filter_to,
         )
 
-        exception_2 = self.create_exception(
-            valid_from=(filter_from - timedelta(days=5)).date(),
-            valid_to=filter_to.date(),
+        right_overlap = self.create_exception(
+            valid_from=filter_from,
+            valid_to=filter_to + timedelta(days=5),
         )
 
-        exception_3 = self.create_exception(
-            valid_from=filter_from.date(),
-            valid_to=(filter_to + timedelta(days=5)).date(),
-        )
-
-        exception_4 = self.create_exception(
-            valid_from=(filter_to + timedelta(days=5)).date(),
-            valid_to=(filter_to + timedelta(days=25)).date(),
+        outside_range = self.create_exception(
+            valid_from=filter_to + timedelta(days=5),
+            valid_to=filter_to + timedelta(days=25),
         )
 
         response = self.client.get(
@@ -599,10 +599,12 @@ class TestAvailabilityExceptionsViewSet(CareAPITestBase):
             format="json",
         )
 
-        self.assertContains(response, str(exception_1.external_id), status_code=200)
-        self.assertContains(response, str(exception_2.external_id), status_code=200)
-        self.assertContains(response, str(exception_3.external_id), status_code=200)
-        self.assertNotContains(response, str(exception_4.external_id), status_code=200)
+        self.assertContains(response, str(within_range.external_id), status_code=200)
+        self.assertContains(response, str(left_overlap.external_id), status_code=200)
+        self.assertContains(response, str(right_overlap.external_id), status_code=200)
+        self.assertNotContains(
+            response, str(outside_range.external_id), status_code=200
+        )
 
     def test_create_exception_with_permissions(self):
         """Users with can_write_user_schedule permission can create exceptions."""


### PR DESCRIPTION
## Proposed Changes

- Add Monthly filtering in Schedule and Exception using valid_from and valid_to

### Associated Issue : 

- FE issue : [ Month-based filtering in the schedule #12461 ](https://github.com/ohcnetwork/care_fe/issues/12461)

## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to filter schedules and availability exceptions by date range using new filter options.
- **Tests**
  - Introduced tests to verify filtering of schedules and availability exceptions by date range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->