### PR TITLE
Fix load govt orgs command to have correct metadata

### DIFF
--- a/care/emr/management/commands/load_govt_organization.py
+++ b/care/emr/management/commands/load_govt_organization.py
@@ -110,6 +110,7 @@ class Command(BaseCommand):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.migration_id = int(datetime.now(tz=UTC).timestamp() * 1000)
+        self.country = "India"
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -148,8 +149,9 @@ class Command(BaseCommand):
             "system_generated": True,
             "level_cache": 0,
             "metadata": {
-                "country": "india",
+                "country": self.country,
                 "govt_org_type": "state",
+                "govt_org_children_type": "district",
             },
             "meta": {
                 "migration_id": self.migration_id,
@@ -184,8 +186,9 @@ class Command(BaseCommand):
                 "system_generated": True,
                 "level_cache": 1,
                 "metadata": {
-                    "country": "india",
+                    "country": self.country,
                     "govt_org_type": "district",
+                    "govt_org_children_type": "local_body",
                 },
                 "meta": {
                     "migration_id": self.migration_id,
@@ -232,7 +235,6 @@ class Command(BaseCommand):
                 )
                 if not dist_obj:
                     continue
-                body_type = local_body.get("localbody_code", " ")[0]
                 local_body_objs.append(
                     Organization(
                         root_org=dist_obj.parent,
@@ -242,11 +244,10 @@ class Command(BaseCommand):
                         level_cache=2,
                         system_generated=True,
                         metadata={
-                            "country": "india",
-                            "govt_org_type": local_body_choice_map.get(
-                                body_type, "other_local_body"
-                            ),
-                            "lsg_code": local_body.get(
+                            "country": self.country,
+                            "govt_org_type": "local_body",
+                            "govt_org_children_type": "ward",
+                            "govt_org_id": local_body.get(
                                 "lsg_code", local_body.get("localbody_code")
                             ),
                         },
@@ -299,9 +300,9 @@ class Command(BaseCommand):
                                     system_generated=True,
                                     level_cache=3,
                                     metadata={
-                                        "country": "india",
+                                        "country": self.country,
                                         "govt_org_type": "ward",
-                                        "ward_number": get_ward_number(ward),
+                                        "govt_org_id": get_ward_number(ward),
                                     },
                                     meta={
                                         "migration_id": self.migration_id,


### PR DESCRIPTION
## Proposed Changes

- Fix load govt orgs command to have correct metadata

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Standardized the use of the country name and metadata keys across all government organization levels for improved consistency.
	- Simplified and unified the assignment of organization types and identifiers in metadata.
- **Chores**
	- Removed redundant variables and streamlined internal logic for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->