### PR TITLE
bug with questionnaire submission on enable when

### DIFF
--- a/care/emr/resources/questionnaire/utils.py
+++ b/care/emr/resources/questionnaire/utils.py
@@ -165,7 +165,7 @@ def is_question_enabled(question, responses, questionnaire_obj):  # noqa PLR0912
 
         # Evaluate the condition across all values
         if operator == "exists":
-            result = bool(all_values)
+            result = bool(all_values) if expected_answer else not bool(all_values)
         elif operator == "equals":
             result = expected_answer in all_values
         elif operator == "not_equals":
@@ -441,30 +441,38 @@ def collect_and_validate_enable_when_questions(
 ):
     """
     Walk the questions and:
-     - If enable_when fails → add to errors
+     - If enable_when fails → check if it (or its children) were answered → error
      - Otherwise recurse into groups and keep the question
     Returns the filtered list of “enabled” questions.
     """
+
+    def any_answered(q):
+        if q["id"] in responses:
+            return True
+        if q.get("questions"):
+            return any(any_answered(child) for child in q["questions"])
+        return False
+
     valid = []
     for q in questions:
-        # check enable_when
-        if q.get("enable_when") and not is_question_enabled(
-            q, responses, questionnaire_obj
-        ):
-            errors.append(
-                {
-                    "question_id": q["id"],
-                    "type": "enable_when_failed",
-                    "msg": (
-                        f"Question '{q.get('link_id', q['id'])}' "
-                        "is not permitted by its enable_when conditions"
-                    ),
-                }
-            )
-            # do not include q in valid
-            continue
+        # check enable_when condition
+        is_enabled = is_question_enabled(q, responses, questionnaire_obj)
 
-        # if it's a group, recurse for its children
+        if not is_enabled:
+            if any_answered(q):
+                errors.append(
+                    {
+                        "question_id": q["id"],
+                        "type": "enable_when_failed",
+                        "msg": (
+                            f"Question or group '{q.get('link_id', q['id'])}' "
+                            "is not permitted by its enable_when conditions"
+                        ),
+                    }
+                )
+            continue  # skip adding to valid
+
+        # if it's a group, recurse
         if q["type"] == QuestionType.group.value:
             grp = q.copy()
             grp["questions"] = collect_and_validate_enable_when_questions(

--- a/care/emr/resources/questionnaire/utils.py
+++ b/care/emr/resources/questionnaire/utils.py
@@ -446,20 +446,32 @@ def collect_and_validate_enable_when_questions(
     Returns the filtered list of “enabled” questions.
     """
 
-    def any_answered(q):
-        if q["id"] in responses:
+    def any_answered(q, resp_map):
+        resp = resp_map.get(q["id"])
+
+        # Direct answer for simple question
+        if resp and getattr(resp, "values", None):
             return True
+
+        # Repeating group: inspect sub_results
+        if resp and getattr(resp, "sub_results", None):
+            for sub in resp.sub_results:
+                sub_resp_map = create_responses_mapping(sub)
+                if any_answered(q, sub_resp_map):
+                    return True
+
+        # Recursively check child questions if present (for nested groups)
         if q.get("questions"):
-            return any(any_answered(child) for child in q["questions"])
+            return any(any_answered(child, resp_map) for child in q["questions"])
+
         return False
 
     valid = []
     for q in questions:
-        # check enable_when condition
         is_enabled = is_question_enabled(q, responses, questionnaire_obj)
 
         if not is_enabled:
-            if any_answered(q):
+            if any_answered(q, responses):
                 errors.append(
                     {
                         "question_id": q["id"],
@@ -470,9 +482,9 @@ def collect_and_validate_enable_when_questions(
                         ),
                     }
                 )
-            continue  # skip adding to valid
+            continue  # skip this question/group
 
-        # if it's a group, recurse
+        # Recurse into groups
         if q["type"] == QuestionType.group.value:
             grp = q.copy()
             grp["questions"] = collect_and_validate_enable_when_questions(


### PR DESCRIPTION
## Proposed Changes

- Brief of changes made.

### Associated Issue

- Link to issue here, explain how the proposed solution will solve the reported issue/ feature request.

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of questions with "exists" conditions, ensuring accurate enablement based on expected answers.
	- Errors are now only shown for questions answered in violation of enablement rules; unanswered, non-enabled questions are silently excluded.

- **Tests**
	- Added a test to verify correct behavior when a question is enabled by the non-existence of another.
	- Enhanced test assertions for more precise validation of enablement errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->