### PR TITLE
added validation for group to have atleast 1 sub question

### DIFF
--- a/care/emr/resources/questionnaire/spec.py
+++ b/care/emr/resources/questionnaire/spec.py
@@ -163,12 +163,17 @@ class Question(QuestionnaireBaseSpec):
         return ids
 
     @model_validator(mode="after")
-    def validate_value_set_or_options(self):
+    def validate_choice_and_group_questions(self):
         if self.type in [QuestionType.choice, QuestionType.quantity] and not (
             self.answer_option or self.answer_value_set
         ):
-            err = "Either answer options or a value set must be provided for choice type questions"
-            raise ValueError(err)
+            raise ValueError(
+                "Either answer options or a value set must be provided for choice type questions"
+            )
+
+        if self.type == QuestionType.group and not self.questions:
+            raise ValueError("Group type questions must have at least one sub-question")
+
         return self
 
 

--- a/care/emr/resources/questionnaire/utils.py
+++ b/care/emr/resources/questionnaire/utils.py
@@ -209,7 +209,7 @@ def validate_question_result(  # noqa : PLR0912
     if questionnaire["type"] == QuestionType.group.value:
         # Iterate and call all child questions
         questionnaire_mapping[questionnaire["id"]] = questionnaire
-        if questionnaire["questions"]:
+        if questionnaire.get("questions"):
             if questionnaire.get("repeats", False):
                 # Handle repeating groups
                 response = responses.get(questionnaire["id"])
@@ -485,7 +485,9 @@ def collect_and_validate_enable_when_questions(
             continue  # skip this question/group
 
         # Recurse into groups
-        if q["type"] == QuestionType.group.value:
+        if q["type"] == QuestionType.group.value and q.get(
+            "questions"
+        ):  # this ignores the case where a group has no questions
             grp = q.copy()
             grp["questions"] = collect_and_validate_enable_when_questions(
                 q["questions"], responses, questionnaire_obj, errors, parent=q["id"]


### PR DESCRIPTION
## Proposed Changes

- Add validation in questionnaire create to raise error if a group is without any sub questions
- Updated submit endpoint to ignore group questions with no sub questions

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation for questionnaire questions, ensuring group-type questions cannot be empty and preventing errors when "questions" are missing.
	- Enhanced robustness by safely handling missing or empty question groups during validation and processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->