### PR TITLE
Make fields in patient optional

### DIFF
--- a/care/emr/resources/patient/spec.py
+++ b/care/emr/resources/patient/spec.py
@@ -40,11 +40,11 @@ class PatientBaseSpec(EMRResource):
     id: UUID4 | None = None
     name: str = Field(max_length=200)
     gender: GenderChoices
-    phone_number: PhoneNumber = Field(max_length=14)
+    phone_number: PhoneNumber | None = Field(None, max_length=14)
     emergency_phone_number: PhoneNumber | None = Field(None, max_length=14)
-    address: str
-    permanent_address: str
-    pincode: int
+    address: str | None = None
+    permanent_address: str | None = None
+    pincode: int | None = None
     deceased_datetime: StrictTZAwareDateTime | None = None
     blood_group: BloodGroupChoices | None = None
 


### PR DESCRIPTION
## Proposed Changes

- Make fields in patient optional

### Associated Issue

- https://github.com/ohcnetwork/care_fe/issues/12699#event-18288396597

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Made phone number, address, permanent address, and pincode fields optional when creating or updating patient information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->