### PR TITLE
Add ordering filter to PaymentReconciliationViewSet

### DIFF
--- a/care/emr/api/viewsets/payment_reconciliation.py
+++ b/care/emr/api/viewsets/payment_reconciliation.py
@@ -1,6 +1,7 @@
 from django.shortcuts import get_object_or_404
 from django_filters import rest_framework as filters
 from rest_framework.exceptions import ValidationError
+from rest_framework.filters import OrderingFilter
 
 from care.emr.api.viewsets.base import (
     EMRBaseViewSet,
@@ -39,7 +40,8 @@ class PaymentReconciliationViewSet(
     pydantic_update_model = BasePaymentReconciliationSpec
     pydantic_read_model = PaymentReconciliationReadSpec
     filterset_class = PaymentReconciliationFilters
-    filter_backends = [filters.DjangoFilterBackend]
+    filter_backends = [filters.DjangoFilterBackend, OrderingFilter]
+    ordering = ["-payment_datetime"]
 
     def get_facility_obj(self):
         return get_object_or_404(

--- a/care/emr/api/viewsets/payment_reconciliation.py
+++ b/care/emr/api/viewsets/payment_reconciliation.py
@@ -41,7 +41,7 @@ class PaymentReconciliationViewSet(
     pydantic_read_model = PaymentReconciliationReadSpec
     filterset_class = PaymentReconciliationFilters
     filter_backends = [filters.DjangoFilterBackend, OrderingFilter]
-    ordering = ["-payment_datetime"]
+    ordering_fields = ["created_date", "payment_datetime"]
 
     def get_facility_obj(self):
         return get_object_or_404(


### PR DESCRIPTION
## Proposed Changes

-  ordering support for created_date, payment_datetime fields


## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins
