### PR TITLE
fix: String length validation in UserSpec

### DIFF
--- a/care/emr/resources/user/spec.py
+++ b/care/emr/resources/user/spec.py
@@ -51,8 +51,8 @@ class UserBaseSpec(EMRResource):
     last_name: str
     phone_number: str = Field(max_length=14)
 
-    prefix: str | None = None
-    suffix: str | None = None
+    prefix: str | None = Field(None, max_length=10)
+    suffix: str | None = Field(None, max_length=50)
 
 
 class UserUpdateSpec(UserBaseSpec):


### PR DESCRIPTION
## Proposed Changes

- Added field validation for prefix and suffix in user model

### Associated Issue

- Issue : [DataError : value too long for type character varying(10)](https://rebuildearth.slack.com/archives/D08Q840D75M/p1751270993756969)

### Architecture changes

- Changes made in the user spec.py file

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added maximum length limits for prefix (10 characters) and suffix (50 characters) fields in user profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->