### PR TITLE
Bug: Field name for user_type in UserFilter

### DIFF
--- a/care/emr/api/viewsets/user.py
+++ b/care/emr/api/viewsets/user.py
@@ -32,7 +32,7 @@ class UserFilter(filters.FilterSet):
         field_name="phone_number", lookup_expr="icontains"
     )
     username = filters.CharFilter(field_name="username", lookup_expr="icontains")
-    user_type = filters.CharFilter(field_name="username", lookup_expr="iexact")
+    user_type = filters.CharFilter(field_name="user_type", lookup_expr="iexact")
 
 
 class UserViewSet(EMRModelViewSet):


### PR DESCRIPTION
## Proposed Changes

- Changed the field name of user_type in UserFilter from "username" - "user_type"

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the user filtering logic to ensure filtering by user type now works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->