### PR TITLE
Add case-insensitive name filter to ProductFilters

### DIFF
--- a/care/emr/api/viewsets/inventory/product.py
+++ b/care/emr/api/viewsets/inventory/product.py
@@ -18,7 +18,7 @@ class ProductFilters(filters.FilterSet):
     status = filters.CharFilter(lookup_expr="iexact")
     facility = filters.UUIDFilter(field_name="facility__external_id")
     product_knowledge = filters.UUIDFilter(field_name="product_knowledge__external_id")
-    name = filters.CharFilter(
+    product_knowledge_name = filters.CharFilter(
         field_name="product_knowledge__name", lookup_expr="icontains"
     )
 

--- a/care/emr/api/viewsets/inventory/product.py
+++ b/care/emr/api/viewsets/inventory/product.py
@@ -18,6 +18,9 @@ class ProductFilters(filters.FilterSet):
     status = filters.CharFilter(lookup_expr="iexact")
     facility = filters.UUIDFilter(field_name="facility__external_id")
     product_knowledge = filters.UUIDFilter(field_name="product_knowledge__external_id")
+    name = filters.CharFilter(
+        field_name="product_knowledge__name", lookup_expr="icontains"
+    )
 
 
 class ProductViewSet(


### PR DESCRIPTION
Introduce a name filter to enable case-insensitive searching for product names in the ProductFilters.