### PR TITLE
fix:added validation for title in noteThreadSpec

### DIFF
--- a/care/emr/resources/notes/thread_spec.py
+++ b/care/emr/resources/notes/thread_spec.py
@@ -1,6 +1,6 @@
 import datetime
 
-from pydantic import UUID4, field_validator
+from pydantic import UUID4, Field, field_validator
 
 from care.emr.models import Encounter
 from care.emr.models.notes import NoteThread
@@ -12,7 +12,7 @@ class NoteThreadSpec(EMRResource):
     __model__ = NoteThread
     __exclude__ = ["patient", "encounter"]
     id: UUID4 | None = None
-    title: str
+    title: str = Field(..., max_length=255)
 
 
 class NoteThreadCreateSpec(NoteThreadSpec):


### PR DESCRIPTION
## Proposed Changes

- added title validation max length 255

### Associated Issue

- [CARE-FXR](https://coronasafe-network.sentry.io/issues/6457802209/events/d5eee835d170423ab4b2e6200a4538ab/)


## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a maximum length of 255 characters for note thread titles to improve data validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->