### PR TITLE
Add ordering fields to viewsets for improved sorting

### DIFF
--- a/care/emr/api/viewsets/account.py
+++ b/care/emr/api/viewsets/account.py
@@ -42,9 +42,7 @@ class AccountViewSet(
     pydantic_retrieve_model = AccountRetrieveSpec
     filterset_class = AccountFilters
     filter_backends = [filters.DjangoFilterBackend, OrderingFilter]
-    ordering = [
-        "-created_date",
-    ]
+    ordering_fields = ["created_date", "modified_date"]
 
     def get_facility_obj(self):
         return get_object_or_404(

--- a/care/emr/api/viewsets/activity_definition.py
+++ b/care/emr/api/viewsets/activity_definition.py
@@ -1,5 +1,6 @@
 from django_filters import rest_framework as filters
 from rest_framework.exceptions import PermissionDenied, ValidationError
+from rest_framework.filters import OrderingFilter
 from rest_framework.generics import get_object_or_404
 
 from care.emr.api.viewsets.base import (
@@ -45,7 +46,8 @@ class ActivityDefinitionViewSet(
     pydantic_read_model = ActivityDefinitionReadSpec
     pydantic_retrieve_model = ActivityDefinitionRetrieveSpec
     filterset_class = ActivityDefinitionFilters
-    filter_backends = [filters.DjangoFilterBackend]
+    filter_backends = [filters.DjangoFilterBackend, OrderingFilter]
+    ordering_fields = ["created_date", "modified_date"]
     resource_type = TagResource.activity_definition
 
     def get_facility_obj(self):

--- a/care/emr/api/viewsets/charge_item.py
+++ b/care/emr/api/viewsets/charge_item.py
@@ -68,9 +68,7 @@ class ChargeItemViewSet(
     pydantic_read_model = ChargeItemReadSpec
     filterset_class = ChargeItemDefinitionFilters
     filter_backends = [filters.DjangoFilterBackend, OrderingFilter]
-    ordering = [
-        "-created_date",
-    ]
+    ordering_fields = ["created_date", "modified_date"]
     questionnaire_type = "charge_item"
     questionnaire_title = "Charge Item"
     questionnaire_description = "Charge Item"

--- a/care/emr/api/viewsets/charge_item_definition.py
+++ b/care/emr/api/viewsets/charge_item_definition.py
@@ -1,5 +1,6 @@
 from django_filters import rest_framework as filters
 from rest_framework.exceptions import PermissionDenied, ValidationError
+from rest_framework.filters import OrderingFilter
 from rest_framework.generics import get_object_or_404
 
 from care.emr.api.viewsets.base import (
@@ -30,7 +31,8 @@ class ChargeItemDefinitionViewSet(
     pydantic_model = ChargeItemDefinitionSpec
     pydantic_read_model = ChargeItemDefinitionReadSpec
     filterset_class = ChargeItemDefinitionFilters
-    filter_backends = [filters.DjangoFilterBackend]
+    filter_backends = [filters.DjangoFilterBackend, OrderingFilter]
+    ordering_fields = ["created_date", "modified_date"]
 
     def get_facility_obj(self):
         return get_object_or_404(

--- a/care/emr/api/viewsets/diagnostic_report.py
+++ b/care/emr/api/viewsets/diagnostic_report.py
@@ -4,6 +4,7 @@ from drf_spectacular.utils import extend_schema
 from pydantic import UUID4, BaseModel
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
+from rest_framework.filters import OrderingFilter
 from rest_framework.response import Response
 
 from care.emr.api.viewsets.base import (
@@ -66,7 +67,8 @@ class DiagnosticReportViewSet(
     pydantic_read_model = DiagnosticReportListSpec
     pydantic_retrieve_model = DiagnosticReportRetrieveSpec
     filterset_class = DiagnosticReportFilters
-    filter_backends = [filters.DjangoFilterBackend]
+    filter_backends = [filters.DjangoFilterBackend, OrderingFilter]
+    ordering_fields = ["created_date", "modified_date"]
 
     def get_patient_obj(self):
         return get_object_or_404(

--- a/care/emr/api/viewsets/healthcare_service.py
+++ b/care/emr/api/viewsets/healthcare_service.py
@@ -1,5 +1,6 @@
 from django_filters import rest_framework as filters
 from rest_framework.exceptions import PermissionDenied, ValidationError
+from rest_framework.filters import OrderingFilter
 from rest_framework.generics import get_object_or_404
 
 from care.emr.api.viewsets.base import (
@@ -34,7 +35,8 @@ class HealthcareServiceViewSet(
     pydantic_read_model = HealthcareServiceReadSpec
     pydantic_retrieve_model = HealthcareServiceRetrieveSpec
     filterset_class = HealthcareServiceFilters
-    filter_backends = [filters.DjangoFilterBackend]
+    filter_backends = [filters.DjangoFilterBackend, OrderingFilter]
+    ordering_fields = ["created_date", "modified_date"]
 
     def get_facility_obj(self):
         return get_object_or_404(

--- a/care/emr/api/viewsets/inventory/inventory_item.py
+++ b/care/emr/api/viewsets/inventory/inventory_item.py
@@ -1,4 +1,5 @@
 from django_filters import rest_framework as filters
+from django_filters.filters import OrderingFilter
 
 from care.emr.api.viewsets.base import EMRBaseViewSet, EMRListMixin, EMRRetrieveMixin
 from care.emr.models.inventory_item import InventoryItem
@@ -24,4 +25,5 @@ class InventoryItemViewSet(EMRRetrieveMixin, EMRListMixin, EMRBaseViewSet):
     pydantic_read_model = InventoryItemReadSpec
     pydantic_retrieve_model = InventoryItemRetrieveSpec
     filterset_class = InventoryItemFilters
-    filter_backends = [filters.DjangoFilterBackend]
+    filter_backends = [filters.DjangoFilterBackend, OrderingFilter]
+    ordering_fields = ["created_date", "modified_date"]

--- a/care/emr/api/viewsets/inventory/product.py
+++ b/care/emr/api/viewsets/inventory/product.py
@@ -1,6 +1,7 @@
 from django.shortcuts import get_object_or_404
 from django_filters import rest_framework as filters
 from rest_framework.exceptions import ValidationError
+from rest_framework.filters import OrderingFilter
 
 from care.emr.api.viewsets.base import (
     EMRBaseViewSet,
@@ -27,7 +28,8 @@ class ProductViewSet(
     pydantic_model = ProductWriteSpec
     pydantic_read_model = ProductReadSpec
     filterset_class = ProductFilters
-    filter_backends = [filters.DjangoFilterBackend]
+    filter_backends = [filters.DjangoFilterBackend, OrderingFilter]
+    ordering_fields = ["created_date", "modified_date"]
 
     def get_facility_obj(self):
         return get_object_or_404(

--- a/care/emr/api/viewsets/inventory/product_knowledge.py
+++ b/care/emr/api/viewsets/inventory/product_knowledge.py
@@ -20,6 +20,7 @@ class ProductKnowledgeFilters(filters.FilterSet):
     status = filters.CharFilter(lookup_expr="iexact")
     facility = filters.UUIDFilter(field_name="facility__external_id")
     name = filters.CharFilter(lookup_expr="icontains")  # TODO : Need better searching
+    product_type = filters.CharFilter(lookup_expr="iexact")
 
 
 class ProductKnowledgeViewSet(

--- a/care/emr/api/viewsets/inventory/product_knowledge.py
+++ b/care/emr/api/viewsets/inventory/product_knowledge.py
@@ -1,4 +1,5 @@
 from django_filters import rest_framework as filters
+from rest_framework.filters import OrderingFilter
 
 from care.emr.api.viewsets.base import (
     EMRBaseViewSet,
@@ -29,4 +30,5 @@ class ProductKnowledgeViewSet(
     pydantic_update_model = BaseProductKnowledgeSpec
     pydantic_read_model = ProductKnowledgeReadSpec
     filterset_class = ProductKnowledgeFilters
-    filter_backends = [filters.DjangoFilterBackend]
+    filter_backends = [filters.DjangoFilterBackend, OrderingFilter]
+    ordering_fields = ["created_date", "modified_date"]

--- a/care/emr/api/viewsets/inventory/supply_delivery.py
+++ b/care/emr/api/viewsets/inventory/supply_delivery.py
@@ -1,6 +1,7 @@
 from django.db import transaction
 from django_filters import rest_framework as filters
 from rest_framework.exceptions import ValidationError
+from rest_framework.filters import OrderingFilter
 
 from care.emr.api.viewsets.base import (
     EMRBaseViewSet,
@@ -57,7 +58,8 @@ class SupplyDeliveryViewSet(
     pydantic_read_model = SupplyDeliveryReadSpec
     pydantic_retrieve_model = SupplyDeliveryRetrieveSpec
     filterset_class = SupplyDeliveryFilters
-    filter_backends = [filters.DjangoFilterBackend]
+    filter_backends = [filters.DjangoFilterBackend, OrderingFilter]
+    ordering_fields = ["created_date", "modified_date"]
 
     def perform_create(self, instance):
         instance.status = SupplyDeliveryStatusOptions.in_progress.value

--- a/care/emr/api/viewsets/inventory/supply_request.py
+++ b/care/emr/api/viewsets/inventory/supply_request.py
@@ -1,4 +1,5 @@
 from django_filters import rest_framework as filters
+from rest_framework.filters import OrderingFilter
 
 from care.emr.api.viewsets.base import (
     EMRBaseViewSet,
@@ -38,4 +39,5 @@ class SupplyRequestViewSet(
     pydantic_model = SupplyRequestWriteSpec
     pydantic_read_model = SupplyRequestReadSpec
     filterset_class = SupplyRequestFilters
-    filter_backends = [filters.DjangoFilterBackend]
+    filter_backends = [filters.DjangoFilterBackend, OrderingFilter]
+    ordering_fields = ["created_date", "modified_date"]

--- a/care/emr/api/viewsets/invoice.py
+++ b/care/emr/api/viewsets/invoice.py
@@ -64,9 +64,7 @@ class InvoiceViewSet(
     pydantic_retrieve_model = InvoiceRetrieveSpec
     filterset_class = InvoiceFilters
     filter_backends = [filters.DjangoFilterBackend, OrderingFilter]
-    ordering = [
-        "-created_date",
-    ]
+    ordering_fields = ["created_date", "modified_date"]
 
     def get_facility_obj(self):
         return get_object_or_404(

--- a/care/emr/api/viewsets/observation_definition.py
+++ b/care/emr/api/viewsets/observation_definition.py
@@ -1,5 +1,6 @@
 from django_filters import rest_framework as filters
 from rest_framework.exceptions import PermissionDenied
+from rest_framework.filters import OrderingFilter
 from rest_framework.generics import get_object_or_404
 
 from care.emr.api.viewsets.base import (
@@ -34,7 +35,8 @@ class ObservationDefinitionViewSet(
     pydantic_update_model = BaseObservationDefinitionSpec
     pydantic_read_model = ObservationDefinitionReadSpec
     filterset_class = ObservationDefinitionFilters
-    filter_backends = [filters.DjangoFilterBackend]
+    filter_backends = [filters.DjangoFilterBackend, OrderingFilter]
+    ordering_fields = ["created_date", "modified_date"]
 
     def authorize_create(self, instance):
         """

--- a/care/emr/api/viewsets/patient.py
+++ b/care/emr/api/viewsets/patient.py
@@ -8,6 +8,7 @@ from drf_spectacular.utils import extend_schema
 from pydantic import UUID4, BaseModel
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied, ValidationError
+from rest_framework.filters import OrderingFilter
 from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 
@@ -45,7 +46,8 @@ class PatientViewSet(EMRModelViewSet):
     pydantic_update_model = PatientUpdateSpec
     pydantic_retrieve_model = PatientRetrieveSpec
     filterset_class = PatientFilters
-    filter_backends = [DjangoFilterBackend]
+    filter_backends = [DjangoFilterBackend, OrderingFilter]
+    ordering_fields = ["created_date", "modified_date"]
 
     def authorize_update(self, request_obj, model_instance):
         if not AuthorizationController.call(

--- a/care/emr/api/viewsets/payment_reconciliation.py
+++ b/care/emr/api/viewsets/payment_reconciliation.py
@@ -41,7 +41,7 @@ class PaymentReconciliationViewSet(
     pydantic_read_model = PaymentReconciliationReadSpec
     filterset_class = PaymentReconciliationFilters
     filter_backends = [filters.DjangoFilterBackend, OrderingFilter]
-    ordering_fields = ["created_date", "payment_datetime"]
+    ordering_fields = ["created_date", "modified_date", "payment_datetime"]
 
     def get_facility_obj(self):
         return get_object_or_404(

--- a/care/emr/api/viewsets/service_request.py
+++ b/care/emr/api/viewsets/service_request.py
@@ -88,9 +88,7 @@ class ServiceRequestViewSet(
     questionnaire_description = "Service Request"
     questionnaire_subject_type = SubjectType.patient.value
     resource_type = TagResource.service_request
-    ordering = [
-        "-created_date",
-    ]
+    ordering_fields = ["created_date", "modified_date"]
 
     def get_facility_obj(self):
         return get_object_or_404(

--- a/care/emr/api/viewsets/specimen.py
+++ b/care/emr/api/viewsets/specimen.py
@@ -1,4 +1,5 @@
 from rest_framework.exceptions import PermissionDenied
+from rest_framework.filters import OrderingFilter
 
 from care.emr.api.viewsets.base import EMRBaseViewSet, EMRRetrieveMixin, EMRUpdateMixin
 from care.emr.models.specimen import Specimen
@@ -17,6 +18,8 @@ class SpecimenViewSet(EMRRetrieveMixin, EMRUpdateMixin, EMRBaseViewSet):
     pydantic_update_model = SpecimenUpdateSpec
     pydantic_read_model = SpecimenReadSpec
     pydantic_retrieve_model = SpecimenRetrieveSpec
+    filter_backends = [OrderingFilter]
+    ordering_fields = ["created_date", "modified_date"]
 
     def authorize_update(self, request_obj, model_instance):
         service_request = model_instance.service_request

--- a/care/emr/api/viewsets/specimen_definition.py
+++ b/care/emr/api/viewsets/specimen_definition.py
@@ -1,5 +1,6 @@
 from django_filters import rest_framework as filters
 from rest_framework.exceptions import PermissionDenied, ValidationError
+from rest_framework.filters import OrderingFilter
 from rest_framework.generics import get_object_or_404
 
 from care.emr.api.viewsets.base import (
@@ -30,7 +31,8 @@ class SpecimenDefinitionViewSet(
     pydantic_model = BaseSpecimenDefinitionSpec
     pydantic_read_model = SpecimenDefinitionReadSpec
     filterset_class = SpecimenDefinitionFilters
-    filter_backends = [filters.DjangoFilterBackend]
+    filter_backends = [filters.DjangoFilterBackend, OrderingFilter]
+    ordering_fields = ["created_date", "modified_date"]
 
     def get_facility_obj(self):
         return get_object_or_404(


### PR DESCRIPTION
Introduce ordering fields to various viewsets, enhancing sorting capabilities by allowing sorting based on creation and modification dates. This change simplifies the sorting process across multiple resources.


- account
- activity_definition
- charge_item
- charge_item_definition
- diagnostic_report
- healthcare_service
- inventory_item
- product
- product_knowledge
- supply_delivery
- supply_request
- invoice
- observation_definition
- patient
- payment_reconciliation
- service_request
- specimen
- specimen_definition