### PR TITLE
Fix import statement for OrderingFilter in inventory_item.py

### DIFF
--- a/care/emr/api/viewsets/inventory/inventory_item.py
+++ b/care/emr/api/viewsets/inventory/inventory_item.py
@@ -1,5 +1,5 @@
 from django_filters import rest_framework as filters
-from django_filters.filters import OrderingFilter
+from rest_framework.filters import OrderingFilter
 
 from care.emr.api.viewsets.base import EMRBaseViewSet, EMRListMixin, EMRRetrieveMixin
 from care.emr.models.inventory_item import InventoryItem


### PR DESCRIPTION
Correct the import path for OrderingFilter to ensure proper functionality in the inventory item view.