### PR TITLE
Add location filter to InventoryItemFilters

### DIFF
--- a/care/emr/api/viewsets/inventory/inventory_item.py
+++ b/care/emr/api/viewsets/inventory/inventory_item.py
@@ -1,8 +1,10 @@
 from django_filters import rest_framework as filters
 from rest_framework.filters import OrderingFilter
+from rest_framework.generics import get_object_or_404
 
 from care.emr.api.viewsets.base import EMRBaseViewSet, EMRListMixin, EMRRetrieveMixin
 from care.emr.models.inventory_item import InventoryItem
+from care.emr.models.location import FacilityLocation
 from care.emr.resources.inventory.inventory_item.spec import (
     InventoryItemReadSpec,
     InventoryItemRetrieveSpec,
@@ -17,7 +19,6 @@ class InventoryItemFilters(filters.FilterSet):
     status = filters.CharFilter(lookup_expr="iexact")
     net_content_gt = filters.NumberFilter(field_name="net_content", lookup_expr="gt")
     net_content = filters.RangeFilter(field_name="net_content")
-    location = filters.UUIDFilter(field_name="location__external_id")
 
 
 class InventoryItemViewSet(EMRRetrieveMixin, EMRListMixin, EMRBaseViewSet):
@@ -28,3 +29,13 @@ class InventoryItemViewSet(EMRRetrieveMixin, EMRListMixin, EMRBaseViewSet):
     filterset_class = InventoryItemFilters
     filter_backends = [filters.DjangoFilterBackend, OrderingFilter]
     ordering_fields = ["created_date", "modified_date"]
+
+    def get_location_obj(self):
+        return get_object_or_404(
+            FacilityLocation, external_id=self.kwargs["location_external_id"]
+        )
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        location = self.get_location_obj()
+        return queryset.filter(location=location)

--- a/care/emr/api/viewsets/inventory/inventory_item.py
+++ b/care/emr/api/viewsets/inventory/inventory_item.py
@@ -17,6 +17,7 @@ class InventoryItemFilters(filters.FilterSet):
     status = filters.CharFilter(lookup_expr="iexact")
     net_content_gt = filters.NumberFilter(field_name="net_content", lookup_expr="gt")
     net_content = filters.RangeFilter(field_name="net_content")
+    location = filters.UUIDFilter(field_name="location__external_id")
 
 
 class InventoryItemViewSet(EMRRetrieveMixin, EMRListMixin, EMRBaseViewSet):


### PR DESCRIPTION
Introduce a location filter to the InventoryItemFilters, allowing for more precise querying of inventory items based on their location.