### PR TITLE
Set accession_identifier default and add filter for specimens

### DIFF
--- a/care/emr/api/viewsets/service_request.py
+++ b/care/emr/api/viewsets/service_request.py
@@ -96,7 +96,7 @@ class ServiceRequestViewSet(
 
     def convert_external_id_to_internal_id(self, instance):
         ids = []
-        for location in instance._locations:
+        for location in instance._locations:  # noqa: SLF001
             obj = (
                 FacilityLocation.objects.only("id")
                 .filter(external_id=location, facility=instance.facility)
@@ -252,6 +252,8 @@ class ServiceRequestViewSet(
         sepcimen_data = BaseSpecimenSpec(**request.data)
         self.authorize_create_specimen(service_request)
         model_instance = sepcimen_data.de_serialize()
+        if not model_instance.accession_identifier:
+            model_instance.accession_identifier = model_instance.external_id
         model_instance.patient = service_request.patient
         model_instance.encounter = service_request.encounter
         model_instance.facility = service_request.facility
@@ -281,6 +283,8 @@ class ServiceRequestViewSet(
             request_params.specimen.model_dump(mode="json")
         )
         model_instance = serializer_obj.de_serialize(obj=specimen)
+        if not model_instance.accession_identifier:
+            model_instance.accession_identifier = model_instance.external_id
         model_instance.patient = service_request.patient
         model_instance.encounter = service_request.encounter
         model_instance.facility = service_request.facility

--- a/care/emr/api/viewsets/specimen.py
+++ b/care/emr/api/viewsets/specimen.py
@@ -1,3 +1,4 @@
+from django_filters import rest_framework as filters
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.filters import OrderingFilter
 
@@ -12,14 +13,19 @@ from care.emr.resources.specimen.spec import (
 from care.security.authorization.base import AuthorizationController
 
 
+class SpecimenFilters(filters.FilterSet):
+    accession_identifier = filters.CharFilter(lookup_expr="icontains")
+
+
 class SpecimenViewSet(EMRRetrieveMixin, EMRUpdateMixin, EMRBaseViewSet):
     database_model = Specimen
     pydantic_model = BaseSpecimenSpec
     pydantic_update_model = SpecimenUpdateSpec
     pydantic_read_model = SpecimenReadSpec
     pydantic_retrieve_model = SpecimenRetrieveSpec
-    filter_backends = [OrderingFilter]
+    filter_backends = [filters.DjangoFilterBackend, OrderingFilter]
     ordering_fields = ["created_date", "modified_date"]
+    filterset_class = SpecimenFilters
 
     def authorize_update(self, request_obj, model_instance):
         service_request = model_instance.service_request


### PR DESCRIPTION
Assign `external_id` to `accession_identifier` when not provided and introduce a filter for `accession_identifier` in the specimen view set.