### PR TITLE
added DEFAULT_RENDERER_CLASSES to settings

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -384,6 +384,9 @@ REST_FRAMEWORK = {
     "SEARCH_PARAM": "search_text",
     "DEFAULT_SCHEMA_CLASS": "care.utils.swagger.schema.AutoSchema",
     "EXCEPTION_HANDLER": "config.exception_handler.exception_handler",
+    "DEFAULT_RENDERER_CLASSES": [
+        "rest_framework.renderers.JSONRenderer",
+    ],
 }
 
 # drf-spectacular (schema generation)


### PR DESCRIPTION
## Proposed Changes

- added DEFAULT_RENDERER_CLASSES to settings to disable `BrowsableAPIRenderer` which causes errors since it expect serilizer class in viewset  

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated settings to ensure API responses are returned in JSON format only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->