### PR TITLE
Add Timestamps to TokenBookingReadSpec and Cancel Reason to CancelBookingSpec

### DIFF
--- a/care/emr/api/viewsets/scheduling/booking.py
+++ b/care/emr/api/viewsets/scheduling/booking.py
@@ -39,6 +39,7 @@ class CancelBookingSpec(BaseModel):
         BookingStatusChoices.entered_in_error,
         BookingStatusChoices.rescheduled,
     ]
+    reason_for_visit: str
 
 
 class RescheduleBookingSpec(BaseModel):
@@ -132,6 +133,7 @@ class TokenBookingViewSet(
                 instance.token_slot.allocated -= 1
                 instance.token_slot.save()
             instance.status = request_data.reason
+            instance.reason_for_visit = request_data.reason_for_visit
             instance.updated_by = user
             instance.save()
         return Response(

--- a/care/emr/api/viewsets/scheduling/booking.py
+++ b/care/emr/api/viewsets/scheduling/booking.py
@@ -39,7 +39,7 @@ class CancelBookingSpec(BaseModel):
         BookingStatusChoices.entered_in_error,
         BookingStatusChoices.rescheduled,
     ]
-    reason_for_visit: str
+    reason_for_visit: str | None
 
 
 class RescheduleBookingSpec(BaseModel):
@@ -132,8 +132,9 @@ class TokenBookingViewSet(
                 # Free up the slot if it is not cancelled already
                 instance.token_slot.allocated -= 1
                 instance.token_slot.save()
+            if request_data.reason_for_visit:
+                instance.reason_for_visit = request_data.reason_for_visit
             instance.status = request_data.reason
-            instance.reason_for_visit = request_data.reason_for_visit
             instance.updated_by = user
             instance.save()
         return Response(

--- a/care/emr/api/viewsets/scheduling/booking.py
+++ b/care/emr/api/viewsets/scheduling/booking.py
@@ -39,7 +39,7 @@ class CancelBookingSpec(BaseModel):
         BookingStatusChoices.entered_in_error,
         BookingStatusChoices.rescheduled,
     ]
-    reason_for_visit: str | None
+    reason_for_visit: str | None = None
 
 
 class RescheduleBookingSpec(BaseModel):

--- a/care/emr/resources/scheduling/slot/spec.py
+++ b/care/emr/resources/scheduling/slot/spec.py
@@ -88,6 +88,10 @@ class TokenBookingReadSpec(TokenBookingBaseSpec):
     reason_for_visit: str
     user: dict = {}
     facility: dict = {}
+    created_by: UserSpec = {}
+    updated_by: UserSpec = {}
+    created_date: datetime.datetime
+    modified_date: datetime.datetime
 
     tags: list[dict] = []
 
@@ -107,3 +111,7 @@ class TokenBookingReadSpec(TokenBookingBaseSpec):
             Facility.objects.get(id=obj.token_slot.resource.facility_id)
         ).model_dump(exclude=["meta"])
         mapping["tags"] = SingleFacilityTagManager().render_tags(obj)
+        if obj.created_by:
+            mapping["created_by"] = UserSpec.serialize(obj.created_by)
+        if obj.updated_by:
+            mapping["updated_by"] = UserSpec.serialize(obj.updated_by)

--- a/care/emr/resources/scheduling/slot/spec.py
+++ b/care/emr/resources/scheduling/slot/spec.py
@@ -88,8 +88,8 @@ class TokenBookingReadSpec(TokenBookingBaseSpec):
     reason_for_visit: str
     user: dict = {}
     facility: dict = {}
-    created_by: UserSpec = {}
-    updated_by: UserSpec = {}
+    created_by: UserSpec | None = None
+    updated_by: UserSpec | None = None
     created_date: datetime.datetime
     modified_date: datetime.datetime
 
@@ -112,6 +112,10 @@ class TokenBookingReadSpec(TokenBookingBaseSpec):
         ).model_dump(exclude=["meta"])
         mapping["tags"] = SingleFacilityTagManager().render_tags(obj)
         if obj.created_by:
-            mapping["created_by"] = UserSpec.serialize(obj.created_by)
+            mapping["created_by"] = UserSpec.serialize(obj.created_by).model_dump(
+                exclude=["meta"]
+            )
         if obj.updated_by:
-            mapping["updated_by"] = UserSpec.serialize(obj.updated_by)
+            mapping["updated_by"] = UserSpec.serialize(obj.updated_by).model_dump(
+                exclude=["meta"]
+            )


### PR DESCRIPTION
## Proposed Changes
- Added reason for cancellation in CancelBookingSpec
- Added created and updated details in TokenBookingReadSpec

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Made the "reason for visit" field optional when cancelling a booking.
  * Booking details now include creation and modification dates along with creator and last updater information, shown only when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->