### PR TITLE
refact:updated the filters for status with multiselector

### DIFF
--- a/care/emr/api/viewsets/allergy_intolerance.py
+++ b/care/emr/api/viewsets/allergy_intolerance.py
@@ -36,7 +36,13 @@ from care.utils.filters.multiselect import MultiSelectFilter
 class AllergyIntoleranceFilters(FilterSet):
     encounter = filters.UUIDFilter(field_name="encounter__external_id")
     clinical_status = MultiSelectFilter(field_name="clinical_status")
+    exclude_clinical_status = MultiSelectFilter(
+        field_name="clinical_status", exclude=True
+    )
     verification_status = MultiSelectFilter(field_name="verification_status")
+    exclude_verification_status = MultiSelectFilter(
+        field_name="verification_status", exclude=True
+    )
     name = CharFilter(field_name="code__display", lookup_expr="icontains")
 
 

--- a/care/emr/api/viewsets/allergy_intolerance.py
+++ b/care/emr/api/viewsets/allergy_intolerance.py
@@ -30,12 +30,13 @@ from care.emr.resources.allergy_intolerance.spec import (
 )
 from care.emr.resources.questionnaire.spec import SubjectType
 from care.security.authorization import AuthorizationController
+from care.utils.filters.multiselect import MultiSelectFilter
 
 
 class AllergyIntoleranceFilters(FilterSet):
     encounter = filters.UUIDFilter(field_name="encounter__external_id")
-    clinical_status = CharFilter(field_name="clinical_status")
-    verification_status = CharFilter(field_name="verification_status")
+    clinical_status = MultiSelectFilter(field_name="clinical_status")
+    verification_status = MultiSelectFilter(field_name="verification_status")
     name = CharFilter(field_name="code__display", lookup_expr="icontains")
 
 


### PR DESCRIPTION
## Proposed Changes

- Updated the clinical and verification status filter with MultiSelectFilter.

### Associated Issue

- Fetching data includes the status with entered in error .

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced filtering options for allergy intolerance records, allowing users to select multiple clinical and verification statuses when filtering results.
  * Added new filters to exclude specific clinical and verification statuses, providing more precise control over displayed allergy intolerance data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->