### PR TITLE
Added encounter filter in Consent

### DIFF
--- a/care/emr/api/viewsets/consent.py
+++ b/care/emr/api/viewsets/consent.py
@@ -1,3 +1,4 @@
+from django_filters import rest_framework as filters
 from drf_spectacular.utils import extend_schema
 from pydantic import UUID4, BaseModel
 from rest_framework.decorators import action
@@ -18,6 +19,10 @@ from care.emr.resources.consent.spec import (
 from care.utils.time_util import care_now
 
 
+class ConsentFilters(filters.FilterSet):
+    encounter = filters.UUIDFilter(field_name="encounter__external_id")
+
+
 class ConsentViewSet(
     ValidateEncounterMixin,
     EncounterBasedAuthorizationBase,
@@ -28,6 +33,8 @@ class ConsentViewSet(
     pydantic_read_model = ConsentListSpec
     pydantic_update_model = ConsentUpdateSpec
     pydantic_retrieve_model = ConsentRetrieveSpec
+    filter_backends = (filters.DjangoFilterBackend,)
+    filterset_class = ConsentFilters
 
     def get_queryset(self):
         self.authorize_read_encounter()


### PR DESCRIPTION
## Proposed Changes

- Added encounter filter in ConsentViewSet

### Associated Issue
- There was no  filter for consent based on encounter , so while switching between encounters the consent was not listing based on encounters

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to filter consent records by encounter external ID in the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->