### PR TITLE
Refactor content disposition handling in S3FilesManager for inline formats

### DIFF
--- a/care/emr/tests/test_file_upload_api.py
+++ b/care/emr/tests/test_file_upload_api.py
@@ -117,7 +117,7 @@ class FileUploadTestCase(CareAPITestBase):
         # NOTE: azure does not support content-disposition
         self.assertEqual(
             file_response.headers["Content-Disposition"],
-            f"attachment; filename={self.file.name}",
+            f"inline; filename={self.file.name}",
             file_response.headers,
         )
 


### PR DESCRIPTION
Enhance the content disposition logic to support inline formats for specific MIME types, improving file handling in the S3FilesManager.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Files such as images and PDFs can now be viewed directly in the browser instead of always being downloaded.
* **Improvements**
  * Enhanced file handling to display supported file types inline for a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->