### PR TITLE
Fix token booking serialization when booked by is null

### DIFF
--- a/care/emr/resources/scheduling/slot/spec.py
+++ b/care/emr/resources/scheduling/slot/spec.py
@@ -107,6 +107,7 @@ class TokenBookingReadSpec(TokenBookingBaseSpec):
             FacilityBareMinimumSpec, id=obj.token_slot.resource.facility_id
         )
         mapping["tags"] = SingleFacilityTagManager().render_tags(obj)
-        mapping["booked_by"] = model_from_cache(UserSpec, id=obj.booked_by_id)
+        if obj.booked_by_id:
+            mapping["booked_by"] = model_from_cache(UserSpec, id=obj.booked_by_id)
 
         cls.serialize_audit_users(mapping, obj)


### PR DESCRIPTION
## Proposed Changes

- Fix token booking serialization when booked by is null

### Associated Issue

- From #3154 

## Merge Checklist

- [ ] Tests added/fixed
- [x] Linting Complete

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when displaying booking information by ensuring user details are only fetched when available, preventing potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->