### PR TITLE
fix discharge summary bug in dischage summary advice

### DIFF
--- a/care/emr/reports/discharge_summary.py
+++ b/care/emr/reports/discharge_summary.py
@@ -1,3 +1,4 @@
+import html
 import logging
 import subprocess
 import tempfile
@@ -159,8 +160,11 @@ def compile_typ(output_file, data):
         with tempfile.TemporaryDirectory() as tmpdir:
             template = Path(tmpdir) / "template.typ"
             template.write_text(
-                render_to_string(
-                    "reports/patient_discharge_summary_pdf_template.typ", context=data
+                html.unescape(
+                    render_to_string(
+                        "reports/patient_discharge_summary_pdf_template.typ",
+                        context=data,
+                    )
                 )
             )
 

--- a/care/templates/reports/patient_discharge_summary_pdf_template.typ
+++ b/care/templates/reports/patient_discharge_summary_pdf_template.typ
@@ -220,7 +220,6 @@
 #line(length: 100%, stroke: mygray)
 #text("")
 {% if discharge_summary_advice %}
-
     = Discharge Summary Advice
-    {{ discharge_summary_advice }}
+    #text("{{ discharge_summary_advice }}")
 {% endif %}


### PR DESCRIPTION
## Proposed Changes

- Fixed bug cause while parsing content when displaying dischage summary advice

### Associated Issue

- slack chat


_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of HTML entities in discharge summary reports to ensure correct display of content.

* **Style**
  * Updated the discharge summary PDF template to remove unnecessary blank lines and temporarily disable the display of discharge summary advice content, while keeping the section header visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->