### PR TITLE
refact:slug validation for tag config

### DIFF
--- a/care/emr/api/viewsets/tag_config.py
+++ b/care/emr/api/viewsets/tag_config.py
@@ -1,6 +1,6 @@
 from django.shortcuts import get_object_or_404
 from django_filters import rest_framework as filters
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.filters import OrderingFilter
 
 from care.emr.api.viewsets.base import (
@@ -54,6 +54,24 @@ class TagConfigViewSet(
     filterset_class = TagConfigFilters
     filter_backends = [filters.DjangoFilterBackend, OrderingFilter]
     ordering_fields = ["priority", "created_date", "modified_date"]
+
+    def validate_data(self, instance, model_obj=None):
+        filters = {"slug": instance.slug}
+        if model_obj:
+            if model_obj.organization:
+                filters["organization"] = model_obj.organization
+            elif model_obj.facility:
+                filters["facility"] = model_obj.facility
+            queryset = TagConfig.objects.filter(**filters).exclude(id=model_obj.id)
+        else:
+            if instance.organization:
+                filters["organization__external_id"] = instance.organization
+            elif instance.facility:
+                filters["facility__external_id"] = instance.facility
+            queryset = TagConfig.objects.filter(**filters)
+        if queryset.exists():
+            raise ValidationError("Slug must be unique")
+        return super().validate_data(instance, model_obj)
 
     def authorize_retrieve(self, model_instance):
         if model_instance.facility and not AuthorizationController.call(

--- a/care/emr/resources/tag/config_spec.py
+++ b/care/emr/resources/tag/config_spec.py
@@ -98,13 +98,6 @@ class TagConfigWriteSpec(TagConfigBaseSpec):
             if not config.exists():
                 err = "Parent tag config not found"
                 raise ValueError(err)
-        # Validate slug uniqueness
-        configs = TagConfig.objects.filter(slug=self.slug)
-        if facility:
-            configs = configs.filter(facility=facility)
-        if configs.exists():
-            err = "Slug must be unique"
-            raise ValidationError(err)
         return self
 
     @model_validator(mode="after")


### PR DESCRIPTION
## Proposed Changes

- moved slug validation to validate_data.

### Associated Issue

- https://github.com/ohcnetwork/roadmap/issues/126

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to ensure the "slug" field is unique within an organization or facility when creating or updating tag configurations.
  * Removed redundant slug uniqueness check from resource validation to streamline the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->