### PR TITLE
fix:added item save before orm filtering

### DIFF
--- a/care/emr/resources/inventory/inventory_item/sync_inventory_item.py
+++ b/care/emr/resources/inventory/inventory_item/sync_inventory_item.py
@@ -36,6 +36,7 @@ def sync_inventory_item(location, product):
                 location=location,
                 net_content=0,
             )
+            inventory_item.save()
 
         delivery_requests_incoming = SupplyDelivery.objects.filter(
             destination=current_location,


### PR DESCRIPTION
### Associated Issue

- https://coronasafe-network.sentry.io/issues/6788897772/?project=5182842&query=is%3Aunresolved&referrer=issue-stream

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured new inventory items are saved immediately after creation, improving data consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->