### PR TITLE
init nix for CARE (flake + devshell + docs + setup)

### DIFF
--- a/docs/nix-development.md
+++ b/docs/nix-development.md
@@ -1,0 +1,373 @@
+# Nix Development Environment for Care
+
+This document describes how to set up and use the Nix-based development environment for the Care healthcare management system.
+
+## Prerequisites
+
+1. **Install Nix**: Follow the installation instructions at [nixos.org](https://nixos.org/download.html) or use the Determinate Systems installer:
+   ```bash
+   curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+   ```
+
+2. **Enable Flakes**: Nix flakes should be enabled automatically with modern installers. If not, add to `~/.config/nix/nix.conf`:
+   ```
+   experimental-features = nix-command flakes
+   ```
+
+3. **Optional - Install direnv**: For automatic environment activation:
+   ```bash
+   # On macOS with Homebrew
+   brew install direnv
+   
+   # On Linux (varies by distribution)
+   sudo apt install direnv  # Ubuntu/Debian
+   sudo dnf install direnv  # Fedora
+   ```
+
+## Quick Setup
+
+For first-time setup, run the automated setup script:
+
+```bash
+./scripts/nix-dev-setup.sh
+```
+
+This script will:
+- Verify Nix installation
+- Set up the development environment
+- Install all Python dependencies
+- Start required services (PostgreSQL, Redis, MinIO)
+- Run database migrations
+- Optionally load sample data
+
+## Manual Setup
+
+If you prefer manual setup or need to troubleshoot:
+
+### 1. Enter Development Shell
+
+```bash
+nix develop
+```
+
+This will:
+- Install all required system packages
+- Set up environment variables
+- Make development commands available
+- Show a helpful welcome message
+
+### 2. Install Python Dependencies
+
+```bash
+setup-dev
+```
+
+### 3. Start Services
+
+```bash
+start-services
+```
+
+This starts:
+- PostgreSQL on port 5432
+- Redis on port 6379  
+- MinIO on port 9000 (console on 9001)
+
+### 4. Set Up Database
+
+```bash
+migrate
+load-fixtures  # Optional: load sample data
+```
+
+### 5. Start Complete Development Environment
+
+#### Option A: Unified Start (Recommended)
+```bash
+rundev
+```
+
+This single command starts both the Django server and Celery worker together with proper migrations and setup.
+
+#### Option B: Separate Services
+```bash
+# Terminal 1: Django server
+runserver
+
+# Terminal 2: Celery worker  
+nix develop --command celery
+```
+
+The Django server will be available at http://localhost:9000
+
+## Available Commands
+
+Once in the development shell (`nix develop`), you have access to these commands:
+
+### Service Management
+- `start-services` - Start PostgreSQL, Redis, and MinIO
+- `stop-services` - Stop background services only
+- `kill-care` - **🛑 Stop ALL development processes and services**
+- `healthcheck` - Check application health
+
+### Development Server
+- `rundev` - **🚀 Start both API server and Celery worker (RECOMMENDED)**
+- `runserver` - Start Django development server only
+- `celery` - Start Celery worker with beat scheduler only
+
+### Database Operations
+- `migrate` - Run database migrations
+- `makemigrations [app]` - Create new migrations
+- `load-fixtures` - Load sample data
+- `dump-db` - Backup database to `care_db.dump`
+- `load-db` - Restore database from `care_db.dump`
+- `reset-db` - Drop and recreate database
+
+### Django Management
+- `manage <command>` - Run any Django management command
+- `manage shell` - Django shell
+- `manage collectstatic` - Collect static files
+
+### Testing
+- `test [path]` - Run tests (with database reuse)
+- `test-no-keep [path]` - Run tests (fresh database)
+- `test-coverage` - Run tests with coverage report
+
+### Code Quality
+- `ruff` - Check and fix staged files
+- `ruff-all` - Check all Python files
+- `ruff-fix-all` - Fix all Python files
+
+### Initial Setup
+- `setup-dev` - Install dependencies and set up environment
+
+## Environment Variables
+
+The development environment sets these variables automatically:
+
+### Database
+- `POSTGRES_USER=postgres`
+- `POSTGRES_PASSWORD=postgres`
+- `POSTGRES_HOST=localhost`
+- `POSTGRES_DB=care`
+- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/care`
+
+### Redis
+- `REDIS_URL=redis://localhost:6379`
+- `CELERY_BROKER_URL=redis://localhost:6379/0`
+
+### Django
+- `DJANGO_DEBUG=true`
+- `DJANGO_SETTINGS_MODULE=config.settings.local`
+
+### MinIO/S3
+- `BUCKET_ENDPOINT=http://localhost:9100`
+- `BUCKET_KEY=minioadmin`
+- `BUCKET_SECRET=minioadmin`
+
+## Service URLs
+
+- **Django Application**: http://localhost:9000
+- **MinIO Console**: http://localhost:9001 (admin: minioadmin/minioadmin)
+- **PostgreSQL**: localhost:5432 (postgres/postgres)
+- **Redis**: localhost:6379
+
+## Development Workflow
+
+### Daily Development
+
+#### Quick Start (Recommended)
+
+1. **Start your session**:
+   ```bash
+   nix develop
+   start-services  # If not already running
+   ```
+
+2. **Start the complete application**:
+   ```bash
+   rundev  # Starts both Django server and Celery worker together
+   ```
+
+#### Manual Start (Advanced)
+
+1. **Start your session**:
+   ```bash
+   nix develop
+   start-services  # If not already running
+   ```
+
+2. **Start services separately**:
+   ```bash
+   # Terminal 1: Django server
+   runserver
+   
+   # Terminal 2: Celery worker
+   nix develop --command celery
+   ```
+
+3. **Make changes and test**:
+   ```bash
+   ruff-all          # Check code style
+   test              # Run tests
+   manage shell      # Interactive Django shell
+   ```
+
+4. **Stop when done**:
+   ```bash
+   kill-care         # Stop all development processes
+   ```
+
+### Working with Database
+
+```bash
+# Create and apply migrations
+makemigrations
+migrate
+
+# Reset database if needed
+stop-services
+reset-db
+start-services
+migrate
+load-fixtures
+```
+
+### Debugging
+
+#### Enable Django Debug Mode
+Set `ATTACH_DEBUGGER=true` and use `runserver` to start with debugpy on port 9876.
+
+#### Check Services
+```bash
+# Check if services are running
+ps aux | grep -E 'postgres|redis|minio'
+
+# View service logs
+journalctl --user -f  # On systemd systems
+```
+
+#### Database Connection Issues
+```bash
+# Check PostgreSQL status
+pg_ctl status -D ~/.local/share/postgres
+
+# Restart PostgreSQL
+stop-services
+start-services
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"Permission denied" errors**:
+   ```bash
+   # Ensure directories are writable
+   mkdir -p ~/.local/bin ~/.local/share/postgres ~/.local/share/minio
+   ```
+
+2. **Services won't start**:
+   ```bash
+   # Stop any conflicting processes
+   stop-services
+   # Check for processes using ports
+   lsof -i :5432  # PostgreSQL
+   lsof -i :6379  # Redis
+   lsof -i :9000  # MinIO
+   ```
+
+3. **Python dependencies issues**:
+   ```bash
+   # Stop everything first
+   kill-care
+   # Reinstall in clean environment
+   rm -rf .venv
+   setup-dev
+   ```
+
+4. **Database connection refused**:
+   ```bash
+   # Wait for PostgreSQL to fully start
+   sleep 5
+   # Or check if initialization is complete
+   pg_ctl status -D ~/.local/share/postgres
+   ```
+
+### Clean Reset
+
+If you encounter persistent issues:
+
+```bash
+# Stop all processes and services
+kill-care
+
+# Clean up data directories
+rm -rf ~/.local/share/postgres ~/.local/share/minio
+
+# Exit and re-enter development shell
+exit
+nix develop
+
+# Restart setup
+setup-dev
+start-services
+migrate
+```
+
+## Differences from Docker Setup
+
+### Advantages of Nix
+- **Faster startup**: No container overhead
+- **Native performance**: Direct system execution
+- **Reproducible**: Same environment across different machines
+- **Integrated tooling**: All tools available in single shell
+- **Easier debugging**: Direct access to processes and files
+
+### Key Differences
+- Services run directly on host (not in containers)
+- Data stored in `~/.local/share/` instead of Docker volumes
+- Environment variables set in shell instead of env files
+- All commands available directly (no `docker compose exec`)
+
+## Integration with Existing Workflow
+
+The Nix setup coexists with Docker setup:
+- Makefile commands still work when using Docker
+- Same Python dependencies and versions
+- Same database schema and migrations
+- Compatible with existing CI/CD pipelines
+
+## Contributing
+
+When adding new dependencies:
+
+1. **Python packages**: Add to `Pipfile` and run `setup-dev`
+2. **System packages**: Add to `flake.nix` buildInputs
+3. **Services**: Update service management scripts in `flake.nix`
+4. **Environment variables**: Add to envVars in `flake.nix`
+
+## Performance Tips
+
+1. **Use direnv**: Automatically enter/exit development shell:
+   ```bash
+   echo "use flake" > .envrc
+   direnv allow
+   ```
+
+2. **Keep services running**: Services persist between shell sessions
+
+3. **Use test database reuse**: Default `test` command reuses database for speed
+
+4. **Parallel testing**: Tests run in parallel by default
+
+5. **Clean shutdown**: Use `kill-care` command to properly stop all processes
+
+## Security Notes
+
+- Services bind to localhost only (not accessible externally)
+- Default credentials are for development only
+- MinIO uses development keys (minioadmin/minioadmin)
+- Database has no password (local development only)
+
+For production deployment, use the Docker setup with proper security configurations.

--- a/docs/nix-development.md
+++ b/docs/nix-development.md
@@ -1,6 +1,6 @@
-# Nix Development Environment for Care
+# Nix Development Environment for CARE 
 
-This document describes how to set up and use the Nix-based development environment for the Care healthcare management system.
+This document describes how to set up and use the Nix-based development environment for the CARE
 
 ## Prerequisites
 
@@ -8,6 +8,8 @@ This document describes how to set up and use the Nix-based development environm
    ```bash
    curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
    ```
+
+   > **Note**: The Determinate Systems installer is preferred as it provides a cleaner installation process and hassle-free uninstallation from user machines.
 
 2. **Enable Flakes**: Nix flakes should be enabled automatically with modern installers. If not, add to `~/.config/nix/nix.conf`:
    ```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,176 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "poetry2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1729742964,
+        "narHash": "sha256-B4mzTcQ0FZHdpeWcpDYPERtyjJd/NIuaQ9+BV1h+MpA=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "e04df33f62cdcf93d73e9a04142464753a16db67",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1755027561,
+        "narHash": "sha256-IVft239Bc8p8Dtvf7UAACMG5P3ZV+3/aO28gXpGtMXI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "005433b926e16227259a1843015b5b2b7f7d1fc3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "poetry2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nix-github-actions": "nix-github-actions",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems_3",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1743690424,
+        "narHash": "sha256-cX98bUuKuihOaRp8dNV1Mq7u6/CQZWTPth2IJPATBXc=",
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "rev": "ce2369db77f45688172384bbeb962bc6c2ea6f94",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "poetry2nix": "poetry2nix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "poetry2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1730120726,
+        "narHash": "sha256-LqHYIxMrl/1p3/kvm2ir925tZ8DkI0KA10djk8wecSk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "9ef337e492a5555d8e17a51c911ff1f02635be15",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -18,45 +18,6 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "nix-github-actions": {
-      "inputs": {
-        "nixpkgs": [
-          "poetry2nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1729742964,
-        "narHash": "sha256-B4mzTcQ0FZHdpeWcpDYPERtyjJd/NIuaQ9+BV1h+MpA=",
-        "owner": "nix-community",
-        "repo": "nix-github-actions",
-        "rev": "e04df33f62cdcf93d73e9a04142464753a16db67",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nix-github-actions",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1755027561,
@@ -73,35 +34,10 @@
         "type": "github"
       }
     },
-    "poetry2nix": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nix-github-actions": "nix-github-actions",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "systems": "systems_3",
-        "treefmt-nix": "treefmt-nix"
-      },
-      "locked": {
-        "lastModified": 1743690424,
-        "narHash": "sha256-cX98bUuKuihOaRp8dNV1Mq7u6/CQZWTPth2IJPATBXc=",
-        "owner": "nix-community",
-        "repo": "poetry2nix",
-        "rev": "ce2369db77f45688172384bbeb962bc6c2ea6f94",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "poetry2nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "poetry2nix": "poetry2nix"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {
@@ -116,57 +52,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_3": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "poetry2nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1730120726,
-        "narHash": "sha256-LqHYIxMrl/1p3/kvm2ir925tZ8DkI0KA10djk8wecSk=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "9ef337e492a5555d8e17a51c911ff1f02635be15",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,517 @@
+{
+  description = "Care - Django healthcare management system development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    poetry2nix = {
+      url = "github:nix-community/poetry2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, poetry2nix }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        python = pkgs.python313;
+
+        # Create a Python environment with pip-installable packages
+        pythonEnv = python.withPackages (ps: with ps; [
+          pip
+          setuptools
+          wheel
+          virtualenv
+        ]);
+
+        # Environment variables for development
+        envVars = {
+          # Database
+          POSTGRES_USER = "postgres";
+          POSTGRES_PASSWORD = "postgres";
+          POSTGRES_HOST = "localhost";
+          POSTGRES_DB = "care";
+          POSTGRES_PORT = "5432";
+          DATABASE_URL = "postgres://postgres:postgres@localhost:5432/care";
+
+          # Redis
+          REDIS_URL = "redis://localhost:6379";
+          CELERY_BROKER_URL = "redis://localhost:6379/0";
+
+          # Django
+          DJANGO_DEBUG = "true";
+          ATTACH_DEBUGGER = "false";
+          DJANGO_SETTINGS_MODULE = "config.settings.local";
+
+          # MinIO/S3
+          BUCKET_REGION = "ap-south-1";
+          BUCKET_KEY = "minioadmin";
+          BUCKET_SECRET = "minioadmin";
+          BUCKET_ENDPOINT = "http://localhost:9100";
+          BUCKET_EXTERNAL_ENDPOINT = "http://localhost:9100";
+          FILE_UPLOAD_BUCKET = "patient-bucket";
+          FACILITY_S3_BUCKET = "facility-bucket";
+
+          # HCX Config (for local testing)
+          HCX_AUTH_BASE_PATH = "https://staging-hcx.swasth.app/auth/realms/swasth-health-claim-exchange/protocol/openid-connect/token";
+          HCX_ENCRYPTION_PRIVATE_KEY_URL = "https://raw.githubusercontent.com/Swasth-Digital-Health-Foundation/hcx-platform/main/demo-app/server/resources/keys/x509-private-key.pem";
+          HCX_IG_URL = "https://ig.hcxprotocol.io/v0.7.1";
+          HCX_PARTICIPANT_CODE = "qwertyreboot.gmail@swasth-hcx-staging";
+          HCX_PASSWORD = "Opensaber@123";
+          HCX_PROTOCOL_BASE_PATH = "http://staging-hcx.swasth.app/api/v0.7";
+          HCX_USERNAME = "qwertyreboot@gmail.com";
+          HCX_CERT_URL = "https://raw.githubusercontent.com/Swasth-Digital-Health-Foundation/hcx-platform/main/demo-app/server/resources/keys/x509-self-signed-certificate.pem";
+
+          # Typst
+          TYPST_VERSION = "0.12.0";
+
+          # PostgreSQL configuration for compilation
+          PG_CONFIG = "${pkgs.postgresql_15}/bin/pg_config";
+          LDFLAGS = "-L${pkgs.postgresql_15}/lib";
+          CPPFLAGS = "-I${pkgs.postgresql_15}/include";
+        };
+
+        # Helper scripts
+        makeScript = name: text: pkgs.writeShellScriptBin name ''
+          set -euo pipefail
+          ${text}
+        '';
+
+        # Install Typst
+        typstInstaller = makeScript "install-typst" ''
+          if ! command -v typst >/dev/null 2>&1; then
+            echo "Installing Typst v${envVars.TYPST_VERSION}..."
+            TYPST_INSTALL_DIR="$HOME/.local/bin" TYPST_VERSION="${envVars.TYPST_VERSION}" ./scripts/install_typst.sh
+            export PATH="$HOME/.local/bin:$PATH"
+          else
+            echo "Typst already installed"
+          fi
+        '';
+
+        # Service management scripts
+        startServices = makeScript "start-services" ''
+          echo "Starting PostgreSQL..."
+          if ! pgrep -x "postgres" > /dev/null; then
+            mkdir -p ~/.local/share/postgres/sockets
+            initdb -D ~/.local/share/postgres -U postgres --auth=trust || true
+
+            # Configure socket directory
+            echo "unix_socket_directories = '$HOME/.local/share/postgres/sockets'" >> ~/.local/share/postgres/postgresql.conf
+
+            pg_ctl -D ~/.local/share/postgres -l ~/.local/share/postgres/logfile start
+            sleep 2
+            createdb -U postgres care || echo "Database 'care' already exists"
+          else
+            echo "PostgreSQL already running"
+          fi
+
+          echo "Starting Redis..."
+          if ! pgrep -x "redis-server" > /dev/null; then
+            redis-server --daemonize yes --bind 127.0.0.1 --port 6379
+          else
+            echo "Redis already running"
+          fi
+
+          echo "Starting MinIO..."
+          if ! pgrep -x "minio" > /dev/null; then
+            mkdir -p ~/.local/share/minio
+            MINIO_ROOT_USER="${envVars.BUCKET_KEY}" MINIO_ROOT_PASSWORD="${envVars.BUCKET_SECRET}" \
+            minio server ~/.local/share/minio --address ":9100" --console-address ":9001" &
+            sleep 3
+          else
+            echo "MinIO already running"
+          fi
+
+          echo "All services started!"
+        '';
+
+        stopServices = makeScript "stop-services" ''
+          echo "Stopping services..."
+          pkill postgres || true
+          pkill redis-server || true
+          pkill minio || true
+          echo "Services stopped"
+        '';
+
+        # Kill all development processes
+        killAll = makeScript "kill-care" ''
+          echo "🛑 Stopping all Care development processes..."
+
+          # Stop Django development server
+          echo "Stopping Django development server..."
+          pkill -f "runserver_plus" || true
+          pkill -f "manage.py runserver" || true
+          pkill -f "python.*manage.py" || true
+
+          # Stop Celery workers and beat
+          echo "Stopping Celery workers..."
+          pkill -f "celery.*worker" || true
+          pkill -f "celery.*beat" || true
+          pkill -f "watchmedo.*celery" || true
+
+          # Stop debugpy if running
+          echo "Stopping debugger..."
+          pkill -f "debugpy" || true
+
+          # Stop background services
+          echo "Stopping background services..."
+          pkill postgres || true
+          pkill redis-server || true
+          pkill minio || true
+
+          # Clean up any remaining Python processes that might be related
+          echo "Cleaning up remaining processes..."
+          pkill -f "python.*config.celery_app" || true
+
+          # Wait a moment for processes to terminate
+          sleep 2
+
+          # Force kill any stubborn processes
+          echo "Force killing stubborn processes..."
+          pkill -9 -f "runserver_plus" 2>/dev/null || true
+          pkill -9 -f "celery.*worker" 2>/dev/null || true
+          pkill -9 -f "celery.*beat" 2>/dev/null || true
+
+          echo "✅ All development processes stopped"
+          echo ""
+          echo "To restart:"
+          echo "  start-services  # Start background services"
+          echo "  rundev          # Start unified development environment"
+        '';
+
+        # Development setup
+        setupDev = makeScript "setup-dev" ''
+          echo "Setting up development environment..."
+
+          # Install Python dependencies
+          if [ ! -d ".venv" ]; then
+            echo "Creating virtual environment..."
+            python -m venv .venv
+          fi
+
+          source .venv/bin/activate
+
+          echo "Installing Python dependencies..."
+          pip install --upgrade pip pipenv
+          pipenv install --dev --system
+
+          # Install plugins
+          python install_plugins.py
+
+          # Install Typst
+          ${typstInstaller}/bin/install-typst
+
+          echo "Development environment setup complete!"
+        '';
+
+        # Django management commands
+        djangoManage = makeScript "manage" ''
+          source .venv/bin/activate 2>/dev/null || true
+          python manage.py "$@"
+        '';
+
+        # Database operations
+        migrateDb = makeScript "migrate" ''
+          source .venv/bin/activate
+          python manage.py migrate
+        '';
+
+        makeMigrations = makeScript "makemigrations" ''
+          source .venv/bin/activate
+          python manage.py makemigrations "$@"
+        '';
+
+        loadFixtures = makeScript "load-fixtures" ''
+          source .venv/bin/activate
+          python manage.py load_fixtures
+        '';
+
+        # Unified development server (API + Celery)
+        runDev = makeScript "rundev" ''
+          source .venv/bin/activate
+
+          echo "🚀 Starting unified Care development environment..."
+
+          # Wait for services
+          ./scripts/wait_for_db.sh
+          ./scripts/wait_for_redis.sh
+
+          # Run migrations and setup (from celery scripts)
+          echo "📊 Running database migrations..."
+          python manage.py migrate --noinput
+          python manage.py compilemessages -v 0
+          python manage.py sync_permissions_roles
+          python manage.py sync_valueset
+
+          # Collect static files (from start script)
+          echo "📦 Collecting static files..."
+          python manage.py collectstatic --noinput
+
+          echo "✅ Setup complete! Starting services..."
+
+          # Start Celery worker and beat in background
+          echo "🔄 Starting Celery worker with beat scheduler..."
+          watchmedo auto-restart --directory=./ --pattern=*.py --recursive -- \
+            celery --workdir="$(pwd)" -A config.celery_app worker -B --loglevel=INFO &
+
+          CELERY_PID=$!
+
+          # Cleanup function
+          cleanup() {
+            echo "🛑 Shutting down services..."
+            kill $CELERY_PID 2>/dev/null || true
+            exit 0
+          }
+
+          trap cleanup SIGINT SIGTERM
+
+          # Wait a moment for Celery to start
+          sleep 3
+
+          # Start Django development server
+          echo "🌐 Starting Django development server on http://localhost:9000..."
+          if [[ "''${ATTACH_DEBUGGER:-false}" == "true" ]]; then
+            echo "🐛 Debug mode enabled - waiting for debugger on port 9876..."
+            python -m debugpy --wait-for-client --listen 0.0.0.0:9876 manage.py runserver_plus 0.0.0.0:9000 --print-sql
+          else
+            python manage.py runserver_plus 0.0.0.0:9000 --print-sql
+          fi
+        '';
+
+        # Individual development server (API only)
+        runServer = makeScript "runserver" ''
+          source .venv/bin/activate
+          ./scripts/wait_for_db.sh
+          ./scripts/wait_for_redis.sh
+
+          echo "📊 Running migrations..."
+          python manage.py migrate --noinput
+          python manage.py compilemessages -v 0
+          python manage.py sync_permissions_roles
+          python manage.py sync_valueset
+
+          echo "📦 Collecting static files..."
+          python manage.py collectstatic --noinput
+
+          echo "🌐 Starting Django development server..."
+          if [[ "''${ATTACH_DEBUGGER:-false}" == "true" ]]; then
+            echo "🐛 Debug mode enabled - waiting for debugger on port 9876..."
+            python -m debugpy --wait-for-client --listen 0.0.0.0:9876 manage.py runserver_plus 0.0.0.0:9000 --print-sql
+          else
+            python manage.py runserver_plus 0.0.0.0:9000 --print-sql
+          fi
+        '';
+
+        # Individual Celery worker
+        runCelery = makeScript "celery" ''
+          source .venv/bin/activate
+          ./scripts/wait_for_db.sh
+          ./scripts/wait_for_redis.sh
+
+          echo "📊 Running migrations..."
+          python manage.py migrate --noinput
+          python manage.py compilemessages -v 0
+          python manage.py sync_permissions_roles
+          python manage.py sync_valueset
+
+          echo "🔄 Starting Celery worker with beat scheduler..."
+          watchmedo auto-restart --directory=./ --pattern=*.py --recursive -- \
+            celery --workdir="$(pwd)" -A config.celery_app worker -B --loglevel=INFO
+        '';
+
+        # Testing
+        runTests = makeScript "test" ''
+          source .venv/bin/activate
+          python manage.py test "''${@:-}" --settings=config.settings.test --keepdb --parallel --shuffle
+        '';
+
+        runTestsNoKeep = makeScript "test-no-keep" ''
+          source .venv/bin/activate
+          python manage.py test "''${@:-}" --settings=config.settings.test --parallel --shuffle
+        '';
+
+        testCoverage = makeScript "test-coverage" ''
+          source .venv/bin/activate
+          coverage run manage.py test --settings=config.settings.test --keepdb --parallel --shuffle
+          coverage combine || true
+          coverage xml
+          coverage report
+        '';
+
+        # Code quality
+        ruffCheck = makeScript "ruff" ''
+          source .venv/bin/activate
+          ruff check --fix $(git diff --name-only --staged | grep -E '\.py$|/pyproject\.toml$' || echo ".")
+        '';
+
+        ruffAll = makeScript "ruff-all" ''
+          source .venv/bin/activate
+          ruff check .
+        '';
+
+        ruffFix = makeScript "ruff-fix-all" ''
+          source .venv/bin/activate
+          ruff check --fix .
+        '';
+
+        # Database backup/restore
+        dumpDb = makeScript "dump-db" ''
+          pg_dump -U postgres -Fc care > care_db.dump
+          echo "Database dumped to care_db.dump"
+        '';
+
+        loadDb = makeScript "load-db" ''
+          if [ -f "care_db.dump" ]; then
+            pg_restore -U postgres --clean --if-exists -d care care_db.dump
+            echo "Database restored from care_db.dump"
+          else
+            echo "care_db.dump not found"
+            exit 1
+          fi
+        '';
+
+        resetDb = makeScript "reset-db" ''
+          dropdb -U postgres care -f || true
+          createdb -U postgres care
+          echo "Database reset"
+        '';
+
+        # Health check
+        healthCheck = makeScript "healthcheck" ''
+          source .venv/bin/activate
+          ./scripts/healthcheck.sh
+        '';
+
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            # Python and package management
+            pythonEnv
+
+            # Databases and services
+            postgresql_15  # PostgreSQL server and client
+            libpq  # PostgreSQL client library
+            libpq.pg_config  # pg_config tool for psycopg compilation
+            redis
+            minio
+
+            # System dependencies for building Python packages
+            pkg-config
+            zlib
+            libjpeg
+            gmp
+            gettext
+            curl
+            wget
+            git
+
+            # Development tools
+            pre-commit
+
+            # Build tools
+            gcc
+            gnumake
+
+            # Development scripts
+            setupDev
+            startServices
+            stopServices
+            killAll
+            djangoManage
+            migrateDb
+            makeMigrations
+            loadFixtures
+            runDev
+            runServer
+            runCelery
+            runTests
+            runTestsNoKeep
+            testCoverage
+            ruffCheck
+            ruffAll
+            ruffFix
+            dumpDb
+            loadDb
+            resetDb
+            healthCheck
+            typstInstaller
+          ];
+
+          shellHook = ''
+            # Add local binaries to PATH (Nix automatically adds buildInputs to PATH)
+            export PATH="$HOME/.local/bin:$PATH"
+
+            ${builtins.concatStringsSep "\n" (pkgs.lib.mapAttrsToList (name: value: "export ${name}='${value}'") envVars)}
+
+            # Create necessary directories
+            mkdir -p ~/.local/bin ~/.local/share/postgres ~/.local/share/postgres/sockets ~/.local/share/minio
+
+            echo "🏥 Welcome to Care development environment!"
+            echo ""
+            echo "Available commands:"
+            echo "  setup-dev          - Set up the development environment"
+            echo "  start-services     - Start PostgreSQL, Redis, and MinIO"
+            echo "  stop-services      - Stop background services only"
+            echo "  kill-care          - 🛑 Stop ALL development processes and services"
+            echo "  rundev             - 🚀 Start both API server and Celery worker (RECOMMENDED)"
+            echo "  runserver          - Start Django development server only"
+            echo "  celery             - Start Celery worker with beat only"
+            echo "  manage <cmd>       - Run Django management commands"
+            echo "  migrate            - Run database migrations"
+            echo "  makemigrations     - Create new migrations"
+            echo "  load-fixtures      - Load sample data"
+            echo "  test               - Run tests with coverage"
+            echo "  test-no-keep       - Run tests without keeping DB"
+            echo "  test-coverage      - Run tests with coverage report"
+            echo "  ruff               - Check and fix staged files"
+            echo "  ruff-all           - Check all files"
+            echo "  ruff-fix-all       - Fix all files"
+            echo "  dump-db            - Backup database"
+            echo "  load-db            - Restore database"
+            echo "  reset-db           - Reset database"
+            echo "  healthcheck        - Check application health"
+            echo ""
+            echo "🚀 Quick Start (Recommended):"
+            echo "  1. Run 'setup-dev' to install dependencies"
+            echo "  2. Run 'start-services' to start required services"
+            echo "  3. Run 'rundev' to start both API server and Celery worker"
+            echo ""
+            echo "📋 Manual Setup:"
+            echo "  1. Run 'setup-dev' to install dependencies"
+            echo "  2. Run 'start-services' to start required services"
+            echo "  3. Run 'migrate' to set up the database"
+            echo "  4. Run 'runserver' and 'celery' in separate terminals"
+            echo ""
+            echo "The Django server will be available at http://localhost:9000"
+            echo "MinIO console will be available at http://localhost:9001"
+            echo ""
+
+            # Auto-activate virtual environment if it exists
+            if [ -d ".venv" ]; then
+              source .venv/bin/activate
+              echo "✅ Virtual environment activated"
+            else
+              echo "⚠️  Run 'setup-dev' to create virtual environment and install dependencies"
+            fi
+
+            # Verify pg_config is available
+            if command -v pg_config >/dev/null 2>&1; then
+              echo "✅ PostgreSQL development tools available"
+            else
+              echo "❌ PostgreSQL development tools not found in PATH"
+            fi
+          '';
+        };
+
+        # Additional outputs for flexibility
+        packages.default = pkgs.writeShellApplication {
+          name = "care-dev";
+          runtimeInputs = [ pythonEnv ];
+          text = ''
+            echo "Care development environment package"
+            echo "Use 'nix develop' to enter the development shell"
+          '';
+        };
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,16 +1,12 @@
 {
-  description = "Care - Django healthcare management system development environment";
+  description = "CARE -  Care is a Digital Public Good enabling TeleICU & Decentralised Administration of Healthcare Capacity across States.";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    poetry2nix = {
-      url = "github:nix-community/poetry2nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
-  outputs = { self, nixpkgs, flake-utils, poetry2nix }:
+  outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};

--- a/scripts/nix-dev-setup.sh
+++ b/scripts/nix-dev-setup.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Nix Development Environment Quick Setup Script for Care
+# This script helps new developers get started quickly with the Care project using Nix
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+echo "🏥 Care Development Environment Setup"
+echo "======================================"
+
+# Check if Nix is installed
+if ! command -v nix >/dev/null 2>&1; then
+    echo "❌ Nix is not installed. Please install Nix first:"
+    echo "   curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install"
+    echo "   or visit: https://nixos.org/download.html"
+    exit 1
+fi
+
+echo "✅ Nix is installed"
+
+# Check if flakes are enabled
+if ! nix flake --help >/dev/null 2>&1; then
+    echo "⚠️  Nix flakes are not enabled. Adding experimental features..."
+    mkdir -p ~/.config/nix
+    echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
+fi
+
+echo "✅ Nix flakes are available"
+
+# Navigate to project root
+cd "$PROJECT_ROOT"
+
+echo ""
+echo "🔧 Setting up development environment..."
+
+# Enter development shell and run setup
+nix develop --command bash -c "
+    echo '📦 Installing Python dependencies...'
+    setup-dev
+
+    echo ''
+    echo '🚀 Starting services...'
+    start-services
+
+    echo ''
+    echo '🗄️  Setting up database...'
+    sleep 3  # Wait for services to fully start
+    migrate
+
+    echo ''
+    echo '📊 Loading sample data (optional)...'
+    read -p 'Load sample fixtures? (y/N): ' -n 1 -r
+    echo
+    if [[ \$REPLY =~ ^[Yy]$ ]]; then
+        load-fixtures || echo 'Failed to load fixtures - continuing anyway'
+    fi
+
+    echo ''
+    echo '✅ Setup complete!'
+    echo ''
+    echo '🎉 Your Care development environment is ready!'
+    echo ''
+    echo '🚀 Quick Start:'
+    echo '  1. Run: nix develop'
+    echo '  2. Run: rundev       (starts both Django server and Celery worker)'
+    echo ''
+    echo '📋 Alternative (Manual):'
+    echo '  1. Run: nix develop'
+    echo '  2. Run: runserver    (Django server only)'
+    echo '  3. In another terminal, run: nix develop --command celery'
+    echo ''
+    echo 'Available services:'
+    echo '  - Django server: http://localhost:9000'
+    echo '  - MinIO console: http://localhost:9001 (admin/minioadmin)'
+    echo '  - PostgreSQL: localhost:5432 (postgres/postgres)'
+    echo '  - Redis: localhost:6379'
+    echo ''
+    echo 'Useful commands:'
+    echo '  - rundev           🚀 Start both API server and Celery worker (RECOMMENDED)'
+    echo '  - runserver        Start Django development server only'
+    echo '  - celery           Start Celery worker and beat only'
+    echo '  - manage <cmd>     Run Django management commands'
+    echo '  - test             Run tests'
+    echo '  - ruff-all         Check code style'
+    echo '  - kill-care        🛑 Stop ALL development processes and services'
+    echo '  - stop-services    Stop background services only'
+    echo ''
+"
+
+echo ""
+echo "🏁 Setup script completed!"
+echo ""
+echo "To start developing:"
+echo "  nix develop"
+echo ""
+echo "If you encounter any issues:"
+echo "  - Check that all services are running: ps aux | grep -E 'postgres|redis|minio'"
+echo "  - Restart services: stop-services && start-services"
+echo "  - Reset database: reset-db && migrate"
+echo ""
+echo "Happy coding! 🚀"

--- a/scripts/nix-dev-setup.sh
+++ b/scripts/nix-dev-setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Nix Development Environment Quick Setup Script for Care
-# This script helps new developers get started quickly with the Care project using Nix
+# Nix Development Environment Quick Setup Script for CARE
+# This script helps new developers get started quickly with the CARE project using Nix
 
 set -euo pipefail
 
@@ -15,6 +15,7 @@ if ! command -v nix >/dev/null 2>&1; then
     echo "❌ Nix is not installed. Please install Nix first:"
     echo "   curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install"
     echo "   or visit: https://nixos.org/download.html"
+    echo "determinate systems nix is preffered as it offers easier installtion 1 click uninstallation support"
     exit 1
 fi
 
@@ -98,6 +99,5 @@ echo ""
 echo "If you encounter any issues:"
 echo "  - Check that all services are running: ps aux | grep -E 'postgres|redis|minio'"
 echo "  - Restart services: stop-services && start-services"
-echo "  - Reset database: reset-db && migrate"
 echo ""
-echo "Happy coding! 🚀"
+echo "Happy Developing! 🚀"


### PR DESCRIPTION
**Summary:**
Adds a reproducible Nix dev shell with Python 3.13, PostgreSQL, Redis, MinIO, and helper commands. Includes docs and a one-step setup script.

**Includes:**

* `flake.nix`, `flake.lock`
* `docs/nix-development.md`
* `scripts/nix-dev-setup.sh`

built in reference with the prod.Dockerfile and Makefiles. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide for a Nix-based development environment, including quick setup, manual steps, available commands, workflow, troubleshooting, and differences from Docker.

* **Chores**
  * Introduced a Nix flake offering a full development shell with commands to set up, run, test, and manage local services.
  * Added an automated bootstrap script that verifies prerequisites, enables Flakes, installs dependencies, starts services, runs migrations, optionally loads sample data, and provides post-setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->