### PR TITLE
refact: facility identifier check in the spec mapping

### DIFF
--- a/care/emr/resources/patient/spec.py
+++ b/care/emr/resources/patient/spec.py
@@ -274,7 +274,7 @@ class PatientRetrieveSpec(PatientListSpec, PatientPermissionsMixin):
             ]
         if kwargs.get("facility"):
             facility = kwargs.get("facility")
-            if facility:
+            if facility and obj.facility_identifiers:
                 mapping["facility_identifiers"] = [
                     {
                         "config": PatientIdentifierConfigCache.get_config(x["config"]),


### PR DESCRIPTION
### Associated Issue

- https://coronasafe-network.sentry.io/issues/6750008645/?project=5182842&query=is%3Aunresolved&referrer=issue-stream
### Architecture changes

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an occasional error when loading patient details for facilities without associated identifiers, improving reliability across facilities.
  * Prevents empty or missing facility identifier sections from appearing in patient data, resulting in cleaner, more accurate displays.
  * Enhances data serialization robustness to reduce unexpected failures during patient retrieval, ensuring patient profiles load consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->