### PR TITLE
Adds support for upsert on charge item definition and product

### DIFF
--- a/care/emr/api/viewsets/charge_item_definition.py
+++ b/care/emr/api/viewsets/charge_item_definition.py
@@ -9,6 +9,7 @@ from care.emr.api.viewsets.base import (
     EMRListMixin,
     EMRRetrieveMixin,
     EMRUpdateMixin,
+    EMRUpsertMixin,
 )
 from care.emr.models.charge_item_definition import ChargeItemDefinition
 from care.emr.resources.charge_item_definition.spec import (
@@ -25,7 +26,12 @@ class ChargeItemDefinitionFilters(filters.FilterSet):
 
 
 class ChargeItemDefinitionViewSet(
-    EMRCreateMixin, EMRRetrieveMixin, EMRUpdateMixin, EMRListMixin, EMRBaseViewSet
+    EMRCreateMixin,
+    EMRRetrieveMixin,
+    EMRUpdateMixin,
+    EMRListMixin,
+    EMRUpsertMixin,
+    EMRBaseViewSet,
 ):
     database_model = ChargeItemDefinition
     pydantic_model = ChargeItemDefinitionSpec

--- a/care/emr/api/viewsets/inventory/product.py
+++ b/care/emr/api/viewsets/inventory/product.py
@@ -9,6 +9,7 @@ from care.emr.api.viewsets.base import (
     EMRListMixin,
     EMRRetrieveMixin,
     EMRUpdateMixin,
+    EMRUpsertMixin,
 )
 from care.emr.models.product import Product
 from care.emr.resources.inventory.product.spec import ProductReadSpec, ProductWriteSpec
@@ -23,7 +24,12 @@ class ProductFilters(filters.FilterSet):
 
 
 class ProductViewSet(
-    EMRCreateMixin, EMRRetrieveMixin, EMRUpdateMixin, EMRListMixin, EMRBaseViewSet
+    EMRCreateMixin,
+    EMRRetrieveMixin,
+    EMRUpdateMixin,
+    EMRListMixin,
+    EMRUpsertMixin,
+    EMRBaseViewSet,
 ):
     database_model = Product
     pydantic_model = ProductWriteSpec


### PR DESCRIPTION
## Proposed Changes

- Adds support for upsert on charge item definition and product

### Associated Issue

- Required for bulk importing product and charge item definitions

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [x] Linting Complete

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added create-or-update (upsert) behavior for Charge Item Definitions and Products, enabling a single save action to create new records or update existing ones.
  - Streamlines workflows and reduces duplicate entries across these modules.
  - Improves consistency of save operations when records already exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->