### PR TITLE
fix: use get_queryset() in EMRUpsertMixin

### DIFF
--- a/care/emr/api/viewsets/base.py
+++ b/care/emr/api/viewsets/base.py
@@ -249,11 +249,12 @@ class EMRUpsertMixin:
         unhandled = False
         try:
             with transaction.atomic():
+                queryset = self.get_queryset()
                 for datapoint in datapoints:
                     try:
                         if "id" in datapoint:
                             instance = get_object_or_404(
-                                self.database_model, external_id=datapoint["id"]
+                                queryset, external_id=datapoint["id"]
                             )
                             result = self.handle_update(instance, datapoint)
                         else:


### PR DESCRIPTION
## Proposed Changes

- fixes https://github.com/ohcnetwork/roadmap/issues/128

changed endpoints:

- allergy_intolerance
- charge_item
- product_knowledge
- supply_delivery
- supply_request
- meta_artifacts
- medication/dispense

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Upsert operations now honor the view’s configured filters and scopes, ensuring updates apply only to records within the allowed dataset.
  * Behavior is now consistent with list/detail endpoints, preventing unintended changes to out‑of‑scope items.
  * Create-on-missing remains unchanged; updates still occur when an ID is provided.
  * Improves reliability for multi-datapoint submissions without altering request/response formats or error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->