### PR TITLE
add upsert mixins to activity, observation, specimen def

### DIFF
--- a/care/emr/api/viewsets/activity_definition.py
+++ b/care/emr/api/viewsets/activity_definition.py
@@ -10,6 +10,7 @@ from care.emr.api.viewsets.base import (
     EMRRetrieveMixin,
     EMRTagMixin,
     EMRUpdateMixin,
+    EMRUpsertMixin,
 )
 from care.emr.models import ActivityDefinition
 from care.emr.models.charge_item_definition import ChargeItemDefinition
@@ -40,6 +41,7 @@ class ActivityDefinitionViewSet(
     EMRListMixin,
     EMRTagMixin,
     EMRBaseViewSet,
+    EMRUpsertMixin,
 ):
     database_model = ActivityDefinition
     pydantic_model = ActivityDefinitionWriteSpec

--- a/care/emr/api/viewsets/observation_definition.py
+++ b/care/emr/api/viewsets/observation_definition.py
@@ -9,6 +9,7 @@ from care.emr.api.viewsets.base import (
     EMRListMixin,
     EMRRetrieveMixin,
     EMRUpdateMixin,
+    EMRUpsertMixin,
 )
 from care.emr.models.observation_definition import ObservationDefinition
 from care.emr.resources.observation_definition.spec import (
@@ -28,7 +29,12 @@ class ObservationDefinitionFilters(filters.FilterSet):
 
 
 class ObservationDefinitionViewSet(
-    EMRCreateMixin, EMRRetrieveMixin, EMRUpdateMixin, EMRListMixin, EMRBaseViewSet
+    EMRCreateMixin,
+    EMRRetrieveMixin,
+    EMRUpdateMixin,
+    EMRListMixin,
+    EMRBaseViewSet,
+    EMRUpsertMixin,
 ):
     database_model = ObservationDefinition
     pydantic_model = ObservationDefinitionCreateSpec

--- a/care/emr/api/viewsets/specimen_definition.py
+++ b/care/emr/api/viewsets/specimen_definition.py
@@ -9,6 +9,7 @@ from care.emr.api.viewsets.base import (
     EMRListMixin,
     EMRRetrieveMixin,
     EMRUpdateMixin,
+    EMRUpsertMixin,
 )
 from care.emr.models.specimen_definition import SpecimenDefinition
 from care.emr.resources.specimen_definition.spec import (
@@ -25,7 +26,12 @@ class SpecimenDefinitionFilters(filters.FilterSet):
 
 
 class SpecimenDefinitionViewSet(
-    EMRCreateMixin, EMRRetrieveMixin, EMRUpdateMixin, EMRListMixin, EMRBaseViewSet
+    EMRCreateMixin,
+    EMRRetrieveMixin,
+    EMRUpdateMixin,
+    EMRListMixin,
+    EMRBaseViewSet,
+    EMRUpsertMixin,
 ):
     database_model = SpecimenDefinition
     pydantic_model = BaseSpecimenDefinitionSpec

--- a/care/emr/resources/common/monetary_component.py
+++ b/care/emr/resources/common/monetary_component.py
@@ -23,7 +23,7 @@ class MonetaryComponent(BaseModel):
     def base_no_factor(self):
         if (
             self.monetary_component_type == MonetaryComponentType.base.value
-            and not self.amount
+            and self.amount is None
         ):
             raise ValueError("Base component must have an amount.")
         return self


### PR DESCRIPTION
## Proposed Changes

- Added mixins to activity, observation and specimen definitions
- Also switched to is None check (to allow for importing 0 as base amount for charge items).

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added create-or-update (upsert) support to Activity, Observation, and Specimen Definition APIs, enabling seamless idempotent updates via a single request.

- Bug Fixes
  - Corrected monetary validation to accept zero (0) amounts as valid for base components, preventing erroneous “missing amount” errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->