### PR TITLE
using enum choice in resource request

### DIFF
--- a/care/emr/resources/resource_request/spec.py
+++ b/care/emr/resources/resource_request/spec.py
@@ -50,8 +50,8 @@ class ResourceRequestBaseSpec(EMRResource):
     reason: str
     referring_facility_contact_name: str
     referring_facility_contact_number: str
-    status: str
-    category: str
+    status: StatusChoices
+    category: CategoryChoices
     priority: int
 
 

--- a/care/emr/resources/resource_request/spec.py
+++ b/care/emr/resources/resource_request/spec.py
@@ -103,6 +103,8 @@ class ResourceRequestCreateSpec(ResourceRequestBaseSpec):
 class ResourceRequestListSpec(ResourceRequestBaseSpec):
     origin_facility: dict
     assigned_facility: dict | None = None
+    created_date: datetime.datetime
+    modified_date: datetime.datetime
 
     @classmethod
     def perform_extra_serialization(cls, mapping, obj):


### PR DESCRIPTION
## Proposed Changes

- staus and category were not using the defined enums choice , so updated specs to use them

### Associated Issue

- Link to issue here, explain how the proposed solution will solve the reported issue/ feature request.

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Standardized status and category to predefined choices for consistent validation and clearer error messages.
  - Improves reliability of filtering, sorting, and reporting that rely on these fields.

- **New Features**
  - List and detail views now include created and modified timestamps for resource requests, making record timelines visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->