### PR TITLE
Add location in dispense read spec

### DIFF
--- a/care/emr/resources/medication/dispense/spec.py
+++ b/care/emr/resources/medication/dispense/spec.py
@@ -13,6 +13,7 @@ from care.emr.resources.base import EMRResource
 from care.emr.resources.charge_item.spec import ChargeItemReadSpec
 from care.emr.resources.inventory.inventory_item.spec import InventoryItemReadSpec
 from care.emr.resources.medication.request.spec import DosageInstruction
+from care.emr.resources.location.spec import FacilityLocationListSpec
 
 
 class MedicationDispenseStatus(str, Enum):
@@ -138,6 +139,7 @@ class MedicationDispenseReadSpec(BaseMedicationDispenseSpec):
     charge_item: dict | None = None
     created_date: datetime
     modified_date: datetime
+    location: dict
 
     @classmethod
     def perform_extra_serialization(cls, mapping, obj):
@@ -147,3 +149,4 @@ class MedicationDispenseReadSpec(BaseMedicationDispenseSpec):
             mapping["charge_item"] = ChargeItemReadSpec.serialize(
                 obj.charge_item
             ).to_json()
+        mapping["location"] = FacilityLocationListSpec.serialize(obj.location).to_json()

--- a/care/emr/resources/medication/dispense/spec.py
+++ b/care/emr/resources/medication/dispense/spec.py
@@ -12,8 +12,8 @@ from care.emr.models.medication_request import MedicationRequest
 from care.emr.resources.base import EMRResource
 from care.emr.resources.charge_item.spec import ChargeItemReadSpec
 from care.emr.resources.inventory.inventory_item.spec import InventoryItemReadSpec
-from care.emr.resources.medication.request.spec import DosageInstruction
 from care.emr.resources.location.spec import FacilityLocationListSpec
+from care.emr.resources.medication.request.spec import DosageInstruction
 
 
 class MedicationDispenseStatus(str, Enum):


### PR DESCRIPTION
### Associated Issue

- Link to issue here, explain how the proposed solution will solve the reported issue/ feature request.

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Medication Dispense views and API responses now include dispensing location information, shown alongside existing details for clearer context.
  * Location appears automatically wherever Medication Dispense data is displayed or exported, improving traceability for clinical and operational workflows.
  * Enhances clarity about where a dispense occurred for audits, reporting, and care coordination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->