### PR TITLE
Add configuration for testing integration in vscode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+MANAGE_PY_PATH=manage.py
+
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_HOST=db

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
   "configurations": [
     {
       "name": "Docker: Django",
-      "type": "python",
+      "type": "debugpy",
       "request": "attach",
       "pathMappings": [
         {
@@ -14,12 +14,14 @@
           "remoteRoot": "/app"
         }
       ],
-      "port": 9876,
-      "host": "127.0.0.1",
+      "connect": {
+        "port": 9876,
+        "host": "127.0.0.1",
+      },
     },
     {
       "name": "Python: Django",
-      "type": "python",
+      "type": "debugpy",
       "request": "launch",
       "program": "${workspaceFolder}/manage.py",
       "args": [
@@ -27,54 +29,43 @@
         "9000",
         "--print-sql"
       ],
-      "env": {
-        "DATABASE_URL": "postgres://postgres:postgres@localhost:5433/care"
-      },
+      "envFile": "${workspaceFolder}/.env",
       "django": true,
       "justMyCode": false
     },
     {
       "name": "Python: Django Make Migrations",
-      "type": "python",
+      "type": "debugpy",
       "request": "launch",
       "program": "${workspaceFolder}/manage.py",
       "args": [
         "makemigrations"
       ],
-      "env": {
-        "DATABASE_URL": "postgres://postgres:postgres@localhost:5433/care"
-      },
+      "envFile": "${workspaceFolder}/.env",
       "django": true,
       "justMyCode": false
     },
     {
       "name": "Python: Django Migrate",
-      "type": "python",
+      "type": "debugpy",
       "request": "launch",
       "program": "${workspaceFolder}/manage.py",
       "args": [
         "migrate"
       ],
-      "env": {
-        "DATABASE_URL": "postgres://postgres:postgres@localhost:5433/care"
-      },
+      "envFile": "${workspaceFolder}/.env",
       "django": true,
       "justMyCode": false
     },
     {
-      "name": "Python: Django test",
-      "type": "python",
+      "name": "Python: Debug Tests",
+      "type": "debugpy",
       "request": "launch",
-      "program": "${workspaceFolder}/manage.py",
-      "env": {
-        "DATABASE_URL": "postgres://postgres:postgres@localhost:5433/care"
-      },
-      "args": [
-        "test",
-        "--keepdb"
-      ],
-      "django": true,
+      "program": "${file}",
+      "envFile": "${workspaceFolder}/.env",
+      "purpose": ["debug-test"],
+      "console": "integratedTerminal",
       "justMyCode": false
-    },
+    }
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,5 +24,13 @@
   "python.languageServer": "Pylance",
   "cSpell.words": [
     "Typst"
-  ]
+  ],
+  "python.testing.unittestArgs": [
+    "--noinput",
+    "--shuffle",
+    "--parallel",
+    "--keepdb",
+  ],
+  "python.testing.pytestEnabled": false,
+  "python.testing.unittestEnabled": true
 }


### PR DESCRIPTION
## Proposed Changes

- Add configuration for testing integration in vscode
- the integration needs `MANAGE_PY_PATH=./manage.py` to be present in .env file
<img width="643" height="789" alt="image" src="https://github.com/user-attachments/assets/01596aea-e1a7-46bb-ab38-6769f9eed904" />


## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment template to include a variable for the Django management script.
  * Modernized debugging configurations to use the latest Python debugger, unified connection settings, and consolidated environment handling via an env file.
  * Streamlined test debugging to focus on the currently opened test file with consistent behavior across configurations.

* **Tests**
  * Switched the editor’s testing framework to unittest, disabled pytest, and added parallelized, deterministic test options (no input, shuffle, parallel, keep DB) for faster, more reliable runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->