### PR TITLE
Add caching to UserResourceFavorites

### DIFF
--- a/care/emr/api/viewsets/favorites.py
+++ b/care/emr/api/viewsets/favorites.py
@@ -1,11 +1,14 @@
 from django.conf import settings
+from django.core.cache import cache
+from django.shortcuts import get_object_or_404
 from pydantic import BaseModel
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
-from care.emr.models.favorites import UserResourceFavorites
+from care.emr.models.favorites import UserResourceFavorites, favorite_lists_cache_key
 from care.emr.resources.favorites.spec import DEFAULT_FAVORITE_LIST
+from care.facility.models.facility import Facility
 
 
 class FavoriteRequest(BaseModel):
@@ -15,57 +18,79 @@ class FavoriteRequest(BaseModel):
 class EMRFavoritesMixin:
     FAVORITE_RESOURCE = None
 
-    def get_facility_obj(self, obj):
+    def retrieve_facility_obj(self, obj):
         return obj.facility
 
     @action(detail=False, methods=["GET"])
     def favorite_lists(self, request, *args, **kwargs):
         user = self.request.user
-        favorites_obj = UserResourceFavorites.objects.filter(
-            user=user, resource_type=self.FAVORITE_RESOURCE
+
+        facility = request.query_params.get("facility")
+        if facility:
+            facility = get_object_or_404(
+                Facility.objects.only("id"), external_id=facility
+            )
+
+        favorite_lists = cache.get(
+            favorite_lists_cache_key(user, self.FAVORITE_RESOURCE, facility)
         )
-        return Response(
-            {"lists": list(set(favorites_obj.values_list("favorite_list", flat=True)))}
-        )
+        if favorite_lists is None:
+            favorite_list_obj = list(
+                set(
+                    UserResourceFavorites.objects.filter(
+                        user=user,
+                        resource_type=self.FAVORITE_RESOURCE,
+                        facility=facility,
+                    )
+                    .order_by("-modified_date")
+                    .values_list("favorite_list", flat=True)
+                )
+            )
+            cache.set(
+                favorite_lists_cache_key(user, self.FAVORITE_RESOURCE, facility),
+                favorite_list_obj,
+            )
+        return Response({"lists": favorite_lists})
 
     @action(detail=True, methods=["POST"])
     def add_favorite(self, request, *args, **kwargs):
-        obj = self.get_object()
-        self.authorize_retrieve(obj)
-        user = self.request.user
         request_data = FavoriteRequest(**request.data)
         favorite_list = request_data.favorite_list
-        favorites_obj, _ = UserResourceFavorites.objects.get_or_create(
+        obj = self.get_object()
+        user = self.request.user
+        favorite_list_obj, _ = UserResourceFavorites.objects.get_or_create(
             user=user,
             favorite_list=favorite_list,
             resource_type=self.FAVORITE_RESOURCE,
-            facility=self.get_facility_obj(obj),
+            facility=self.retrieve_facility_obj(obj),
         )
-        if len(favorites_obj.favorites) >= settings.MAX_FAVORITES_PER_LIST:
-            raise ValidationError("Maximum number of favorites reached")
-        favorites_obj.favorites.append(obj.id)
-        favorites_obj.favorites = list(set(favorites_obj.favorites))
-        favorites_obj.save(update_fields=["favorites"])
+        favorite_list_obj.favorites.insert(0, obj.id)
+        # trim favorites list to max allowed
+        favorite_list_obj.favorites = list(set(favorite_list_obj.favorites))[
+            -settings.MAX_FAVORITES_PER_LIST :
+        ]
+        favorite_list_obj.save(update_fields=["favorites"])
         return Response({})
 
     @action(detail=True, methods=["POST"])
     def remove_favorite(self, request, *args, **kwargs):
-        obj = self.get_object()
-        self.authorize_retrieve(obj)
-        user = self.request.user
         request_data = FavoriteRequest(**request.data)
         favorite_list = request_data.favorite_list
-        favorites_obj = UserResourceFavorites.objects.filter(
+        obj = self.get_object()
+        user = self.request.user
+        favorite_list_obj = UserResourceFavorites.objects.filter(
             user=user,
             favorite_list=favorite_list,
             resource_type=self.FAVORITE_RESOURCE,
-            facility=self.get_facility_obj(obj),
+            facility=self.retrieve_facility_obj(obj),
         ).first()
-        if not favorites_obj:
+        if not favorite_list_obj:
             raise ValidationError("Favorite List not found")
-        favorites_obj.favorites = [
-            fav for fav in favorites_obj.favorites if fav != obj.id
-        ]
-        favorites_obj.favorites = list(set(favorites_obj.favorites))
-        favorites_obj.save(update_fields=["favorites"])
+        favorite_list_obj_favorites = set(favorite_list_obj.favorites)
+        try:
+            favorite_list_obj_favorites.remove(obj.id)
+        except KeyError:
+            pass
+        favorite_list_obj.favorites = list(favorite_list_obj_favorites)
+        favorite_list_obj.save(update_fields=["favorites"])
         return Response({})

--- a/care/emr/api/viewsets/favorites.py
+++ b/care/emr/api/viewsets/favorites.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.core.cache import cache
-from django.shortcuts import get_object_or_404
 from pydantic import BaseModel
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
@@ -9,6 +8,7 @@ from rest_framework.response import Response
 from care.emr.models.favorites import UserResourceFavorites, favorite_lists_cache_key
 from care.emr.resources.favorites.spec import DEFAULT_FAVORITE_LIST
 from care.facility.models.facility import Facility
+from care.utils.shortcuts import get_object_or_404
 
 
 class FavoriteRequest(BaseModel):

--- a/care/emr/api/viewsets/favorites.py
+++ b/care/emr/api/viewsets/favorites.py
@@ -5,7 +5,11 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
-from care.emr.models.favorites import UserResourceFavorites, favorite_lists_cache_key
+from care.emr.models.favorites import (
+    UserResourceFavorites,
+    favorite_list_object_cache_key,
+    favorite_lists_cache_key,
+)
 from care.emr.resources.favorites.spec import DEFAULT_FAVORITE_LIST
 from care.facility.models.facility import Facility
 from care.utils.shortcuts import get_object_or_404
@@ -78,11 +82,12 @@ class EMRFavoritesMixin:
         favorite_list = request_data.favorite_list
         obj = self.get_object()
         user = self.request.user
+        facility = self.retrieve_facility_obj(obj)
         favorite_list_obj = UserResourceFavorites.objects.filter(
             user=user,
             favorite_list=favorite_list,
             resource_type=self.FAVORITE_RESOURCE,
-            facility=self.retrieve_facility_obj(obj),
+            facility=facility,
         ).first()
         if not favorite_list_obj:
             raise ValidationError("Favorite List not found")
@@ -91,6 +96,20 @@ class EMRFavoritesMixin:
             favorite_list_obj_favorites.remove(obj.id)
         except KeyError:
             pass
+        if len(favorite_list_obj_favorites) == 0:
+            cache.delete(
+                favorite_lists_cache_key(user, self.FAVORITE_RESOURCE, facility)
+            )
+            cache.delete(
+                favorite_list_object_cache_key(
+                    user,
+                    self.FAVORITE_RESOURCE,
+                    facility,
+                    favorite_list_obj.favorite_list,
+                )
+            )
+            favorite_list_obj.delete()
+            return Response({})
         favorite_list_obj.favorites = list(favorite_list_obj_favorites)
         favorite_list_obj.save(update_fields=["favorites"])
         return Response({})

--- a/care/emr/models/favorites.py
+++ b/care/emr/models/favorites.py
@@ -49,6 +49,10 @@ class UserResourceFavorites(EMRBaseModel):
         )
 
     def save(self, *args, **kwargs):
+        if not self.pk:
+            cache.delete(
+                favorite_lists_cache_key(self.user, self.resource_type, self.facility)
+            )
         update_fields = kwargs.get("update_fields", [])
         super().save(*args, **kwargs)
         self.refresh_cache(refresh_list="favorite_list" in update_fields)

--- a/care/emr/models/favorites.py
+++ b/care/emr/models/favorites.py
@@ -49,10 +49,6 @@ class UserResourceFavorites(EMRBaseModel):
         )
 
     def save(self, *args, **kwargs):
-        if not self.pk:
-            cache.delete(
-                favorite_lists_cache_key(self.user, self.resource_type, self.facility)
-            )
-        update_fields = kwargs.get("update_fields", [])
+        refresh_list = not self.pk
         super().save(*args, **kwargs)
-        self.refresh_cache(refresh_list="favorite_list" in update_fields)
+        self.refresh_cache(refresh_list=refresh_list)

--- a/care/emr/models/favorites.py
+++ b/care/emr/models/favorites.py
@@ -1,9 +1,18 @@
 from django.contrib.postgres.fields import ArrayField
+from django.core.cache import cache
 from django.db import models
 
 from care.emr.models import EMRBaseModel
 from care.facility.models.facility import Facility
 from care.users.models import User
+
+
+def favorite_lists_cache_key(user, resource_type, facility):
+    return f"user_favorites_lists:{user.id}:{resource_type}:{facility.id if facility else '-'}"
+
+
+def favorite_list_object_cache_key(user, resource_type, facility, favorite_list):
+    return f"user_favorites_list_object:{user.id}:{resource_type}:{facility.id if facility else '-'}:{favorite_list}"
 
 
 class UserResourceFavorites(EMRBaseModel):
@@ -14,3 +23,32 @@ class UserResourceFavorites(EMRBaseModel):
     facility = models.ForeignKey(
         Facility, on_delete=models.CASCADE, null=True, blank=True
     )
+
+    def refresh_cache(self, refresh_list=False):
+        if refresh_list:
+            favorites_obj = list(
+                set(
+                    self.__class__.objects.filter(
+                        user_id=self.user_id,
+                        resource_type=self.resource_type,
+                        facility_id=self.facility_id,
+                    )
+                    .order_by("-modified_date")
+                    .values_list("favorite_list", flat=True)
+                )
+            )
+            cache.set(
+                favorite_lists_cache_key(self.user, self.resource_type, self.facility),
+                favorites_obj,
+            )
+        cache.set(
+            favorite_list_object_cache_key(
+                self.user, self.resource_type, self.facility, self.favorite_list
+            ),
+            self.favorites,
+        )
+
+    def save(self, *args, **kwargs):
+        update_fields = kwargs.get("update_fields")
+        super().save(*args, **kwargs)
+        self.refresh_cache(refresh_list="favorite_list" in update_fields)

--- a/care/emr/models/favorites.py
+++ b/care/emr/models/favorites.py
@@ -49,6 +49,6 @@ class UserResourceFavorites(EMRBaseModel):
         )
 
     def save(self, *args, **kwargs):
-        update_fields = kwargs.get("update_fields")
+        update_fields = kwargs.get("update_fields", [])
         super().save(*args, **kwargs)
         self.refresh_cache(refresh_list="favorite_list" in update_fields)

--- a/care/emr/resources/favorites/filters.py
+++ b/care/emr/resources/favorites/filters.py
@@ -1,8 +1,12 @@
+from django.core.cache import cache
 from django.shortcuts import get_object_or_404
 from rest_framework.compat import coreapi, coreschema
 from rest_framework.filters import BaseFilterBackend
 
-from care.emr.models.favorites import UserResourceFavorites
+from care.emr.models.favorites import (
+    UserResourceFavorites,
+    favorite_list_object_cache_key,
+)
 from care.facility.models.facility import Facility
 
 
@@ -35,25 +39,36 @@ class FavoritesFilter(BaseFilterBackend):
 
     def filter_queryset(self, request, queryset, view):
         favorite_list = request.query_params.get("favorite_list")
-        facility = request.query_params.get("facility")
         if not favorite_list:
             return queryset
+
+        facility = request.query_params.get("facility")
         if facility:
             facility = get_object_or_404(
                 Facility.objects.only("id"), external_id=facility
             )
-        else:
-            facility = None
-        favorites_objs = UserResourceFavorites.objects.filter(
-            user=request.user,
-            favorite_list=favorite_list,
-            resource_type=view.FAVORITE_RESOURCE,
+
+        favorites = cache.get(
+            favorite_list_object_cache_key(
+                request.user, view.FAVORITE_RESOURCE, facility, favorite_list
+            )
         )
-        if facility:
-            favorites_objs = favorites_objs.filter(facility=facility)
-        else:
-            favorites_objs = favorites_objs.filter(facility__is_null=True)
-        favorites_obj = favorites_objs.first()
-        if not favorites_obj:
+        if favorites is not None:
+            favorites_objs = UserResourceFavorites.objects.filter(
+                user=request.user,
+                favorite_list=favorite_list,
+                resource_type=view.FAVORITE_RESOURCE,
+                facility=facility,
+            ).first()
+            # setting the cache value as [] to ignore unnecessary cache misses
+            favorites = favorites_objs.favorites if favorites_objs else []
+            cache.set(
+                favorite_list_object_cache_key(
+                    request.user, view.FAVORITE_RESOURCE, facility, favorite_list
+                ),
+                favorites,
+            )
+
+        if not favorites:
             return queryset.none()
-        return queryset.filter(id__in=favorites_obj.favorites)
+        return queryset.filter(id__in=favorites)

--- a/care/emr/resources/favorites/filters.py
+++ b/care/emr/resources/favorites/filters.py
@@ -53,7 +53,7 @@ class FavoritesFilter(BaseFilterBackend):
                 request.user, view.FAVORITE_RESOURCE, facility, favorite_list
             )
         )
-        if favorites is not None:
+        if favorites is None:
             favorites_objs = UserResourceFavorites.objects.filter(
                 user=request.user,
                 favorite_list=favorite_list,


### PR DESCRIPTION
## Proposed Changes

- closes https://github.com/ohcnetwork/roadmap/issues/133
- Add Caching
- Make it a queue, as in next added is added to the first
- Right now it hits an error when the max size is reached, lets just trim the ends instead of raising error
- Get rid of Authz
- Rename favorites_obj to favorite_list_obj for consistency


## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins
