### PR TITLE
Update TokenBookingReadSpec to replace user with resource

### DIFF
--- a/care/emr/resources/scheduling/slot/spec.py
+++ b/care/emr/resources/scheduling/slot/spec.py
@@ -10,6 +10,7 @@ from care.emr.resources.base import EMRResource, model_from_cache
 from care.emr.resources.charge_item.spec import ChargeItemReadSpec
 from care.emr.resources.facility.spec import FacilityBareMinimumSpec
 from care.emr.resources.patient.otp_based_flow import PatientOTPReadSpec
+from care.emr.resources.scheduling.resource.spec import serialize_resource
 from care.emr.resources.scheduling.token.spec import TokenReadSpec
 from care.emr.resources.user.spec import UserSpec
 from care.emr.tagging.base import SingleFacilityTagManager
@@ -105,7 +106,7 @@ class TokenBookingReadSpec(TokenBookingBaseSpec):
     booked_by: UserSpec
     status: str
     note: str
-    user: dict = {}
+    resource: dict = {}
     facility: dict = {}
     created_by: UserSpec | None = None
     updated_by: UserSpec | None = None
@@ -124,7 +125,7 @@ class TokenBookingReadSpec(TokenBookingBaseSpec):
         mapping["patient"] = PatientOTPReadSpec.serialize(obj.patient).model_dump(
             exclude=["meta"]
         )
-        mapping["user"] = model_from_cache(UserSpec, id=obj.token_slot.resource.user_id)
+        mapping["resource"] = serialize_resource(obj.token_slot.resource)
         mapping["facility"] = model_from_cache(
             FacilityBareMinimumSpec, id=obj.token_slot.resource.facility_id
         )


### PR DESCRIPTION
## Proposed Changes


> [!WARNING] 
> user has been replaced with resource in TokenBookingReadSpec


- fixes [CARE-H09](https://coronasafe-network.sentry.io/issues/6873645229/events/442926bb3b354be3bb07a373f32d3434/)



## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins
