### PR TITLE
Set subject_type default value as encounter for Observation

### DIFF
--- a/care/emr/resources/observation/spec.py
+++ b/care/emr/resources/observation/spec.py
@@ -67,7 +67,7 @@ class BaseObservationSpec(EMRResource):
 
     alternate_coding: CodeableConcept | None = None
 
-    subject_type: SubjectType
+    subject_type: SubjectType = SubjectType.encounter.value
 
     encounter: UUID4 | None = None
 


### PR DESCRIPTION
## Proposed Changes

This pull request makes a small change to the `BaseObservationSpec` class in `care/emr/resources/observation/spec.py`. The default value for the `subject_type` attribute is now set to `SubjectType.encounter.value` instead of requiring it to be explicitly provided.

Because the ObservationUpdateSpec is used inside the upsert_observations and at the end of method the value for subject_type is being overwritten to `encounter` https://github.com/ohcnetwork/care/blob/bb689e524d42f12c51dac2267c050b600229256c/care/emr/api/viewsets/diagnostic_report.py#L198

So there is no point is sending that field from frontend and so without a default value in spec, the request would fail at validation https://github.com/ohcnetwork/care/blob/bb689e524d42f12c51dac2267c050b600229256c/care/emr/api/viewsets/diagnostic_report.py#L188

### Associated Issue

- Link to issue here, explain how the proposed solution will solve the reported issue/ feature request.

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins
