### PR TITLE
Multi Status filter for Get Appointments in patient viewset

### DIFF
--- a/care/emr/api/viewsets/patient.py
+++ b/care/emr/api/viewsets/patient.py
@@ -278,6 +278,7 @@ class PatientViewSet(EMRModelViewSet):
     @action(detail=True, methods=["GET"])
     def get_appointments(self, request, *args, **kwargs):
         facility = self.request.GET.get("facility", None)
+        status = self.request.GET.get("status", None)
         queryset = TokenBooking.objects.all().order_by("-token_slot__start_datetime")
         if facility:
             facility = get_object_or_404(Facility, external_id=facility)
@@ -293,6 +294,11 @@ class PatientViewSet(EMRModelViewSet):
             )
         else:
             queryset = queryset.filter(patient=self.get_object())
+
+        if status:
+            status_list = status.split(",")
+            queryset = queryset.filter(status__in=status_list)
+
         paginator = self.pagination_class()
         page = paginator.paginate_queryset(queryset, request)
         if page is not None:


### PR DESCRIPTION
## Proposed Changes

- Brief of changes made.

### Associated Issue

- Link to issue here, explain how the proposed solution will solve the reported issue/ feature request.

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Appointments API now supports optional filtering by status via a query parameter.
  - Accepts a comma-separated list of statuses to retrieve only matching appointments.
  - Works whether you’re querying appointments across a facility or for the current user.
  - Backward-compatible: if no status is provided, results are unchanged.
  - Enables faster, more targeted appointment retrieval for clients needing specific states (e.g., scheduled, completed, cancelled).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->