### PR TITLE
use MultiSelectFilter for encounter status

### DIFF
--- a/care/emr/api/viewsets/encounter.py
+++ b/care/emr/api/viewsets/encounter.py
@@ -44,6 +44,7 @@ from care.emr.tasks.discharge_summary import generate_discharge_summary_task
 from care.facility.models import Facility
 from care.security.authorization import AuthorizationController
 from care.users.models import User
+from care.utils.filters.multiselect import MultiSelectFilter
 from care.utils.shortcuts import get_object_or_404
 
 
@@ -61,7 +62,7 @@ class LiveFilter(filters.CharFilter):
 
 class EncounterFilters(filters.FilterSet):
     facility = filters.UUIDFilter(field_name="facility__external_id")
-    status = filters.CharFilter(field_name="status", lookup_expr="iexact")
+    status = MultiSelectFilter(field_name="status")
     encounter_class = filters.CharFilter(
         field_name="encounter_class", lookup_expr="iexact"
     )


### PR DESCRIPTION
## Proposed Changes
Replace status filter with `MultiSelectFilter`

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-select status filtering for encounters. You can now choose multiple statuses at once when filtering encounter lists, making it easier to narrow results to the exact set you need (e.g., viewing “Open” and “In Progress” together). This enhances list browsing, review workflows, and data auditing by reducing the need to run multiple searches and enabling more flexible, precise result sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->