### PR TITLE
Added update authorization in payment reconciliation

### DIFF
--- a/care/emr/api/viewsets/payment_reconciliation.py
+++ b/care/emr/api/viewsets/payment_reconciliation.py
@@ -105,6 +105,14 @@ class PaymentReconciliationViewSet(
             if invoice.facility != facility:
                 raise ValidationError("Invoice is not associated with the facility")
 
+    def authorize_update(self, request_obj, model_instance):
+        if not AuthorizationController.call(
+            "can_write_payment_reconciliation_in_facility",
+            self.request.user,
+            model_instance.facility,
+        ):
+            raise PermissionDenied("Cannot update payment reconciliation")
+
     @action(methods=["POST"], detail=True)
     def cancel_payment_reconciliation(self, request, *args, **kwargs):
         request_data = PaymentReconciliationCancelRequest(**request.data)


### PR DESCRIPTION
## Proposed Changes

- Added update authorization in payment reconciliation api

### Architecture changes

- Added authorize_update for permission check for update payment reconciliation
 
## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced permission checks when updating payment reconciliation records, ensuring only users with write access for the related facility can make changes.
  * Aligns update behavior with existing create permissions for consistent access control.
  * Unauthorized users now receive a clear permission error during update attempts; authorized users experience no change to their workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->