### PR TITLE
fix:added location check in retrieve spec

### DIFF
--- a/care/emr/resources/payment_reconciliation/spec.py
+++ b/care/emr/resources/payment_reconciliation/spec.py
@@ -128,4 +128,7 @@ class PaymentReconciliationRetrieveSpec(PaymentReconciliationReadSpec):
     @classmethod
     def perform_extra_serialization(cls, mapping, obj):
         super().perform_extra_serialization(mapping, obj)
-        mapping["location"] = FacilityLocationListSpec.serialize(obj.location).to_json()
+        if obj.location:
+            mapping["location"] = FacilityLocationListSpec.serialize(
+                obj.location
+            ).to_json()


### PR DESCRIPTION
## Proposed Changes

- Added location check in retrieve spec

### Associated Issue

- Hitting AttributeError: 'NoneType' object has no attribute 'id'

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Payment Reconciliation details now omit the location field when no location is available, preventing empty or misleading values.
  * Ensures more consistent API responses and reduces potential client-side errors when parsing Payment Reconciliation data.
  * Existing behavior remains unchanged when a valid location is present, maintaining compatibility for integrations that rely on the location field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->