### PR TITLE
Separate TokenBookingRead spec for OTP

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,15 +21,13 @@
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true,
   "githubPullRequests.ignoredPullRequestBranches": ["develop", "staging"],
-  "python.languageServer": "Pylance",
-  "cSpell.words": [
-    "Typst"
-  ],
+  "python.languageServer": "None",
+  "cSpell.words": ["Typst"],
   "python.testing.unittestArgs": [
     "--noinput",
     "--shuffle",
     "--parallel",
-    "--keepdb",
+    "--keepdb"
   ],
   "python.testing.pytestEnabled": false,
   "python.testing.unittestEnabled": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,13 +21,15 @@
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true,
   "githubPullRequests.ignoredPullRequestBranches": ["develop", "staging"],
-  "python.languageServer": "None",
-  "cSpell.words": ["Typst"],
+  "python.languageServer": "Pylance",
+  "cSpell.words": [
+    "Typst"
+  ],
   "python.testing.unittestArgs": [
     "--noinput",
     "--shuffle",
     "--parallel",
-    "--keepdb"
+    "--keepdb",
   ],
   "python.testing.pytestEnabled": false,
   "python.testing.unittestEnabled": true

--- a/care/emr/api/otp_viewsets/slot.py
+++ b/care/emr/api/otp_viewsets/slot.py
@@ -15,8 +15,8 @@ from care.emr.models.patient import Patient
 from care.emr.models.scheduling import TokenBooking, TokenSlot
 from care.emr.resources.scheduling.slot.spec import (
     BookingStatusChoices,
-    TokenBookingReadSpec,
     TokenSlotBaseSpec,
+    TokenBookingOTPReadSpec,
 )
 from care.utils.shortcuts import get_object_or_404
 from config.patient_otp_authentication import (
@@ -60,8 +60,11 @@ class OTPSlotViewSet(EMRRetrieveMixin, EMRBaseViewSet):
             external_id=request_data.patient, phone_number=request.user.phone_number
         ).exists():
             raise ValidationError("Patient not allowed")
-        return SlotViewSet.create_appointment_handler(
+        appointment = SlotViewSet.create_appointment_handler(
             self.get_object(), request.data, None
+        )
+        return Response(
+            TokenBookingOTPReadSpec.serialize(appointment).model_dump(exclude=["meta"])
         )
 
     @extend_schema(
@@ -78,8 +81,11 @@ class OTPSlotViewSet(EMRRetrieveMixin, EMRBaseViewSet):
         token_booking = get_object_or_404(
             TokenBooking, external_id=request_data.appointment, patient=patient
         )
-        return TokenBookingViewSet.cancel_appointment_handler(
+        appointment = TokenBookingViewSet.cancel_appointment_handler(
             token_booking, {"reason": BookingStatusChoices.cancelled}, None
+        )
+        return Response(
+            TokenBookingOTPReadSpec.serialize(appointment).model_dump(exclude=["meta"])
         )
 
     @action(detail=False, methods=["GET"])
@@ -90,7 +96,7 @@ class OTPSlotViewSet(EMRRetrieveMixin, EMRBaseViewSet):
         return Response(
             {
                 "results": [
-                    TokenBookingReadSpec.serialize(obj).model_dump(exclude=["meta"])
+                    TokenBookingOTPReadSpec.serialize(obj).model_dump(exclude=["meta"])
                     for obj in appointments
                 ]
             }

--- a/care/emr/api/otp_viewsets/slot.py
+++ b/care/emr/api/otp_viewsets/slot.py
@@ -15,8 +15,8 @@ from care.emr.models.patient import Patient
 from care.emr.models.scheduling import TokenBooking, TokenSlot
 from care.emr.resources.scheduling.slot.spec import (
     BookingStatusChoices,
-    TokenSlotBaseSpec,
     TokenBookingOTPReadSpec,
+    TokenSlotBaseSpec,
 )
 from care.utils.shortcuts import get_object_or_404
 from config.patient_otp_authentication import (

--- a/care/emr/api/otp_viewsets/slot.py
+++ b/care/emr/api/otp_viewsets/slot.py
@@ -63,9 +63,7 @@ class OTPSlotViewSet(EMRRetrieveMixin, EMRBaseViewSet):
         appointment = SlotViewSet.create_appointment_handler(
             self.get_object(), request.data, None
         )
-        return Response(
-            TokenBookingOTPReadSpec.serialize(appointment).model_dump(exclude=["meta"])
-        )
+        return Response(TokenBookingOTPReadSpec.serialize(appointment).to_json())
 
     @extend_schema(
         request=CancelAppointmentSpec,
@@ -84,9 +82,7 @@ class OTPSlotViewSet(EMRRetrieveMixin, EMRBaseViewSet):
         appointment = TokenBookingViewSet.cancel_appointment_handler(
             token_booking, {"reason": BookingStatusChoices.cancelled}, None
         )
-        return Response(
-            TokenBookingOTPReadSpec.serialize(appointment).model_dump(exclude=["meta"])
-        )
+        return Response(TokenBookingOTPReadSpec.serialize(appointment).to_json())
 
     @action(detail=False, methods=["GET"])
     def get_appointments(self, request, *args, **kwargs):
@@ -96,7 +92,7 @@ class OTPSlotViewSet(EMRRetrieveMixin, EMRBaseViewSet):
         return Response(
             {
                 "results": [
-                    TokenBookingOTPReadSpec.serialize(obj).model_dump(exclude=["meta"])
+                    TokenBookingOTPReadSpec.serialize(obj).to_json()
                     for obj in appointments
                 ]
             }

--- a/care/emr/api/viewsets/scheduling/availability.py
+++ b/care/emr/api/viewsets/scheduling/availability.py
@@ -27,7 +27,8 @@ from care.emr.resources.scheduling.schedule.spec import (
 from care.emr.resources.scheduling.slot.spec import (
     CANCELLED_STATUS_CHOICES,
     COMPLETED_STATUS_CHOICES,
-    TokenSlotBaseSpec, TokenBookingReadSpec,
+    TokenBookingReadSpec,
+    TokenSlotBaseSpec,
 )
 from care.emr.resources.tag.config_spec import TagResource
 from care.emr.tagging.base import SingleFacilityTagManager
@@ -321,7 +322,9 @@ class SlotViewSet(EMRRetrieveMixin, EMRBaseViewSet):
     def create_appointment(self, request, *args, **kwargs):
         slot_obj = self.get_object()
         self.authorize_update(None, slot_obj)
-        appointment = self.create_appointment_handler(slot_obj, request.data, request.user)
+        appointment = self.create_appointment_handler(
+            slot_obj, request.data, request.user
+        )
         return Response(
             TokenBookingReadSpec.serialize(appointment).model_dump(exclude=["meta"])
         )

--- a/care/emr/api/viewsets/scheduling/availability.py
+++ b/care/emr/api/viewsets/scheduling/availability.py
@@ -27,8 +27,7 @@ from care.emr.resources.scheduling.schedule.spec import (
 from care.emr.resources.scheduling.slot.spec import (
     CANCELLED_STATUS_CHOICES,
     COMPLETED_STATUS_CHOICES,
-    TokenBookingReadSpec,
-    TokenSlotBaseSpec,
+    TokenSlotBaseSpec, TokenBookingReadSpec,
 )
 from care.emr.resources.tag.config_spec import TagResource
 from care.emr.tagging.base import SingleFacilityTagManager
@@ -310,9 +309,7 @@ class SlotViewSet(EMRRetrieveMixin, EMRBaseViewSet):
                     user,
                     obj.resource.facility,
                 )
-        return Response(
-            TokenBookingReadSpec.serialize(appointment).model_dump(exclude=["meta"])
-        )
+        return appointment
 
     def authorize_update(self, request_obj, model_instance):
         if not AuthorizationController.call(
@@ -324,7 +321,10 @@ class SlotViewSet(EMRRetrieveMixin, EMRBaseViewSet):
     def create_appointment(self, request, *args, **kwargs):
         slot_obj = self.get_object()
         self.authorize_update(None, slot_obj)
-        return self.create_appointment_handler(slot_obj, request.data, request.user)
+        appointment = self.create_appointment_handler(slot_obj, request.data, request.user)
+        return Response(
+            TokenBookingReadSpec.serialize(appointment).model_dump(exclude=["meta"])
+        )
 
     @action(detail=False, methods=["POST"])
     def availability_stats(self, request, *args, **kwargs):

--- a/care/emr/api/viewsets/scheduling/availability.py
+++ b/care/emr/api/viewsets/scheduling/availability.py
@@ -325,9 +325,7 @@ class SlotViewSet(EMRRetrieveMixin, EMRBaseViewSet):
         appointment = self.create_appointment_handler(
             slot_obj, request.data, request.user
         )
-        return Response(
-            TokenBookingReadSpec.serialize(appointment).model_dump(exclude=["meta"])
-        )
+        return Response(TokenBookingReadSpec.serialize(appointment).to_json())
 
     @action(detail=False, methods=["POST"])
     def availability_stats(self, request, *args, **kwargs):

--- a/care/emr/api/viewsets/scheduling/booking.py
+++ b/care/emr/api/viewsets/scheduling/booking.py
@@ -199,7 +199,9 @@ class TokenBookingViewSet(
     def cancel(self, request, *args, **kwargs):
         instance = self.get_object()
         self.authorize_update({}, instance)
-        appointment = self.cancel_appointment_handler(instance, request.data, request.user)
+        appointment = self.cancel_appointment_handler(
+            instance, request.data, request.user
+        )
         return Response(
             TokenBookingReadSpec.serialize(appointment).model_dump(exclude=["meta"])
         )

--- a/care/emr/api/viewsets/scheduling/booking.py
+++ b/care/emr/api/viewsets/scheduling/booking.py
@@ -202,9 +202,7 @@ class TokenBookingViewSet(
         appointment = self.cancel_appointment_handler(
             instance, request.data, request.user
         )
-        return Response(
-            TokenBookingReadSpec.serialize(appointment).model_dump(exclude=["meta"])
-        )
+        return Response(TokenBookingReadSpec.serialize(appointment).to_json())
 
     @extend_schema(
         request=RescheduleBookingSpec,
@@ -253,9 +251,7 @@ class TokenBookingViewSet(
                     request.user,
                     facility,
                 )
-            return Response(
-                TokenBookingReadSpec.serialize(appointment).model_dump(exclude=["meta"])
-            )
+            return Response(TokenBookingReadSpec.serialize(appointment).to_json())
 
     @action(detail=False, methods=["GET"])
     def available_users(self, request, *args, **kwargs):

--- a/care/emr/api/viewsets/scheduling/booking.py
+++ b/care/emr/api/viewsets/scheduling/booking.py
@@ -193,15 +193,16 @@ class TokenBookingViewSet(
                 instance.charge_item.status = ChargeItemStatusOptions.aborted.value
                 instance.charge_item.save()
             instance.save()
-        return Response(
-            TokenBookingReadSpec.serialize(instance).model_dump(exclude=["meta"])
-        )
+        return instance
 
     @action(detail=True, methods=["POST"])
     def cancel(self, request, *args, **kwargs):
         instance = self.get_object()
         self.authorize_update({}, instance)
-        return self.cancel_appointment_handler(instance, request.data, request.user)
+        appointment = self.cancel_appointment_handler(instance, request.data, request.user)
+        return Response(
+            TokenBookingReadSpec.serialize(appointment).model_dump(exclude=["meta"])
+        )
 
     @extend_schema(
         request=RescheduleBookingSpec,

--- a/care/emr/resources/scheduling/slot/spec.py
+++ b/care/emr/resources/scheduling/slot/spec.py
@@ -144,7 +144,7 @@ class TokenBookingOTPReadSpec(TokenBookingBaseReadSpec):
 
     @classmethod
     def perform_extra_serialization(cls, mapping, obj):
-        TokenBookingBaseReadSpec.perform_extra_serialization(mapping, obj)
+        super().perform_extra_serialization(mapping, obj)
         mapping["patient"] = PatientOTPReadSpec.serialize(obj.patient).model_dump(
             exclude=["meta"]
         )
@@ -155,7 +155,7 @@ class TokenBookingReadSpec(TokenBookingBaseReadSpec):
 
     @classmethod
     def perform_extra_serialization(cls, mapping, obj):
-        TokenBookingBaseReadSpec.perform_extra_serialization(mapping, obj)
+        super().perform_extra_serialization(mapping, obj)
         mapping["patient"] = PatientListSpec.serialize(obj.patient).model_dump(
             exclude=["meta"]
         )

--- a/care/emr/resources/scheduling/slot/spec.py
+++ b/care/emr/resources/scheduling/slot/spec.py
@@ -10,6 +10,7 @@ from care.emr.resources.base import EMRResource, model_from_cache
 from care.emr.resources.charge_item.spec import ChargeItemReadSpec
 from care.emr.resources.facility.spec import FacilityBareMinimumSpec
 from care.emr.resources.patient.otp_based_flow import PatientOTPReadSpec
+from care.emr.resources.patient.spec import PatientListSpec
 from care.emr.resources.scheduling.resource.spec import serialize_resource
 from care.emr.resources.scheduling.schedule.spec import SchedulableResourceTypeOptions
 from care.emr.resources.scheduling.token.spec import TokenReadSpec
@@ -96,11 +97,10 @@ class TokenBookingMinimumReadSpec(TokenBookingBaseSpec):
         )
 
 
-class TokenBookingReadSpec(TokenBookingBaseSpec):
+class TokenBookingBaseReadSpec(TokenBookingBaseSpec):
     id: UUID4 | None = None
 
     token_slot: TokenSlotBaseSpec
-    patient: PatientOTPReadSpec
     booked_on: datetime.datetime
     booked_by: UserSpec
     status: str
@@ -122,9 +122,6 @@ class TokenBookingReadSpec(TokenBookingBaseSpec):
         mapping["token_slot"] = TokenSlotBaseSpec.serialize(obj.token_slot).model_dump(
             exclude=["meta"]
         )
-        mapping["patient"] = PatientOTPReadSpec.serialize(obj.patient).model_dump(
-            exclude=["meta"]
-        )
         mapping["resource_type"] = obj.token_slot.resource.resource_type
         mapping["resource"] = serialize_resource(obj.token_slot.resource)
         mapping["facility"] = model_from_cache(
@@ -140,6 +137,28 @@ class TokenBookingReadSpec(TokenBookingBaseSpec):
                 obj.charge_item
             ).to_json()
         cls.serialize_audit_users(mapping, obj)
+
+
+class TokenBookingOTPReadSpec(TokenBookingBaseReadSpec):
+    patient: PatientOTPReadSpec
+
+    @classmethod
+    def perform_extra_serialization(cls, mapping, obj):
+        TokenBookingBaseReadSpec.perform_extra_serialization(mapping, obj)
+        mapping["patient"] = PatientOTPReadSpec.serialize(obj.patient).model_dump(
+            exclude=["meta"]
+        )
+
+
+class TokenBookingReadSpec(TokenBookingBaseReadSpec):
+    patient: PatientListSpec
+
+    @classmethod
+    def perform_extra_serialization(cls, mapping, obj):
+        TokenBookingBaseReadSpec.perform_extra_serialization(mapping, obj)
+        mapping["patient"] = PatientListSpec.serialize(obj.patient).model_dump(
+            exclude=["meta"]
+        )
 
 
 class TokenBookingRetrieveSpec(TokenBookingReadSpec):

--- a/care/emr/resources/scheduling/slot/spec.py
+++ b/care/emr/resources/scheduling/slot/spec.py
@@ -92,9 +92,7 @@ class TokenBookingMinimumReadSpec(TokenBookingBaseSpec):
     @classmethod
     def perform_extra_serialization(cls, mapping, obj):
         mapping["id"] = obj.external_id
-        mapping["token_slot"] = TokenSlotBaseSpec.serialize(obj.token_slot).model_dump(
-            exclude=["meta"]
-        )
+        mapping["token_slot"] = TokenSlotBaseSpec.serialize(obj.token_slot).to_json()
 
 
 class TokenBookingBaseReadSpec(TokenBookingBaseSpec):
@@ -119,9 +117,7 @@ class TokenBookingBaseReadSpec(TokenBookingBaseSpec):
     @classmethod
     def perform_extra_serialization(cls, mapping, obj):
         mapping["id"] = obj.external_id
-        mapping["token_slot"] = TokenSlotBaseSpec.serialize(obj.token_slot).model_dump(
-            exclude=["meta"]
-        )
+        mapping["token_slot"] = TokenSlotBaseSpec.serialize(obj.token_slot).to_json()
         mapping["resource_type"] = obj.token_slot.resource.resource_type
         mapping["resource"] = serialize_resource(obj.token_slot.resource)
         mapping["facility"] = model_from_cache(
@@ -145,9 +141,7 @@ class TokenBookingOTPReadSpec(TokenBookingBaseReadSpec):
     @classmethod
     def perform_extra_serialization(cls, mapping, obj):
         super().perform_extra_serialization(mapping, obj)
-        mapping["patient"] = PatientOTPReadSpec.serialize(obj.patient).model_dump(
-            exclude=["meta"]
-        )
+        mapping["patient"] = PatientOTPReadSpec.serialize(obj.patient).to_json()
 
 
 class TokenBookingReadSpec(TokenBookingBaseReadSpec):
@@ -156,9 +150,7 @@ class TokenBookingReadSpec(TokenBookingBaseReadSpec):
     @classmethod
     def perform_extra_serialization(cls, mapping, obj):
         super().perform_extra_serialization(mapping, obj)
-        mapping["patient"] = PatientListSpec.serialize(obj.patient).model_dump(
-            exclude=["meta"]
-        )
+        mapping["patient"] = PatientListSpec.serialize(obj.patient).to_json()
 
 
 class TokenBookingRetrieveSpec(TokenBookingReadSpec):


### PR DESCRIPTION
## Proposed Changes

- Separate TokenBookingRead spec for OTP

### Associated Issue

- Required for having PatientListSpec in non OTP based token booking views

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - OTP-specific appointment responses with patient details tailored for OTP flows.

- Bug Fixes
  - Consistent JSON responses when creating, canceling, rescheduling, and listing appointments.
  - Cleaner payloads with reduced internal metadata exposure.

- Refactor
  - Handlers now return model objects while endpoints uniformly serialize and return final API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->