### PR TITLE
supply delivery: allow filtering just by supplier

### DIFF
--- a/care/emr/api/viewsets/inventory/supply_delivery.py
+++ b/care/emr/api/viewsets/inventory/supply_delivery.py
@@ -256,6 +256,8 @@ class SupplyDeliveryViewSet(
                     queryset, "order__origin", origin, include_children
                 )
                 filtered = True
+            if "supplier" in self.request.GET:
+                filtered = True
             if not filtered:
                 raise ValidationError("No filters provided")
         return queryset


### PR DESCRIPTION
## Proposed Changes

- allow filtering just by supplier (needed to show all deliveries in purchase delivery detailed view)

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Supply Delivery API now recognizes the supplier parameter as a valid filter, preventing “filters required” errors when only supplier is provided.
  * Users can reliably filter supply deliveries by supplier alongside existing options (order, request_order, destination, origin), improving consistency of filtered results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->