### PR TITLE
fixing ordering issue in set care team

### DIFF
--- a/care/emr/resources/encounter/spec.py
+++ b/care/emr/resources/encounter/spec.py
@@ -171,13 +171,20 @@ class EncounterRetrieveSpec(EncounterListSpec, EncounterPermissionsMixin):
 
         care_team = []
         user_mapping = {x["user_id"]: x for x in obj.care_team}
-        for member in User.objects.filter(id__in=user_mapping.keys()):
-            care_team.append(
-                {
-                    "member": UserSpec.serialize(member).to_json(),
-                    "role": user_mapping[member.id]["role"],
-                }
-            )
+        user_ids = list(user_mapping.keys())
+
+        users = User.objects.filter(id__in=user_ids)
+        user_lookup = {user.id: user for user in users}
+
+        for user_id in user_ids:
+            if user_id in user_lookup:
+                member = user_lookup[user_id]
+                care_team.append(
+                    {
+                        "member": UserSpec.serialize(member).to_json(),
+                        "role": user_mapping[user_id]["role"],
+                    }
+                )
 
         mapping["care_team"] = care_team
 

--- a/care/emr/resources/encounter/spec.py
+++ b/care/emr/resources/encounter/spec.py
@@ -11,7 +11,7 @@ from care.emr.models import (
     TokenBooking,
 )
 from care.emr.models.patient import Patient
-from care.emr.resources.base import EMRResource, PeriodSpec
+from care.emr.resources.base import EMRResource, PeriodSpec, model_from_cache
 from care.emr.resources.encounter.constants import (
     AdmitSourcesChoices,
     ClassChoices,
@@ -173,18 +173,13 @@ class EncounterRetrieveSpec(EncounterListSpec, EncounterPermissionsMixin):
         user_mapping = {x["user_id"]: x for x in obj.care_team}
         user_ids = list(user_mapping.keys())
 
-        users = User.objects.filter(id__in=user_ids)
-        user_lookup = {user.id: user for user in users}
-
         for user_id in user_ids:
-            if user_id in user_lookup:
-                member = user_lookup[user_id]
-                care_team.append(
-                    {
-                        "member": UserSpec.serialize(member).to_json(),
-                        "role": user_mapping[user_id]["role"],
-                    }
-                )
+            care_team.append(
+                {
+                    "member": model_from_cache(UserSpec, id=user_id),
+                    "role": user_mapping[user_id]["role"],
+                }
+            )
 
         mapping["care_team"] = care_team
 


### PR DESCRIPTION
## Proposed Changes

- Fixes : https://github.com/ohcnetwork/care_fe/issues/14127

Was cause `User.objects.filter` doesn't maintains the order of results according to the list of user id

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins
