### PR TITLE
add support for multi-tags in evaluation metric

### DIFF
--- a/care/emr/utils/compute_observation_interpretation.py
+++ b/care/emr/utils/compute_observation_interpretation.py
@@ -5,6 +5,7 @@ def compute_observation_interpretation(model_instance, metrics_cache):
     """Helper method to compute interpretation for observation instances."""
     evaluation_context = {
         "patient": model_instance.patient,
+        "encounter": model_instance.encounter,
     }
     try:
         evaluator = InterpretationEvaluator(

--- a/care/utils/evaluators/evaluation_metric/base.py
+++ b/care/utils/evaluators/evaluation_metric/base.py
@@ -33,7 +33,7 @@ class EvaluationMetricBase:
     def evaluate_has_tag(self, rule):
         value = self.get_value()
         rule = self.clean_rule(rule)
-        return any(tag in value for tag in rule)
+        return rule in value
 
     def clean_rule(self, rule):
         return rule

--- a/care/utils/evaluators/evaluation_metric/base.py
+++ b/care/utils/evaluators/evaluation_metric/base.py
@@ -33,7 +33,7 @@ class EvaluationMetricBase:
     def evaluate_has_tag(self, rule):
         value = self.get_value()
         rule = self.clean_rule(rule)
-        return rule in value
+        return any(tag in value for tag in rule)
 
     def clean_rule(self, rule):
         return rule

--- a/care/utils/evaluators/evaluation_metric/encounter_tag.py
+++ b/care/utils/evaluators/evaluation_metric/encounter_tag.py
@@ -15,10 +15,15 @@ class EncounterTagsMetric(EvaluationMetricBase):
     ]
 
     def clean_rule(self, rule):
-        tag_config = TagConfig.objects.only("id").filter(external_id=rule).first()
+        tag_ids = rule.get("value", "").split(",")
+        tag_config = (
+            TagConfig.objects.only("id")
+            .filter(external_id__in=tag_ids)
+            .values_list("id", flat=True)
+        )
         if tag_config is None:
             return -1
-        return tag_config.id
+        return tag_config
 
     def get_value(self):
         encounter = self.context_object

--- a/care/utils/evaluators/evaluation_metric/encounter_tag.py
+++ b/care/utils/evaluators/evaluation_metric/encounter_tag.py
@@ -14,6 +14,12 @@ class EncounterTagsMetric(EvaluationMetricBase):
         AllowedOperations.has_tag.value,
     ]
 
+    def evaluate_has_tag(self, rule):
+        value = self.get_value()
+        self._value_type = rule.get("value_type", "encounter")
+        rule = self.clean_rule(rule)
+        return any(tag in value for tag in rule)
+
     def clean_rule(self, rule):
         tag_ids = rule.get("value", "").split(",")
         tag_config = (
@@ -28,11 +34,12 @@ class EncounterTagsMetric(EvaluationMetricBase):
     def get_value(self):
         encounter = self.context_object
         facility_external_id = str(encounter.facility.external_id)
+        if self._value_type == "encounter":
+            return [*encounter.tags]
         patient = encounter.patient
         patient_facility_tags = patient.facility_tags.get(facility_external_id, [])
         patient_instance_tags = patient.instance_tags
-        encounter_tags = encounter.tags
-        return [*patient_facility_tags, *patient_instance_tags, *encounter_tags]
+        return [*patient_facility_tags, *patient_instance_tags]
 
 
 EvaluatorMetricsRegistry.register(EncounterTagsMetric)

--- a/care/utils/evaluators/evaluation_metric/encounter_tag.py
+++ b/care/utils/evaluators/evaluation_metric/encounter_tag.py
@@ -15,8 +15,8 @@ class EncounterTagsMetric(EvaluationMetricBase):
     ]
 
     def evaluate_has_tag(self, rule):
-        value = self.get_value()
         self._value_type = rule.get("value_type", "encounter")
+        value = self.get_value()
         rule = self.clean_rule(rule)
         return any(tag in value for tag in rule)
 


### PR DESCRIPTION
## Proposed Changes

- add support for multiple tags
- use rule as dictionary for tags as well 
- value and value_type as keys, value_type would denote tag resource type - patient or encounter.

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins
