### PR TITLE
Add reset-and-setup command to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: logs
+.PHONY: logs reset-and-setup
 
 
 DOCKER_VERSION := $(shell docker --version 2>/dev/null)
@@ -76,6 +76,8 @@ load-db:
 reset-db:
 	docker compose exec db sh -c "dropdb -U postgres care -f"
 	docker compose exec db sh -c "createdb -U postgres care"
+
+reset-and-setup: reset-db migrate load-fixtures
 
 ruff-all:
 	ruff check .


### PR DESCRIPTION
Adds a new `reset-and-setup` command to the Makefile that combines the functionality of:

- `reset-db`: Clears and recreates the database
- `migrate`: Runs database migrations  
- `load-fixtures`: Loads fixture data

Usage:
```bash
make reset-and-setup
```

The command reuses existing make targets instead of duplicating code, making it maintainable and following make best practices.