### PR TITLE
fix:rename internal version field to _version

### DIFF
--- a/care/emr/resources/base.py
+++ b/care/emr/resources/base.py
@@ -70,7 +70,7 @@ class EMRResource(BaseModel):
                 **kwargs,
                 user=user,
             )
-        constructed["version"] = getattr(cls, "__version__", 0.1)
+        constructed["_version"] = getattr(cls, "__version__", 0.1)
         return cls.model_construct(**constructed)
 
     def get_context(self):

--- a/care/emr/resources/questionnaire/spec.py
+++ b/care/emr/resources/questionnaire/spec.py
@@ -179,7 +179,7 @@ class Question(QuestionnaireBaseSpec):
 
 
 class QuestionnaireWriteSpec(QuestionnaireBaseSpec):
-    version: str = Field("1.0", frozen=True, description="Version of the questionnaire")
+    version: str = Field(frozen=True, description="Version of the questionnaire")
     slug: SlugType | None = None
     title: str
     description: str | None = None

--- a/care/emr/resources/questionnaire/spec.py
+++ b/care/emr/resources/questionnaire/spec.py
@@ -179,7 +179,6 @@ class Question(QuestionnaireBaseSpec):
 
 
 class QuestionnaireWriteSpec(QuestionnaireBaseSpec):
-    version: str = Field(frozen=True, description="Version of the questionnaire")
     slug: SlugType | None = None
     title: str
     description: str | None = None
@@ -255,6 +254,7 @@ class QuestionnaireSpec(QuestionnaireWriteSpec):
 
     def perform_extra_deserialization(self, is_update, obj):
         obj._organizations = self.organizations  # noqa SLF001
+        obj.version = "1.0"  # Initial version
 
 
 class QuestionnaireUpdateSpec(QuestionnaireWriteSpec):

--- a/data/questionnaire_fixtures.json
+++ b/data/questionnaire_fixtures.json
@@ -2,7 +2,6 @@
     {
         "id": "2c2e0b28-09ee-4822-ae78-d8bc5802b506",
         "slug": "respiratory-support",
-        "version": "1.0",
         "title": "Respiratory Support record IPD",
         "description": "",
         "status": "active",
@@ -54,7 +53,6 @@
     {
         "id": "f8af46b5-a559-43e8-8b0d-a500fae6416f",
         "slug": "ongoing_medication",
-        "version": "1.0",
         "title": "Ongoing Medication",
         "description": "",
         "status": "active",
@@ -78,7 +76,6 @@
     {
         "id": "6da0dcf8-94f9-4979-bc2a-ed7dab59ee25",
         "slug": "medicine",
-        "version": "1.0",
         "title": "Medicine",
         "description": "",
         "status": "active",
@@ -116,7 +113,6 @@
     {
         "id": "3e65b2ae-0707-438d-891e-fa24705e92ee",
         "slug": "test-diagnosis",
-        "version": "1.0",
         "title": "Diagnosis",
         "description": "",
         "status": "active",
@@ -147,7 +143,6 @@
     {
         "id": "3d95fc31-85b7-42dc-aeab-4f706d9a42d7",
         "slug": "death-form-V4",
-        "version": "1.0",
         "title": "Death Form",
         "description": "",
         "status": "active",
@@ -166,7 +161,6 @@
     {
         "id": "d7e6329d-8edc-4720-8753-6bf96747fed5",
         "slug": "patient_feedback",
-        "version": "1.0",
         "title": "Feedback Form  (NCG - Patient)",
         "description": "",
         "status": "active",
@@ -212,7 +206,6 @@
     {
         "id": "3081bed6-b694-42ec-87a8-666c3fd0ae36",
         "slug": "respiratory_status-v3",
-        "version": "1.0",
         "title": "Respiratory Status",
         "description": "A form to document respiratory status, including bilateral air entry and respiratory support details.",
         "status": "active",
@@ -392,7 +385,6 @@
     {
         "id": "742aec8d-0d5e-45e0-b150-07f99e7142b6",
         "slug": "ncgdoctornotes",
-        "version": "1.0",
         "title": "Doctors Notes NCG",
         "description": "",
         "status": "active",

--- a/data/questionnaire_fixtures.json
+++ b/data/questionnaire_fixtures.json
@@ -2,7 +2,7 @@
     {
         "id": "2c2e0b28-09ee-4822-ae78-d8bc5802b506",
         "slug": "respiratory-support",
-        "version": "",
+        "version": "1.0",
         "title": "Respiratory Support record IPD",
         "description": "",
         "status": "active",
@@ -54,7 +54,7 @@
     {
         "id": "f8af46b5-a559-43e8-8b0d-a500fae6416f",
         "slug": "ongoing_medication",
-        "version": "",
+        "version": "1.0",
         "title": "Ongoing Medication",
         "description": "",
         "status": "active",
@@ -78,7 +78,7 @@
     {
         "id": "6da0dcf8-94f9-4979-bc2a-ed7dab59ee25",
         "slug": "medicine",
-        "version": "",
+        "version": "1.0",
         "title": "Medicine",
         "description": "",
         "status": "active",
@@ -116,7 +116,7 @@
     {
         "id": "3e65b2ae-0707-438d-891e-fa24705e92ee",
         "slug": "test-diagnosis",
-        "version": "",
+        "version": "1.0",
         "title": "Diagnosis",
         "description": "",
         "status": "active",
@@ -147,7 +147,7 @@
     {
         "id": "3d95fc31-85b7-42dc-aeab-4f706d9a42d7",
         "slug": "death-form-V4",
-        "version": "",
+        "version": "1.0",
         "title": "Death Form",
         "description": "",
         "status": "active",
@@ -166,7 +166,7 @@
     {
         "id": "d7e6329d-8edc-4720-8753-6bf96747fed5",
         "slug": "patient_feedback",
-        "version": "",
+        "version": "1.0",
         "title": "Feedback Form  (NCG - Patient)",
         "description": "",
         "status": "active",
@@ -212,7 +212,7 @@
     {
         "id": "3081bed6-b694-42ec-87a8-666c3fd0ae36",
         "slug": "respiratory_status-v3",
-        "version": "",
+        "version": "1.0",
         "title": "Respiratory Status",
         "description": "A form to document respiratory status, including bilateral air entry and respiratory support details.",
         "status": "active",
@@ -392,7 +392,7 @@
     {
         "id": "742aec8d-0d5e-45e0-b150-07f99e7142b6",
         "slug": "ncgdoctornotes",
-        "version": "",
+        "version": "1.0",
         "title": "Doctors Notes NCG",
         "description": "",
         "status": "active",


### PR DESCRIPTION
## Proposed Changes

- Renamed constructed["version"] to constructed["_version"] in EMRResource 
serialization to prevent overwriting the version field for models

- Updated the version field in questionnaire json

### Associated Issue

- https://github.com/ohcnetwork/care_fe/pull/14012

## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins
