### PR TITLE
Add Windows support for make up command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
 .PHONY: logs reset-and-setup
 
 
-DOCKER_VERSION := $(shell docker --version 2>/dev/null)
+ifeq ($(OS),Windows_NT)
+    DOCKER_VERSION := $(shell docker --version 2> NUL)
+else
+    DOCKER_VERSION := $(shell docker --version 2>/dev/null)
+endif
+
 
 docker_config_file := 'docker-compose.local.yaml'
 


### PR DESCRIPTION
## Proposed Changes

- Added Windows compatibility for the `make up` command in the `Makefile`.
- This allows contributors using Windows OS to start and manage the project setup without errors.
- The script now automatically detects the OS and executes appropriate commands for Windows and Unix-like systems.

### Associated Issue

- No existing issue was opened for this.  
- Found and fixed the issue while setting up the project on Windows — previously, the `make up` command failed due to unsupported shell commands.

### Architecture changes

- No architecture-level changes made.  
- Only improvements in the `Makefile` to ensure cross-platform support.

## Merge Checklist

- [x] Tests added/fixed (manual verification on Windows)
- [x] Update docs in `/docs` (if applicable)
- [x] Linting Complete
- [x] Any other necessary step (ensured backward compatibility with Unix-based systems)

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins
