### PR TITLE
Add 'net_content' to ordering fields in InventoryItemViewSet

### DIFF
--- a/care/emr/api/viewsets/inventory/inventory_item.py
+++ b/care/emr/api/viewsets/inventory/inventory_item.py
@@ -32,7 +32,7 @@ class InventoryItemViewSet(EMRRetrieveMixin, EMRListMixin, EMRBaseViewSet):
     pydantic_retrieve_model = InventoryItemRetrieveSpec
     filterset_class = InventoryItemFilters
     filter_backends = [filters.DjangoFilterBackend, OrderingFilter]
-    ordering_fields = ["created_date", "modified_date"]
+    ordering_fields = ["created_date", "modified_date", "net_content"]
 
     def get_location_obj(self):
         return get_object_or_404(


### PR DESCRIPTION
## Proposed Changes
Add 'net_content' to ordering fields in InventoryItemViewSet

### Associated Issue
https://github.com/ohcnetwork/care_fe/issues/14302


## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to sort inventory items by net content, providing additional filtering options alongside existing date-based sorting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->