### PR TITLE
Enable PlugConfig API

### DIFF
--- a/config/api_router.py
+++ b/config/api_router.py
@@ -103,10 +103,13 @@ from care.emr.api.viewsets.user import UserViewSet
 from care.emr.api.viewsets.valueset import ValueSetViewSet
 from care.security.api.viewsets.permissions import PermissionViewSet
 from care.security.api.viewsets.roles import RoleViewSet
+from care.users.api.viewsets.plug_config import PlugConfigViewset
 
 router = DefaultRouter() if settings.DEBUG else SimpleRouter()
 
 router.register("users", UserViewSet, basename="users")
+
+router.register("plug_config", PlugConfigViewset, basename="plug_configs")
 
 user_nested_router = NestedSimpleRouter(router, r"users", lookup="users")
 


### PR DESCRIPTION
## Proposed Changes

- The Plugin Config APIs are re-enabled which is required for https://github.com/ohcnetwork/care_fe/pull/14121

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New API endpoint for plug configuration management now available, enabling programmatic access to manage and retrieve plug configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->