### PR TITLE
fix deadlock in TagConfig endpoints

### DIFF
--- a/care/emr/models/tag_config.py
+++ b/care/emr/models/tag_config.py
@@ -84,7 +84,9 @@ class TagConfig(EMRBaseModel):
                     timezone.now() + timedelta(days=self.cache_expiry_days)
                 ),
             }
-            self.save(update_fields=["cached_parent_json"])
+            TagConfig.objects.filter(id=self.id).update(
+                cached_parent_json=self.cached_parent_json
+            )
             return self.cached_parent_json
         return {}
 


### PR DESCRIPTION
## Proposed Changes

- Fixing deadlock causing in GET and LIST endpoint of tag config.
### Cause
GET/LIST endpoints were calling .save(), which triggered the post_save signal used for cache invalidation. Since reads don't change data, they shouldn't invalidate cache. This caused recursive invalidation cascades and deadlocks.

---
_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal caching mechanism to improve performance by reducing unnecessary processing overhead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->