### PR TITLE
add file authz for service request and diagnostic reports

### DIFF
--- a/care/emr/api/viewsets/file_upload.py
+++ b/care/emr/api/viewsets/file_upload.py
@@ -22,6 +22,8 @@ from care.emr.api.viewsets.base import (
 )
 from care.emr.models import Encounter, FileUpload, Patient
 from care.emr.models.consent import Consent
+from care.emr.models.diagnostic_report import DiagnosticReport
+from care.emr.models.service_request import ServiceRequest
 from care.emr.resources.file_upload.spec import (
     FileTypeChoices,
     FileUploadCreateSpec,
@@ -33,7 +35,7 @@ from care.security.authorization import AuthorizationController
 from care.utils.shortcuts import get_object_or_404
 
 
-def file_authorizer(user, file_type, associating_id, permission):
+def file_authorizer(user, file_type, associating_id, permission):  # noqa PLR0912
     allowed = False
     if file_type == FileTypeChoices.patient.value:
         patient_obj = get_object_or_404(Patient, external_id=associating_id)
@@ -69,12 +71,34 @@ def file_authorizer(user, file_type, associating_id, permission):
             allowed = AuthorizationController.call(
                 "can_update_encounter_obj", user, encounter_obj
             )
-    elif file_type in [
-        FileTypeChoices.diagnostic_report.value,
-        FileTypeChoices.service_request.value,
-    ]:
-        # TODO : AuthZ Pending
-        allowed = True
+    elif file_type == FileTypeChoices.diagnostic_report.value:
+        diagnostic_report_obj = get_object_or_404(
+            DiagnosticReport, external_id=associating_id
+        )
+        if permission == "read":
+            allowed = AuthorizationController.call(
+                "can_read_diagnostic_report",
+                user,
+                diagnostic_report_obj.service_request,
+            )
+        elif permission == "write":
+            allowed = AuthorizationController.call(
+                "can_write_diagnostic_report",
+                user,
+                diagnostic_report_obj.service_request,
+            )
+    elif file_type == FileTypeChoices.service_request.value:
+        service_request_obj = get_object_or_404(
+            ServiceRequest, external_id=associating_id
+        )
+        if permission == "read":
+            allowed = AuthorizationController.call(
+                "can_read_service_request", user, service_request_obj
+            )
+        elif permission == "write":
+            allowed = AuthorizationController.call(
+                "can_write_service_request", user, service_request_obj
+            )
     if not allowed:
         raise PermissionDenied("Cannot View File")
 


### PR DESCRIPTION

- Added authz for in file upload for service request and diagnostic reports



_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented explicit authorization controls for diagnostic reports and service request files.
  * Enhanced file access security with proper permission checks enforced during read and write operations.
  * Maintains consistent access denial messaging when users lack required permissions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->