### PR TITLE
Fixes facility filter when used along with include_instance for product knowledge

### DIFF
--- a/care/emr/api/viewsets/inventory/product_knowledge.py
+++ b/care/emr/api/viewsets/inventory/product_knowledge.py
@@ -23,14 +23,18 @@ from care.emr.resources.inventory.product_knowledge.spec import (
 )
 from care.facility.models.facility import Facility
 from care.security.authorization.base import AuthorizationController
-from care.utils.filters.dummy_filter import DummyBooleanFilter, DummyCharFilter
+from care.utils.filters.dummy_filter import (
+    DummyBooleanFilter,
+    DummyCharFilter,
+    DummyUUIDFilter,
+)
 from care.utils.filters.null_filter import NullFilter
 from care.utils.shortcuts import get_object_or_404
 
 
 class ProductKnowledgeFilters(filters.FilterSet):
     status = filters.CharFilter(lookup_expr="iexact")
-    facility = filters.UUIDFilter(field_name="facility__external_id")
+    facility = DummyUUIDFilter()
     name = filters.CharFilter(lookup_expr="icontains")  # TODO : Need better searching
     product_type = filters.CharFilter(lookup_expr="iexact")
     facility_is_null = NullFilter(field_name="facility")


### PR DESCRIPTION


## Proposed Changes

- Fixes facility filter when used along with include_instance for product knowledge

### Associated Issue

- Link to issue here, explain how the proposed solution will solve the reported issue/ feature request.

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated facility filtering logic in product knowledge inventory to improve lookup accuracy and null value handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->