### PR TITLE
fixes `ADDITIONAL_PLUGS` env not read during docker builds for install_plugins

### DIFF
--- a/docker-compose.coolify.yaml
+++ b/docker-compose.coolify.yaml
@@ -8,6 +8,8 @@ services:
     build:
       context: .
       dockerfile: docker/dev.Dockerfile
+      args:
+        ADDITIONAL_PLUGS: ${ADDITIONAL_PLUGS:-}
     env_file:
       - ./docker/.local.env
     volumes:

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -1,15 +1,16 @@
-
 services:
   backend:
     image: care_local
     build:
       context: .
       dockerfile: docker/dev.Dockerfile
+      args:
+        ADDITIONAL_PLUGS: ${ADDITIONAL_PLUGS:-}
     env_file:
       - ./docker/.local.env
     volumes:
       - .:/app
-    entrypoint: [ "bash", "scripts/start-dev.sh" ]
+    entrypoint: ["bash", "scripts/start-dev.sh"]
     ports:
       - "9000:9000"
       - "9876:9876" #debugpy
@@ -26,7 +27,7 @@ services:
     image: care_local
     env_file:
       - ./docker/.local.env
-    entrypoint: [ "bash", "scripts/celery-dev.sh" ]
+    entrypoint: ["bash", "scripts/celery-dev.sh"]
     restart: unless-stopped
     depends_on:
       - db

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -24,6 +24,9 @@ RUN --mount=type=cache,target=/root/.cache/pip pip install pipenv==2024.4.0
 COPY Pipfile Pipfile.lock $APP_HOME/
 RUN --mount=type=cache,target=/root/.cache/pip pipenv  install --system --categories "packages dev-packages docs"
 
+ARG ADDITIONAL_PLUGS=""
+ENV ADDITIONAL_PLUGS=$ADDITIONAL_PLUGS
+
 COPY . $APP_HOME/
 
 RUN --mount=type=cache,target=/root/.cache/pip python3 $APP_HOME/install_plugins.py

--- a/docker/prod.Dockerfile
+++ b/docker/prod.Dockerfile
@@ -33,11 +33,11 @@ RUN python -m venv $APP_HOME/.venv
 COPY Pipfile Pipfile.lock $APP_HOME/
 RUN pipenv install --deploy --categories "packages"
 
-ARG ADDITIONAL_PLUGS=""
-ENV ADDITIONAL_PLUGS=$ADDITIONAL_PLUGS
-
 COPY plugs/ $APP_HOME/plugs/
 COPY install_plugins.py plug_config.py $APP_HOME/
+
+ARG ADDITIONAL_PLUGS=""
+ENV ADDITIONAL_PLUGS=$ADDITIONAL_PLUGS
 RUN python3 $APP_HOME/install_plugins.py
 
 # ---


### PR DESCRIPTION
## Proposed Changes

The envs are not accessible during docker build. If `ADDITIONAL_PLUGS` env was set, `install_plugins` step would not be able to read them during docker builds and when the container runs, it'd fail as the container expects these plugs to be installed.

- fixes `ADDITIONAL_PLUGS` env not read during docker builds for install_plugins, using build args

### Associated Issue

- The envs are not accessible during docker build. If `ADDITIONAL_PLUGS` env was set, `install_plugins` step would not be able to read them during docker builds and when the container runs, it'd fail as the container expects these plugs to be installed.

## Merge Checklist

- [x] Linting Complete
- [x] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker build configuration to support optional dynamic plugin installation through configurable environment variables, enabling more flexible deployments in both development and production environments
  * Standardized container service entrypoint syntax formatting for consistency across configuration files

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->