### PR TITLE
fix race condition in test cases

### DIFF
--- a/care/utils/tests/base.py
+++ b/care/utils/tests/base.py
@@ -56,7 +56,13 @@ class CareAPITestBase(APITestCase):
         return baker.make(RoleModel, **kwargs)
 
     def create_role_with_permissions(self, permissions, role_name=None):
+        from django.core.cache import cache
+
         from care.security.models import PermissionModel, RoleModel, RolePermission
+        from care.security.models.role import (
+            ROLE_PERMISSION_SK_CACHE_KEY,
+            ROLE_PERMISSIONS_CACHE_KEY,
+        )
 
         role = baker.make(RoleModel, name=role_name or self.fake.name())
 
@@ -68,6 +74,10 @@ class CareAPITestBase(APITestCase):
             )
             bulk.append(RolePermission(role=role, permission=permission_obj))
         RolePermission.objects.bulk_create(bulk)
+
+        # bulk_create wasn't triggering post_save, so manually clearing cache
+        cache.delete(ROLE_PERMISSIONS_CACHE_KEY.format(role.id))
+        cache.delete(ROLE_PERMISSION_SK_CACHE_KEY.format(role.id))
         return role
 
     def create_patient(self, **kwargs):


### PR DESCRIPTION
## Proposed Changes

We were using bulk_create in our test cases for creating permissions for role, but bulk_creaet doesn't trigger the post_save signal we have to clear the cache, which was the cause of error. 

Due to --shuffle flag the error was caused randomly cause one test was creating permissions which were not deleted from cache and then they were getting used in the next test providing invalid data 


_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role permission cache synchronization to ensure changes are immediately reflected in the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->