### PR TITLE
Fix unpacking of parent_cache in authorization classes for booking, scheduling, and token access

### DIFF
--- a/care/security/authorization/booking.py
+++ b/care/security/authorization/booking.py
@@ -64,7 +64,7 @@ class BookingAccess(AuthorizationHandler):
         """
         if obj.managing_organization:
             orgs = [
-                obj.managing_organization.parent_cache,
+                *obj.managing_organization.parent_cache,
                 obj.managing_organization.id,
             ]
             return self.check_permission_in_facility_organization(
@@ -124,7 +124,7 @@ class BookingAccess(AuthorizationHandler):
         """
         if obj.managing_organization:
             orgs = [
-                obj.managing_organization.parent_cache,
+                *obj.managing_organization.parent_cache,
                 obj.managing_organization.id,
             ]
             return self.check_permission_in_facility_organization(

--- a/care/security/authorization/scheduling.py
+++ b/care/security/authorization/scheduling.py
@@ -67,7 +67,7 @@ class ScheduleAccess(AuthorizationHandler):
         """
         if obj.managing_organization:
             orgs = [
-                obj.managing_organization.parent_cache,
+                *obj.managing_organization.parent_cache,
                 obj.managing_organization.id,
             ]
             return self.check_permission_in_facility_organization(
@@ -106,7 +106,7 @@ class ScheduleAccess(AuthorizationHandler):
         """
         if obj.managing_organization:
             orgs = [
-                obj.managing_organization.parent_cache,
+                *obj.managing_organization.parent_cache,
                 obj.managing_organization.id,
             ]
             return self.check_permission_in_facility_organization(

--- a/care/security/authorization/token.py
+++ b/care/security/authorization/token.py
@@ -114,7 +114,7 @@ class TokenAccess(AuthorizationHandler):
         """
         if obj.managing_organization:
             orgs = [
-                obj.managing_organization.parent_cache,
+                *obj.managing_organization.parent_cache,
                 obj.managing_organization.id,
             ]
             return self.check_permission_in_facility_organization(
@@ -153,7 +153,7 @@ class TokenAccess(AuthorizationHandler):
         """
         if obj.managing_organization:
             orgs = [
-                obj.managing_organization.parent_cache,
+                *obj.managing_organization.parent_cache,
                 obj.managing_organization.id,
             ]
             return self.check_permission_in_facility_organization(


### PR DESCRIPTION
## Proposed Changes

- [CARE-H6R](https://coronasafe-network.sentry.io/issues/6943194078/events/1344ae63a88146a8971f50119549a54a/)

if obj.managing_organization.parent_cache is an empty array django refuses to use it for __in lookup
obj.managing_organization.parent_cache is an array by default

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved authorization and permission checks to properly evaluate complete organization hierarchies across booking, scheduling, and token operations, ensuring correct access control in multi-level organizational structures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->