### PR TITLE
Fixed required patient identifier validation in patient specs

### DIFF
--- a/care/emr/resources/patient/spec.py
+++ b/care/emr/resources/patient/spec.py
@@ -122,8 +122,8 @@ class PatientCreateSpec(PatientBaseSpec):
         instance_identifier_configs = PatientIdentifierConfigCache.get_instance_config()
         configs = {str(x.config): x for x in self.identifiers}
         for identifier_config in instance_identifier_configs:
-            if identifier_config["id"] in configs:
-                value = configs[identifier_config["id"]].value
+            if str(identifier_config["id"]) in configs:
+                value = configs[str(identifier_config["id"])].value
                 validate_identifier_config(identifier_config, value)
             elif identifier_config["config"]["required"]:
                 err = f"Identifier config {identifier_config['config']['system']} is required"
@@ -193,8 +193,8 @@ class PatientUpdateSpec(PatientBaseSpec):
         instance_identifier_configs = PatientIdentifierConfigCache.get_instance_config()
         configs = {str(x.config): x for x in identifiers}
         for identifier_config in instance_identifier_configs:
-            if identifier_config["id"] in configs:
-                value = configs[identifier_config["id"]].value
+            if str(identifier_config["id"]) in configs:
+                value = configs[str(identifier_config["id"])].value
                 validate_identifier_config(
                     identifier_config, value, info.context.get("object")
                 )


### PR DESCRIPTION
## Proposed Changes

- Fix required patient identifier validation in patient create and update spec; When we check for patient identifier config id, we are comparing string to uuid, so it is always false, fixed that by converting uuid to string while checking.

### Associated Issue

- https://github.com/ohcnetwork/care_fe/issues/14598


## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced identifier configuration validation to ensure more reliable and consistent handling during patient record creation and updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->