### PR TITLE
update docker backup doc link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ make teardown
 Prebuilt docker images for server deployments are available
 on [ghcr](https://github.com/ohcnetwork/care/pkgs/container/care)
 
-For backup and restore use [this](/docs/databases/backup.rst) documentation.
+For backup and restore use [this](/docs/setup/database-backup.rst) documentation.
 
 ## Contributing
 


### PR DESCRIPTION
## Proposed Changes

This pull request makes a minor documentation update to the backup and restore instructions in the `README.md` file. The change updates the link to point to the correct backup documentation.

- Updated the backup and restore documentation link in `README.md` to `/docs/setup/database-backup.rst` for accuracy.

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated database backup documentation reference in README to reflect new location.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->