### PR TITLE
fix:save updated_by user data for custom invoice apis

### DIFF
--- a/care/emr/api/viewsets/invoice.py
+++ b/care/emr/api/viewsets/invoice.py
@@ -194,6 +194,7 @@ class InvoiceViewSet(
                     charge_items.values_list("id", flat=True)
                 )
                 sync_invoice_items(invoice)
+                invoice.updated_by = self.request.user
                 invoice.save()
                 charge_items.update(
                     status=ChargeItemStatusOptions.billed.value, paid_invoice=invoice
@@ -219,6 +220,7 @@ class InvoiceViewSet(
                 with transaction.atomic():
                     invoice.charge_items.remove(charge_item.id)
                     sync_invoice_items(invoice)
+                    invoice.updated_by = self.request.user
                     invoice.save()
                     charge_item.status = ChargeItemStatusOptions.billable.value
                     charge_item.paid_invoice = None
@@ -241,6 +243,7 @@ class InvoiceViewSet(
                 )
                 invoice.charge_items = charge_items.values_list("id", flat=True)
                 sync_invoice_items(invoice)
+                invoice.updated_by = self.request.user
                 invoice.save()
                 charge_items.update(
                     status=ChargeItemStatusOptions.billed.value, paid_invoice=invoice
@@ -268,5 +271,6 @@ class InvoiceViewSet(
                 ).update(
                     status=ChargeItemStatusOptions.billable.value, paid_invoice=None
                 )
+                invoice.updated_by = self.request.user
                 invoice.save()
         return Response(InvoiceRetrieveSpec.serialize(invoice).to_json())


### PR DESCRIPTION
## Proposed Changes

- added updated_by for the custom invoice apis
- https://github.com/ohcnetwork/care_fe/pull/14538
- https://github.com/ohcnetwork/care_fe/issues/14537

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced invoice operation tracking to record the user responsible for updates across invoice modifications, including item attachment, removal, account association, and cancellation actions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->