### PR TITLE
fix:updated the extension field in delivery order spec

### DIFF
--- a/care/emr/resources/inventory/supply_delivery/delivery_order.py
+++ b/care/emr/resources/inventory/supply_delivery/delivery_order.py
@@ -41,12 +41,6 @@ class BaseSupplyDeliveryOrderSpec(EMRResource):
     status: SupplyDeliveryOrderStatusOptions
     name: str
     note: str | None = None
-
-
-class SupplyDeliveryOrderWriteSpec(BaseSupplyDeliveryOrderSpec):
-    supplier: UUID4 | None = None
-    origin: UUID4 | None = None
-    destination: UUID4
     extensions: dict
 
     @field_validator("extensions")
@@ -57,6 +51,12 @@ class SupplyDeliveryOrderWriteSpec(BaseSupplyDeliveryOrderSpec):
         except Exception as e:
             raise ValueError("Invalid additional metadata") from e
         return v
+
+
+class SupplyDeliveryOrderWriteSpec(BaseSupplyDeliveryOrderSpec):
+    supplier: UUID4 | None = None
+    origin: UUID4 | None = None
+    destination: UUID4
 
     def perform_extra_deserialization(self, is_update, obj):
         obj.destination = get_object_or_404(
@@ -83,7 +83,6 @@ class SupplyDeliveryOrderReadSpec(BaseSupplyDeliveryOrderSpec):
     destination: dict
     supplier: dict | None = None
     tags: list[dict] = []
-    extensions: dict
 
     @classmethod
     def perform_extra_serialization(cls, mapping, obj):


### PR DESCRIPTION
## Proposed Changes

- Updated the BaseSupplyDeliveryOrderSpec with extensions
 
## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured supply delivery order data models to improve consistency between read and write operations.
  * Made the origin field optional for supply delivery orders (previously required).
  * Removed extensions field from supply delivery read operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->