### PR TITLE
fix:updated chargeitem in sr cancel api

### DIFF
--- a/care/emr/api/viewsets/service_request.py
+++ b/care/emr/api/viewsets/service_request.py
@@ -281,8 +281,8 @@ class ServiceRequestViewSet(
                 service_resource=ChargeItemResourceOptions.service_request.value,
             ):
                 handle_charge_item_cancel(charge_item)
-                instance.charge_item.status = ChargeItemStatusOptions.aborted.value
-                instance.charge_item.save()
+                charge_item.status = ChargeItemStatusOptions.aborted.value
+                charge_item.save()
             instance.save(update_fields=["status", "updated_by"])
         return Response(status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
## Proposed Changes

- updated instance.charge_item.status to charge_item.status

### Associated Issue

- [ISSUE](https://coronasafe-network.sentry.io/issues/7134077581/?query=is%3Aunresolved&referrer=issue-stream) ServiceRequest' object has no attribute 'charge_item

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the service request cancellation process where charge item statuses were not being updated correctly. The cancellation workflow now properly updates and saves the status for each charge item associated with the cancelled service request, ensuring accurate billing records and proper reflection of cancellation status throughout the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->