### PR TITLE
Fix title and description  for manage users permission

### DIFF
--- a/care/security/permissions/facility_organization.py
+++ b/care/security/permissions/facility_organization.py
@@ -65,8 +65,8 @@ class FacilityOrganizationPermissions(enum.Enum):
         ],
     )
     can_manage_facility_organization_users = Permission(
-        "Can Manage Users in an Organizations",
-        "",
+        "Can Manage Users in a Facility Organization",
+        "Add, remove, and assign roles to users in a facility organization",
         PermissionContext.FACILITY_ORGANIZATION,
         [FACILITY_ADMIN_ROLE, ADMINISTRATOR],
     )

--- a/care/security/permissions/organization.py
+++ b/care/security/permissions/organization.py
@@ -48,8 +48,8 @@ class OrganizationPermissions(enum.Enum):
         [ADMIN_ROLE],
     )
     can_manage_organization_users = Permission(
-        "Can Manage Users in an Organizations",
-        "",
+        "Can Manage Users in an Organization",
+        "Add, remove, and assign roles to users in an organization",
         PermissionContext.ORGANIZATION,
         [ADMIN_ROLE, ADMINISTRATOR, FACILITY_ADMIN_ROLE],
     )


### PR DESCRIPTION
## Proposed Changes

- Fix the title and add description for `can_manage_facility_organization_users`, `can_manage_organization_users`

### Associated Issue

- Link to issue here, explain how the proposed solution will solve the reported issue/ feature request.

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated permission labels and descriptions for user management permissions to provide clearer, more specific naming and functionality guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->