### PR TITLE
fix:added requester field in DiagnosticReportRetrieveSpec

### DIFF
--- a/care/emr/resources/diagnostic_report/spec.py
+++ b/care/emr/resources/diagnostic_report/spec.py
@@ -6,13 +6,14 @@ from pydantic import UUID4
 from care.emr.models.diagnostic_report import DiagnosticReport
 from care.emr.models.observation import Observation
 from care.emr.models.service_request import ServiceRequest
-from care.emr.resources.base import EMRResource
+from care.emr.resources.base import EMRResource, model_from_cache
 from care.emr.resources.diagnostic_report.valueset import (
     DIAGNOSTIC_SERVICE_SECTIONS_CODE_VALUESET,
 )
 from care.emr.resources.encounter.spec import EncounterListSpec
 from care.emr.resources.observation.spec import ObservationRetrieveSpec
 from care.emr.resources.observation.valueset import CARE_OBSERVATION_VALUSET
+from care.emr.resources.user.spec import UserSpec
 from care.emr.utils.valueset_coding_type import ValueSetBoundCoding
 from care.utils.shortcuts import get_object_or_404
 
@@ -65,6 +66,7 @@ class DiagnosticReportRetrieveSpec(DiagnosticReportListSpec):
 
     created_by: dict | None = None
     updated_by: dict | None = None
+    requester: dict | None = None
 
     @classmethod
     def perform_extra_serialization(cls, mapping, obj):
@@ -77,3 +79,7 @@ class DiagnosticReportRetrieveSpec(DiagnosticReportListSpec):
             for observation in observations
         ]
         mapping["encounter"] = EncounterListSpec.serialize(obj.encounter).to_json()
+        if obj.service_request:
+            mapping["requester"] = (
+                model_from_cache(UserSpec, id=obj.service_request.requester_id),
+            )

--- a/care/emr/resources/diagnostic_report/spec.py
+++ b/care/emr/resources/diagnostic_report/spec.py
@@ -79,7 +79,5 @@ class DiagnosticReportRetrieveSpec(DiagnosticReportListSpec):
             for observation in observations
         ]
         mapping["encounter"] = EncounterListSpec.serialize(obj.encounter).to_json()
-        if obj.service_request:
-            mapping["requester"] = (
-                model_from_cache(UserSpec, id=obj.service_request.requester_id),
-            )
+        if obj.service_request_id:
+            mapping["requester"] = model_from_cache(UserSpec, id=obj.service_request.requester_id)


### PR DESCRIPTION
## Proposed Changes

- Added SR requester field in the DiagnosticReportRetrieveSpec

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diagnostic reports now include requester details when a service request is associated, showing who requested the report.
  * If no requester is associated, reports remain unchanged (requester field will be empty).
  * Provides additional context for clinicians and downstream workflows.
  * Visible wherever diagnostic reports are viewed; no changes to existing privacy or access controls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->