### PR TITLE
fix: add install pip using pipenv

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -50,7 +50,7 @@ python-magic = {version = "==0.4.28", index = "python-magic-bin"}
 django-import-export = "==4.3.14"
 evalidate = "==2.1.1"
 weasyprint = "==67.0"
-pip = "*"
+pip = "==25.3"
 
 [dev-packages]
 boto3-stubs = { extras = ["s3", "boto3"], version = "*" }

--- a/Pipfile
+++ b/Pipfile
@@ -50,6 +50,7 @@ python-magic = {version = "==0.4.28", index = "python-magic-bin"}
 django-import-export = "==4.3.14"
 evalidate = "==2.1.1"
 weasyprint = "==67.0"
+pip = "*"
 
 [dev-packages]
 boto3-stubs = { extras = ["s3", "boto3"], version = "*" }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "127392963ebecb7f1c9b64bb2f529ac75030d0b2384cda465021f6db84cb8b3e"
+            "sha256": "b6dc43295beaa7969573f5a089028ccb2003e467ddd827436b2de369af145134"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1622,6 +1622,15 @@
             "index": "pypi",
             "markers": "python_version >= '3.10'",
             "version": "==12.0.0"
+        },
+        "pip": {
+            "hashes": [
+                "sha256:8d0538dbbd7babbd207f261ed969c65de439f6bc9e5dbd3b3b9a77f25d95f343",
+                "sha256:9655943313a94722b7774661c21049070f6bbb0a1516bf02f7c8d5d9201514cd"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==25.3"
         },
         "ply": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b6dc43295beaa7969573f5a089028ccb2003e467ddd827436b2de369af145134"
+            "sha256": "9a570702c8b994690ffdfbd95b966ca49a8a76861528fd831935ad55ebadbf12"
         },
         "pipfile-spec": 6,
         "requires": {


### PR DESCRIPTION
## Proposed Changes

- fix: add install pip using pipenv
- recently heroku updated the buildpacks which excluded the pip installation of pipenv is dected [ref](https://github.com/heroku/heroku-buildpack-python/blob/main/CHANGELOG.md#v292---2025-07-23).
- explicitely installing pip in the virtual environment resolves the issue

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Added pip as an explicit project dependency to ensure consistent package management and reproducible environments across installations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->