### PR TITLE
Use string values for superadmin gender,user_type

### DIFF
--- a/care/users/models.py
+++ b/care/users/models.py
@@ -37,8 +37,8 @@ class CustomUserManager(UserManager):
 
     def create_superuser(self, username, email, password, **extra_fields):
         extra_fields["phone_number"] = "+919696969696"
-        extra_fields["gender"] = 3
-        extra_fields["user_type"] = 40
+        extra_fields["gender"] = "male"
+        extra_fields["user_type"] = "administrator"
         return super().create_superuser(username, email, password, **extra_fields)
 
     def make_random_password(

--- a/care/users/models.py
+++ b/care/users/models.py
@@ -37,7 +37,7 @@ class CustomUserManager(UserManager):
 
     def create_superuser(self, username, email, password, **extra_fields):
         extra_fields["phone_number"] = "+919696969696"
-        extra_fields["gender"] = "male"
+        extra_fields["gender"] = "non_binary"
         extra_fields["user_type"] = "administrator"
         return super().create_superuser(username, email, password, **extra_fields)
 


### PR DESCRIPTION
## Proposed Changes

- Use spec conformant values for user_type and gender in createsuperadmin method

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed superuser creation so gender and user-type values are stored in a consistent, correct format to prevent mismatches and improve account setup reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->