### PR TITLE
fix:updated the account retrive spec parent class

### DIFF
--- a/care/emr/resources/account/spec.py
+++ b/care/emr/resources/account/spec.py
@@ -88,7 +88,7 @@ class AccountReadSpec(AccountMinimalReadSpec):
         mapping["tags"] = SingleFacilityTagManager().render_tags(obj)
 
 
-class AccountRetrieveSpec(AccountMinimalReadSpec):
+class AccountRetrieveSpec(AccountReadSpec):
     """Account retrieve specification"""
 
     patient: dict


### PR DESCRIPTION
## Proposed Changes

- updated the parent class of Account retrieve spec to Account read spec

### Associated Issue

- Not listing account related tags in Account retrieve spec

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Account retrieval now returns expanded data fields, including patient and tags information, providing more complete account details in API responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->