### PR TITLE
switch to retrieve spec for payment reconciliation in invoice retrieve

### DIFF
--- a/care/emr/resources/invoice/spec.py
+++ b/care/emr/resources/invoice/spec.py
@@ -12,7 +12,7 @@ from care.emr.resources.account.spec import AccountMinimalReadSpec, AccountReadS
 from care.emr.resources.base import EMRResource, model_from_cache
 from care.emr.resources.charge_item.spec import ChargeItemReadSpec
 from care.emr.resources.payment_reconciliation.spec import (
-    PaymentReconciliationMinimalReadSpec,
+    PaymentReconciliationRetrieveSpec,
 )
 from care.emr.resources.user.spec import UserSpec
 
@@ -108,7 +108,7 @@ class InvoiceRetrieveSpec(InvoiceReadSpec):
         total_payments = Decimal(0)
         for payment in PaymentReconciliation.objects.filter(target_invoice=obj):
             payments.append(
-                PaymentReconciliationMinimalReadSpec.serialize(payment).to_json()
+                PaymentReconciliationRetrieveSpec.serialize(payment).to_json()
             )
             total_payments += payment.amount
         mapping["total_payments"] = total_payments


### PR DESCRIPTION
## Proposed Changes

- Switch to using payment reconciliation retrieve spec (need payment location for invoice retrieve).

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated payment reconciliation data serialization to use an enhanced specification for improved data handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->