### PR TITLE
fixed overflowing decimal bug

### DIFF
--- a/care/emr/resources/account/spec.py
+++ b/care/emr/resources/account/spec.py
@@ -2,7 +2,7 @@ import datetime
 from decimal import Decimal
 from enum import Enum
 
-from pydantic import UUID4
+from pydantic import UUID4, Field
 
 from care.emr.extensions.base import ExtensionResource
 from care.emr.extensions.validator import ExtensionValidator
@@ -62,10 +62,10 @@ class AccountUpdateSpec(ExtensionValidator, AccountSpec):
 class AccountMinimalReadSpec(AccountSpec):
     """Account read specification"""
 
-    total_gross: Decimal
-    total_paid: Decimal
-    total_balance: Decimal
-    total_billable_charge_items: Decimal
+    total_gross: Decimal = Field(max_digits=20, decimal_places=6)
+    total_paid: Decimal = Field(max_digits=20, decimal_places=6)
+    total_balance: Decimal = Field(max_digits=20, decimal_places=6)
+    total_billable_charge_items: Decimal = Field(max_digits=20, decimal_places=6)
     calculated_at: datetime.datetime
     created_date: datetime.datetime
     modified_date: datetime.datetime

--- a/care/emr/resources/charge_item/spec.py
+++ b/care/emr/resources/charge_item/spec.py
@@ -2,7 +2,7 @@ import datetime
 from decimal import Decimal
 from enum import Enum
 
-from pydantic import UUID4, BaseModel, model_validator
+from pydantic import UUID4, BaseModel, Field, model_validator
 
 from care.emr.models.account import Account
 from care.emr.models.charge_item import ChargeItem
@@ -61,7 +61,7 @@ class ChargeItemSpec(EMRResource):
     description: str | None = None
     status: ChargeItemStatusOptions
     code: Coding | None = None
-    quantity: Decimal
+    quantity: Decimal = Field(max_digits=20, decimal_places=6)
     unit_price_components: list[MonetaryComponent]
     note: str | None = None
     override_reason: ChargeItemOverrideReason | None = None
@@ -147,7 +147,7 @@ class ChargeItemReadSpec(ChargeItemSpec):
     """Account read specification"""
 
     total_price_components: list[dict]
-    total_price: Decimal
+    total_price: Decimal = Field(max_digits=20, decimal_places=6)
     charge_item_definition: dict
     paid_invoice: dict | None = None
     tags: list[dict] = []

--- a/care/emr/resources/common/monetary_component.py
+++ b/care/emr/resources/common/monetary_component.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 from enum import Enum
 
-from pydantic import BaseModel, RootModel, model_validator
+from pydantic import BaseModel, Field, RootModel, model_validator
 
 from care.emr.resources.common.coding import Coding
 from care.emr.resources.common.condition_evaluator import EvaluatorConditionSpec
@@ -18,9 +18,11 @@ class MonetaryComponentType(str, Enum):
 class MonetaryComponent(BaseModel):
     monetary_component_type: MonetaryComponentType
     code: Coding | None = None
-    factor: Decimal | None = None
-    amount: Decimal | None = None
-    tax_included_amount: Decimal | None = None
+    factor: Decimal | None = Field(default=None, max_digits=20, decimal_places=6)
+    amount: Decimal | None = Field(default=None, max_digits=20, decimal_places=6)
+    tax_included_amount: Decimal | None = Field(
+        default=None, max_digits=20, decimal_places=6
+    )
     conditions: list[EvaluatorConditionSpec] = []
 
     @model_validator(mode="after")

--- a/care/emr/resources/common/quantity.py
+++ b/care/emr/resources/common/quantity.py
@@ -13,6 +13,8 @@ class Quantity(BaseModel):
     )
     value: Decimal | None = Field(
         None,
+        max_digits=20,
+        decimal_places=6,
         description="The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
     )
     unit: Coding | None = Field(None, description="A human-readable form of the unit.")

--- a/care/emr/resources/facility/spec.py
+++ b/care/emr/resources/facility/spec.py
@@ -1,9 +1,8 @@
-from decimal import Decimal
-
 from django.conf import settings
 from django.db.models.functions import Lower, Trim
 from pydantic import UUID4, BaseModel, field_validator, model_validator
 from pydantic_core.core_schema import ValidationInfo
+from pydantic_extra_types.coordinate import Latitude, Longitude
 
 from care.emr.models import Organization
 from care.emr.models.patient import PatientIdentifierConfigCache
@@ -32,8 +31,8 @@ class FacilityBareMinimumSpec(EMRResource):
 
 class FacilityBaseSpec(FacilityBareMinimumSpec):
     description: str
-    longitude: Decimal | None = None
-    latitude: Decimal | None = None
+    longitude: Longitude | None = None
+    latitude: Latitude | None = None
     pincode: int
     address: str
     phone_number: str

--- a/care/emr/resources/inventory/inventory_item/spec.py
+++ b/care/emr/resources/inventory/inventory_item/spec.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 from enum import Enum
 
-from pydantic import UUID4
+from pydantic import UUID4, Field
 
 from care.emr.models.inventory_item import InventoryItem
 from care.emr.resources.base import EMRResource
@@ -33,7 +33,7 @@ class InventoryItemWriteSpec(BaseInventoryItemSpec):
 class InventoryItemReadSpec(BaseInventoryItemSpec):
     """Supply delivery read specification"""
 
-    net_content: Decimal
+    net_content: Decimal = Field(max_digits=20, decimal_places=6)
     product: dict
     location: dict
 

--- a/care/emr/resources/inventory/supply_delivery/spec.py
+++ b/care/emr/resources/inventory/supply_delivery/spec.py
@@ -2,7 +2,7 @@ import datetime
 from decimal import Decimal
 from enum import Enum
 
-from pydantic import UUID4, model_validator
+from pydantic import UUID4, Field, model_validator
 
 from care.emr.extensions.base import ExtensionResource
 from care.emr.extensions.validator import ExtensionValidator
@@ -69,7 +69,7 @@ class SupplyDeliveryWriteSpec(ExtensionValidator, BaseSupplyDeliverySpec):
     supplied_item_pack_quantity: int | None = None
     supplied_item_pack_size: int | None = None
 
-    supplied_item_quantity: Decimal
+    supplied_item_quantity: Decimal = Field(max_digits=20, decimal_places=6)
     supplied_item: UUID4 | None = None
     supplied_inventory_item: UUID4 | None = None
 

--- a/care/emr/resources/inventory/supply_request/spec.py
+++ b/care/emr/resources/inventory/supply_request/spec.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 from enum import Enum
 
-from pydantic import UUID4
+from pydantic import UUID4, Field
 
 from care.emr.models.product_knowledge import ProductKnowledge
 from care.emr.models.supply_request import RequestOrder, SupplyRequest
@@ -30,7 +30,7 @@ class BaseSupplyRequestSpec(EMRResource):
 
     status: SupplyRequestStatusOptions
 
-    quantity: Decimal
+    quantity: Decimal = Field(max_digits=20, decimal_places=6)
 
 
 class SupplyRequestWriteSpec(BaseSupplyRequestSpec):

--- a/care/emr/resources/invoice/spec.py
+++ b/care/emr/resources/invoice/spec.py
@@ -2,7 +2,7 @@ import datetime
 from decimal import Decimal
 from enum import Enum
 
-from pydantic import UUID4
+from pydantic import UUID4, Field
 
 from care.emr.models.account import Account
 from care.emr.models.charge_item import ChargeItem
@@ -62,8 +62,8 @@ class InvoiceWriteSpec(BaseInvoiceSpec):
 class InvoiceReadSpec(BaseInvoiceSpec):
     """Invoice read specification"""
 
-    total_net: Decimal
-    total_gross: Decimal
+    total_net: Decimal = Field(max_digits=20, decimal_places=6)
+    total_gross: Decimal = Field(max_digits=20, decimal_places=6)
     locked: bool
     created_date: datetime.datetime
     modified_date: datetime.datetime
@@ -86,7 +86,7 @@ class InvoiceRetrieveSpec(InvoiceReadSpec):
     created_by: dict | None
     updated_by: dict | None
     payments: list[dict]
-    total_payments: Decimal
+    total_payments: Decimal = Field(max_digits=20, decimal_places=6)
     lock_history: list[dict]
 
     @classmethod

--- a/care/emr/resources/medication/dispense/spec.py
+++ b/care/emr/resources/medication/dispense/spec.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from decimal import Decimal
 from enum import Enum
 
-from pydantic import UUID4, BaseModel, model_validator
+from pydantic import UUID4, BaseModel, Field, model_validator
 from rest_framework.exceptions import ValidationError
 
 from care.emr.models.encounter import Encounter
@@ -124,8 +124,8 @@ class MedicationDispenseWriteSpec(BaseMedicationDispenseSpec):
     location: UUID4
     authorizing_request: UUID4 | None = None
     item: UUID4
-    quantity: Decimal
-    days_supply: Decimal | None = None
+    quantity: Decimal = Field(max_digits=20, decimal_places=6)
+    days_supply: Decimal | None = Field(default=None, max_digits=20, decimal_places=6)
     fully_dispensed: bool | None = None
     order: UUID4 | None = None
     create_dispense_order: CreateDispenseOrder | None = None
@@ -207,7 +207,7 @@ class MedicationDispenseReadSpec(BaseMedicationDispenseSpec):
     created_date: datetime
     modified_date: datetime
     location: dict
-    quantity: Decimal
+    quantity: Decimal = Field(max_digits=20, decimal_places=6)
     authorizing_request: dict | None = None
     order: dict | None = None
 

--- a/care/emr/resources/medication/request/spec.py
+++ b/care/emr/resources/medication/request/spec.py
@@ -111,12 +111,12 @@ class DoseType(str, Enum):
 
 
 class DosageQuantity(BaseModel):
-    value: Decimal
+    value: Decimal = Field(max_digits=20, decimal_places=6)
     unit: Coding
 
 
 class TimingQuantity(BaseModel):
-    value: Decimal
+    value: Decimal = Field(max_digits=20, decimal_places=6)
     unit: TimingUnit
 
 
@@ -133,7 +133,7 @@ class DoseAndRate(BaseModel):
 
 class TimingRepeat(BaseModel):
     frequency: int
-    period: Decimal
+    period: Decimal = Field(max_digits=20, decimal_places=6)
     period_unit: TimingUnit
     bounds_duration: TimingQuantity
 

--- a/care/emr/resources/observation_definition/spec.py
+++ b/care/emr/resources/observation_definition/spec.py
@@ -1,7 +1,7 @@
 import enum
 from decimal import Decimal
 
-from pydantic import UUID4, BaseModel, field_validator, model_validator
+from pydantic import UUID4, BaseModel, Field, field_validator, model_validator
 
 from care.emr.models.observation_definition import ObservationDefinition
 from care.emr.resources.base import EMRResource
@@ -56,8 +56,8 @@ class InterpretationSpec(BaseModel):
 
 class NumericRangeSpec(BaseModel):
     interpretation: InterpretationSpec
-    min: Decimal | None = None
-    max: Decimal | None = None
+    min: Decimal | None = Field(default=None, max_digits=20, decimal_places=6)
+    max: Decimal | None = Field(default=None, max_digits=20, decimal_places=6)
 
     @model_validator(mode="after")
     def validate_range(self):

--- a/care/emr/resources/payment_reconciliation/spec.py
+++ b/care/emr/resources/payment_reconciliation/spec.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from decimal import Decimal
 from enum import Enum
 
-from pydantic import UUID4, model_validator
+from pydantic import UUID4, Field, model_validator
 
 from care.emr.models.account import Account
 from care.emr.models.invoice import Invoice
@@ -82,9 +82,9 @@ class PaymentReconciliationWriteSpec(BasePaymentReconciliationSpec):
 
     target_invoice: UUID4 | None = None
     account: UUID4
-    amount: Decimal | None = None
-    tendered_amount: Decimal
-    returned_amount: Decimal
+    amount: Decimal | None = Field(default=None, max_digits=20, decimal_places=6)
+    tendered_amount: Decimal = Field(max_digits=20, decimal_places=6)
+    returned_amount: Decimal = Field(max_digits=20, decimal_places=6)
     is_credit_note: bool = False
     location: UUID4 | None = None
 
@@ -104,9 +104,9 @@ class PaymentReconciliationWriteSpec(BasePaymentReconciliationSpec):
 
 
 class PaymentReconciliationMinimalReadSpec(BasePaymentReconciliationSpec):
-    amount: Decimal | None = None
-    tendered_amount: Decimal
-    returned_amount: Decimal
+    amount: Decimal | None = Field(default=None, max_digits=20, decimal_places=6)
+    tendered_amount: Decimal = Field(max_digits=20, decimal_places=6)
+    returned_amount: Decimal = Field(max_digits=20, decimal_places=6)
     is_credit_note: bool
     created_date: datetime
     modified_date: datetime

--- a/care/emr/resources/specimen/spec.py
+++ b/care/emr/resources/specimen/spec.py
@@ -2,7 +2,7 @@ import datetime
 from decimal import Decimal
 from enum import Enum
 
-from pydantic import UUID4, BaseModel, field_validator, model_serializer
+from pydantic import UUID4, BaseModel, Field, field_validator, model_serializer
 
 from care.emr.models.specimen import Specimen
 from care.emr.resources.base import EMRResource, model_from_cache
@@ -34,7 +34,7 @@ class SpecimenStatusOptions(str, Enum):
 class QuantitySpec(BaseModel):
     """Represents a quantity with value and unit"""
 
-    value: Decimal
+    value: Decimal = Field(max_digits=20, decimal_places=6)
     unit: Coding
 
 

--- a/care/emr/resources/specimen_definition/spec.py
+++ b/care/emr/resources/specimen_definition/spec.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 from enum import Enum
 
-from pydantic import UUID4, BaseModel, model_validator
+from pydantic import UUID4, BaseModel, Field, model_validator
 
 from care.emr.models.specimen_definition import SpecimenDefinition
 from care.emr.resources.base import EMRResource
@@ -42,7 +42,7 @@ class HandlingConditionOptions(str, Enum):
 class QuantitySpec(BaseModel):
     """Represents a quantity with value and unit"""
 
-    value: Decimal
+    value: Decimal = Field(max_digits=20, decimal_places=6)
     unit: Coding
 
 
@@ -73,7 +73,7 @@ class ContainerSpec(BaseModel):
 class DurationSpec(BaseModel):
     """Duration specification using value and unit"""
 
-    value: Decimal
+    value: Decimal = Field(max_digits=20, decimal_places=6)
     unit: Coding  # Nees to be restricted to Datetime Units
 
 

--- a/care/emr/tests/test_charge_item_api.py
+++ b/care/emr/tests/test_charge_item_api.py
@@ -635,6 +635,75 @@ class TestChargeItemViewSet(CareAPITestBase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertNotEqual(response.data["id"], first_id)
 
+    def test_create_charge_item_overflow_quantity_returns_400(self):
+        """Test that API returns 400 (not 500) for overflowing quantity values."""
+        role = self.create_role_with_permissions(
+            [ChargeItemPermissions.can_create_charge_item.name]
+        )
+        self.attach_role_facility_organization_user(self.organization, self.user, role)
+        self.client.force_authenticate(user=self.user)
+
+        data = self.get_valid_charge_item_data(
+            quantity="10000000000000000000000.00"  # 22 integer digits, exceeds max
+        )
+        response = self.client.post(self.base_url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_charge_item_overflow_amount_returns_400(self):
+        """Test that API returns 400 (not 500) for overflowing amount values."""
+        role = self.create_role_with_permissions(
+            [ChargeItemPermissions.can_create_charge_item.name]
+        )
+        self.attach_role_facility_organization_user(self.organization, self.user, role)
+        self.client.force_authenticate(user=self.user)
+
+        data = self.get_valid_charge_item_data(
+            unit_price_components=[
+                {
+                    "monetary_component_type": "base",
+                    "currency": "INR",
+                    "amount": "10000000000000000000000.00",  # Overflow
+                    "code": {
+                        "system": "http://test.system.com",
+                        "code": "test-code-001",
+                        "display": "Test Code",
+                    },
+                }
+            ]
+        )
+        response = self.client.post(self.base_url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_upsert_charge_item_overflow_quantity_returns_400(self):
+        """Test that upsert API returns 400 (not 500) for overflowing quantity values."""
+        role = self.create_role_with_permissions(
+            [ChargeItemPermissions.can_create_charge_item.name]
+        )
+        self.attach_role_facility_organization_user(self.organization, self.user, role)
+        self.client.force_authenticate(user=self.user)
+
+        upsert_url = f"{self.base_url}upsert/"
+        data = {
+            "datapoints": [
+                {
+                    "title": "Test Charge Item",
+                    "description": "Test description",
+                    "status": ChargeItemStatusOptions.billable.value,
+                    "quantity": "10000000000000000000000.00",  # Overflow
+                    "unit_price_components": [
+                        {
+                            "monetary_component_type": "base",
+                            "amount": "10.00",
+                        }
+                    ],
+                    "encounter": str(self.encounter.external_id),
+                    "account": str(self.account.external_id),
+                }
+            ]
+        }
+        response = self.client.post(upsert_url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
 
 class TestChargeItemModelValidation(CareAPITestBase):
     def setUp(self):
@@ -879,6 +948,109 @@ class TestChargeItemSpecValidation(CareAPITestBase):
         serialized = ChargeItemReadSpec.serialize(charge_item)
         self.assertEqual(serialized.title, "Test Charge Item")
         self.assertEqual(serialized.id, charge_item.external_id)
+
+    def test_charge_item_spec_overflow_quantity(self):
+        """Test that overflowing quantity values are rejected with validation error."""
+        with self.assertRaises(PydanticValidationError) as context:
+            ChargeItemWriteSpec(
+                title="Test Charge Item",
+                status=ChargeItemStatusOptions.billable.value,
+                quantity=Decimal(
+                    "10000000000000000000000.00"
+                ),  # 22 integer digits, exceeds max_digits=20
+                unit_price_components=[self.get_valid_monetary_component()],
+                encounter=self.encounter.external_id,
+            )
+        self.assertIn("decimal", str(context.exception).lower())
+
+    def test_charge_item_spec_valid_max_quantity(self):
+        """Test that maximum valid quantity (14 integer digits + 6 decimal places) is accepted."""
+        spec = ChargeItemWriteSpec(
+            title="Test Charge Item",
+            status=ChargeItemStatusOptions.billable.value,
+            quantity=Decimal(
+                "99999999999999.999999"
+            ),  # 14 integer digits + 6 decimal places = 20 total
+            unit_price_components=[self.get_valid_monetary_component()],
+            encounter=self.encounter.external_id,
+        )
+        self.assertEqual(spec.quantity, Decimal("99999999999999.999999"))
+
+    def test_monetary_component_overflow_amount(self):
+        """Test that overflowing amount values in monetary component are rejected."""
+        with self.assertRaises(PydanticValidationError) as context:
+            ChargeItemWriteSpec(
+                title="Test Charge Item",
+                status=ChargeItemStatusOptions.billable.value,
+                quantity=Decimal("1.00"),
+                unit_price_components=[
+                    {
+                        "monetary_component_type": "base",
+                        "amount": Decimal("10000000000000000000000.00"),  # Overflow
+                        "code": {
+                            "system": "http://test.system.com",
+                            "code": "test-base",
+                            "display": "Test Base",
+                        },
+                    }
+                ],
+                encounter=self.encounter.external_id,
+            )
+        self.assertIn("decimal", str(context.exception).lower())
+
+    def test_monetary_component_overflow_factor(self):
+        """Test that overflowing factor values in monetary component are rejected."""
+        with self.assertRaises(PydanticValidationError) as context:
+            ChargeItemWriteSpec(
+                title="Test Charge Item",
+                status=ChargeItemStatusOptions.billable.value,
+                quantity=Decimal("1.00"),
+                unit_price_components=[
+                    {
+                        "monetary_component_type": "base",
+                        "amount": Decimal("100.00"),
+                        "code": {
+                            "system": "http://test.system.com",
+                            "code": "test-base",
+                            "display": "Test Base",
+                        },
+                    },
+                    {
+                        "monetary_component_type": "tax",
+                        "factor": Decimal("10000000000000000000000.00"),  # Overflow
+                        "code": {
+                            "system": "http://test.system.com",
+                            "code": "test-tax",
+                            "display": "Test Tax",
+                        },
+                    },
+                ],
+                encounter=self.encounter.external_id,
+            )
+        self.assertIn("decimal", str(context.exception).lower())
+
+    def test_monetary_component_valid_max_amount(self):
+        """Test that maximum valid amount is accepted."""
+        spec = ChargeItemWriteSpec(
+            title="Test Charge Item",
+            status=ChargeItemStatusOptions.billable.value,
+            quantity=Decimal("1.00"),
+            unit_price_components=[
+                {
+                    "monetary_component_type": "base",
+                    "amount": Decimal("99999999999999.999999"),  # Max valid amount
+                    "code": {
+                        "system": "http://test.system.com",
+                        "code": "test-base",
+                        "display": "Test Base",
+                    },
+                }
+            ],
+            encounter=self.encounter.external_id,
+        )
+        self.assertEqual(
+            spec.unit_price_components[0].amount, Decimal("99999999999999.999999")
+        )
 
 
 class TestChargeItemBusinessLogicValidation(CareAPITestBase):


### PR DESCRIPTION
## Proposed Changes

- Add extra validation to Decimal field so overflowing values now  return 400 validation errors instead of 500 database errors and replaced coordinate fields with their relavant pydantic models

### Associated Issue

- Fixes : https://github.com/ohcnetwork/roadmap/issues/226
- Fixes : https://github.com/ohcnetwork/roadmap/issues/222


## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for numeric fields in financial, inventory, and medication records to prevent overflow errors and enforce precision limits.
  * Improved geographic coordinate validation for facility locations using specialized data types.
  * Enhanced decimal precision constraints across monetary and quantity fields to ensure data integrity.

* **Tests**
  * Added comprehensive validation tests for numeric field constraints and overflow prevention.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->