### PR TITLE
fix medication dispense retrieve spec

### DIFF
--- a/care/emr/resources/medication/dispense/spec.py
+++ b/care/emr/resources/medication/dispense/spec.py
@@ -230,18 +230,8 @@ class MedicationDispenseReadSpec(BaseMedicationDispenseSpec):
             ).to_json()
 
 
-class MedicationDispenseRetrieveSpec(BaseMedicationDispenseSpec):
-    order: dict | None = None
-    charge_item: dict | None = None
+class MedicationDispenseRetrieveSpec(MedicationDispenseReadSpec):
 
     @classmethod
     def perform_extra_serialization(cls, mapping, obj):
         super().perform_extra_serialization(mapping, obj)
-        if obj.order:
-            mapping["order"] = MedicationDispenseOrderReadSpec.serialize(
-                obj.order
-            ).to_json()
-        if obj.charge_item:
-            mapping["charge_item"] = ChargeItemReadSpec.serialize(
-                obj.charge_item
-            ).to_json()

--- a/care/emr/resources/medication/dispense/spec.py
+++ b/care/emr/resources/medication/dispense/spec.py
@@ -231,7 +231,6 @@ class MedicationDispenseReadSpec(BaseMedicationDispenseSpec):
 
 
 class MedicationDispenseRetrieveSpec(MedicationDispenseReadSpec):
-
     @classmethod
     def perform_extra_serialization(cls, mapping, obj):
         super().perform_extra_serialization(mapping, obj)


### PR DESCRIPTION
## Proposed Changes

- fix medication dispense retrieve spec

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Medication dispense retrieval responses no longer include the "order" and "charge_item" fields; responses are streamlined and serialization simplified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->