### PR TITLE
cache invalidation for Facilityretreive cache on identifier updation

### DIFF
--- a/care/emr/signals/__init__.py
+++ b/care/emr/signals/__init__.py
@@ -1,1 +1,2 @@
-from .patient import *  # noqa F403
+from .patient import *  # noqa: F403
+from .patient_identifier import *  # noqa: F403

--- a/care/emr/signals/patient_identifier/__init__.py
+++ b/care/emr/signals/patient_identifier/__init__.py
@@ -1,0 +1,1 @@
+from .cache_invalidation import *  # noqa: F403

--- a/care/emr/signals/patient_identifier/cache_invalidation.py
+++ b/care/emr/signals/patient_identifier/cache_invalidation.py
@@ -1,0 +1,24 @@
+from django.core.cache import cache
+from django.db.models.signals import post_save
+
+from care.emr.models.patient import PatientIdentifierConfig
+from care.emr.resources.base import model_cache_key, model_string
+from care.facility.models import Facility
+
+
+def invalidate_facility_cache_on_identifier_change(sender, instance, **kwargs):
+    facility_model_string = model_string(Facility)
+
+    if instance.facility_id:
+        cache.delete_pattern(
+            model_cache_key(facility_model_string, pk=instance.facility.external_id)
+        )
+    else:
+        cache.delete_pattern(model_cache_key(facility_model_string))
+
+
+post_save.connect(
+    invalidate_facility_cache_on_identifier_change,
+    sender=PatientIdentifierConfig,
+    dispatch_uid="invalidate_facility_cache_on_identifier_config_save",
+)


### PR DESCRIPTION
## Proposed Changes

- Invalidating facility spec cache on identifier update

### Associated Issue

- Fixes : https://github.com/ohcnetwork/roadmap/issues/205

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cache invalidation for facility data when patient identifier configurations are updated, preventing stale information from being displayed.

* **Chores**
  * Restructured signal handlers to properly expose patient identifier caching functionality in the public API.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->