### PR TITLE
added validation to catch datetime without timezone

### DIFF
--- a/care/emr/resources/questionnaire/utils.py
+++ b/care/emr/resources/questionnaire/utils.py
@@ -87,7 +87,9 @@ def validate_data(values, value_type, questionnaire_ref):  # noqa PLR0912
             elif value_type == QuestionType.date.value:
                 isoparse(value.value).date()
             elif value_type == QuestionType.datetime.value:
-                isoparse(value.value)
+                parsed_dt = isoparse(value.value)
+                if timezone.is_naive(parsed_dt):
+                    errors.append("DateTime must include timezone information")
             elif value_type == QuestionType.time.value:
                 datetime.strptime(value.value, "%H:%M:%S")  # noqa DTZ007
             elif value_type == QuestionType.choice.value:

--- a/care/emr/tests/test_questionnaire_api.py
+++ b/care/emr/tests/test_questionnaire_api.py
@@ -189,7 +189,7 @@ class QuestionnaireValidationTests(QuestionnaireTestBase):
             "string": "Jane Smith",
             "text": "Persistent cough with fever",
             "date": "2023-12-31",
-            "dateTime": "2023-12-31T15:30:00",
+            "dateTime": "2023-12-31T15:30:00+05:30",
             "time": "15:30:00",
             "choice": "EXCELLENT",
             "url": "http://example.com",


### PR DESCRIPTION
## Proposed Changes

- We were missing validation on questionnaire response datetime, which was allowing datetime to be saved without timezone data. So added validation to avoid that

### Associated Issue

- https://coronasafe-network.sentry.io/issues/7235377742/?alert_rule_id=16635854&alert_type=issue&environment=ssmm-prod&notification_uuid=4de052f3-03e1-4dbe-a06c-cf3d581b578f&project=5182842

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DateTime fields now require timezone information to be included. Submissions with datetime values that lack timezone offset will be rejected with a validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->