### PR TITLE
location: adjust operational status for reserved locations on encounter closure

### DIFF
--- a/care/emr/api/viewsets/location.py
+++ b/care/emr/api/viewsets/location.py
@@ -488,10 +488,6 @@ class FacilityLocationEncounterViewSet(EMRModelViewSet):
 def close_related_location_from_encounter(instance):
     if instance.status in COMPLETED_CHOICES:
         with transaction.atomic():
-            FacilityLocation.objects.filter(current_encounter=instance).update(
-                current_encounter=None,
-                system_availability_status=LocationAvailabilityStatusChoices.available.value,
-            )
             location_ids = (
                 FacilityLocationEncounter.objects.filter(encounter=instance)
                 .exclude(status__in=COMPLETED_CHOICES)
@@ -501,6 +497,7 @@ def close_related_location_from_encounter(instance):
                 id__in=location_ids,
                 system_availability_status=LocationAvailabilityStatusChoices.reserved.value,
             ).update(
+                current_encounter=None,
                 system_availability_status=LocationAvailabilityStatusChoices.available.value,
             )
             FacilityLocationEncounter.objects.filter(encounter=instance).exclude(

--- a/care/emr/api/viewsets/location.py
+++ b/care/emr/api/viewsets/location.py
@@ -480,6 +480,10 @@ class FacilityLocationEncounterViewSet(EMRModelViewSet):
 def close_related_location_from_encounter(instance):
     if instance.status in COMPLETED_CHOICES:
         with transaction.atomic():
+            FacilityLocation.objects.filter(current_encounter=instance).update(
+                current_encounter=None,
+                system_availability_status=LocationAvailabilityStatusChoices.available.value,
+            )
             location_ids = (
                 FacilityLocationEncounter.objects.filter(encounter=instance)
                 .exclude(status__in=COMPLETED_CHOICES)
@@ -491,10 +495,6 @@ def close_related_location_from_encounter(instance):
                 operational_status=FacilityLocationOperationalStatusChoices.O.value,
             ).update(
                 operational_status=FacilityLocationOperationalStatusChoices.U.value,
-            )
-            FacilityLocation.objects.filter(current_encounter=instance).update(
-                current_encounter=None,
-                system_availability_status=LocationAvailabilityStatusChoices.available.value,
             )
             FacilityLocationEncounter.objects.filter(encounter=instance).exclude(
                 status__in=COMPLETED_CHOICES

--- a/care/emr/api/viewsets/location.py
+++ b/care/emr/api/viewsets/location.py
@@ -24,6 +24,7 @@ from care.emr.resources.location.spec import (
     FacilityLocationEncounterUpdateSpec,
     FacilityLocationListSpec,
     FacilityLocationModeChoices,
+    FacilityLocationOperationalStatusChoices,
     FacilityLocationRetrieveSpec,
     FacilityLocationUpdateSpec,
     FacilityLocationWriteSpec,
@@ -307,10 +308,6 @@ class FacilityLocationEncounterViewSet(EMRModelViewSet):
             location=location,
             status=LocationEncounterAvailabilityStatusChoices.active.value,
         ).first()
-        reserved_location_encounter = FacilityLocationEncounter.objects.filter(
-            location=location,
-            status=LocationEncounterAvailabilityStatusChoices.reserved.value,
-        ).first()
         all_encounters = Encounter.objects.filter(current_location=location)
         if active_location_encounter:
             active_location_encounter.encounter.current_location = location
@@ -319,11 +316,6 @@ class FacilityLocationEncounterViewSet(EMRModelViewSet):
                 id=active_location_encounter.encounter_id
             )
             location.current_encounter = active_location_encounter.encounter
-            location.system_availability_status = (
-                LocationAvailabilityStatusChoices.reserved.value
-            )
-        elif reserved_location_encounter:
-            location.current_encounter = None
             location.system_availability_status = (
                 LocationAvailabilityStatusChoices.reserved.value
             )
@@ -495,8 +487,11 @@ def close_related_location_from_encounter(instance):
             )
             FacilityLocation.objects.filter(
                 id__in=location_ids,
-                system_availability_status=LocationAvailabilityStatusChoices.reserved.value,
+                operational_status=FacilityLocationOperationalStatusChoices.O.value,
             ).update(
+                operational_status=FacilityLocationOperationalStatusChoices.U.value,
+            )
+            FacilityLocation.objects.filter(current_encounter=instance).update(
                 current_encounter=None,
                 system_availability_status=LocationAvailabilityStatusChoices.available.value,
             )

--- a/care/emr/api/viewsets/location.py
+++ b/care/emr/api/viewsets/location.py
@@ -487,6 +487,7 @@ def close_related_location_from_encounter(instance):
             )
             FacilityLocation.objects.filter(
                 id__in=location_ids,
+                current_encounter=None,
                 operational_status=FacilityLocationOperationalStatusChoices.O.value,
             ).update(
                 operational_status=FacilityLocationOperationalStatusChoices.U.value,

--- a/care/emr/api/viewsets/location.py
+++ b/care/emr/api/viewsets/location.py
@@ -307,6 +307,10 @@ class FacilityLocationEncounterViewSet(EMRModelViewSet):
             location=location,
             status=LocationEncounterAvailabilityStatusChoices.active.value,
         ).first()
+        reserved_location_encounter = FacilityLocationEncounter.objects.filter(
+            location=location,
+            status=LocationEncounterAvailabilityStatusChoices.reserved.value,
+        ).first()
         all_encounters = Encounter.objects.filter(current_location=location)
         if active_location_encounter:
             active_location_encounter.encounter.current_location = location
@@ -315,6 +319,11 @@ class FacilityLocationEncounterViewSet(EMRModelViewSet):
                 id=active_location_encounter.encounter_id
             )
             location.current_encounter = active_location_encounter.encounter
+            location.system_availability_status = (
+                LocationAvailabilityStatusChoices.reserved.value
+            )
+        elif reserved_location_encounter:
+            location.current_encounter = None
             location.system_availability_status = (
                 LocationAvailabilityStatusChoices.reserved.value
             )
@@ -481,6 +490,17 @@ def close_related_location_from_encounter(instance):
         with transaction.atomic():
             FacilityLocation.objects.filter(current_encounter=instance).update(
                 current_encounter=None,
+                system_availability_status=LocationAvailabilityStatusChoices.available.value,
+            )
+            location_ids = (
+                FacilityLocationEncounter.objects.filter(encounter=instance)
+                .exclude(status__in=COMPLETED_CHOICES)
+                .values_list("location_id", flat=True)
+            )
+            FacilityLocation.objects.filter(
+                id__in=location_ids,
+                system_availability_status=LocationAvailabilityStatusChoices.reserved.value,
+            ).update(
                 system_availability_status=LocationAvailabilityStatusChoices.available.value,
             )
             FacilityLocationEncounter.objects.filter(encounter=instance).exclude(


### PR DESCRIPTION
## Proposed Changes

- Adjust operational status for locations when closing encounter

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Facility location status handling now automatically updates related locations when an encounter is completed, clearing current encounter links and marking availability.
  * Related encounter records are closed with accurate end timestamps when an encounter finishes, ensuring consistent completion state.

* **Bug Fixes**
  * All related updates are applied transactionally to prevent partial state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->