### PR TITLE
add sort by and encounter mapping for facility location encounter

### DIFF
--- a/care/emr/api/viewsets/location.py
+++ b/care/emr/api/viewsets/location.py
@@ -474,7 +474,9 @@ class FacilityLocationEncounterViewSet(EMRModelViewSet):
             "can_list_facility_location_obj", self.request.user, facility, location
         ):
             raise PermissionDenied("You do not have permission to given location")
-        return FacilityLocationEncounter.objects.filter(location=location)
+        return FacilityLocationEncounter.objects.filter(location=location).order_by(
+            "-created_date"
+        )
 
 
 def close_related_location_from_encounter(instance):

--- a/care/emr/resources/location/spec.py
+++ b/care/emr/resources/location/spec.py
@@ -224,5 +224,8 @@ class FacilityLocationEncounterReadSpec(FacilityLocationEncounterBaseSpec):
 
     @classmethod
     def perform_extra_serialization(cls, mapping, obj):
+        from care.emr.resources.encounter.spec import EncounterRetrieveSpec
+
         mapping["id"] = obj.external_id
+        mapping["encounter"] = EncounterRetrieveSpec.serialize(obj.encounter).to_json()
         cls.serialize_audit_users(mapping, obj)


### PR DESCRIPTION
## Proposed Changes

- Add sort by created date for facility location encounter
- For retrieve spec, map encounter

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Location results now display in reverse chronological order by creation date.
  * Encounter details are now included in facility location encounter responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->