### PR TITLE
created by filter for dispense order and invoices

### DIFF
--- a/care/emr/api/viewsets/inventory/dispense_order.py
+++ b/care/emr/api/viewsets/inventory/dispense_order.py
@@ -54,6 +54,7 @@ class DispenseOrderFilters(filters.FilterSet):
     patient = filters.UUIDFilter(field_name="patient__external_id")
     location = DummyUUIDFilter()
     include_children = DummyBooleanFilter()
+    created_by = filters.UUIDFilter(field_name="created_by__external_id")
 
 
 class DispenseOrderViewSet(

--- a/care/emr/api/viewsets/invoice.py
+++ b/care/emr/api/viewsets/invoice.py
@@ -53,6 +53,7 @@ class InvoiceFilters(filters.FilterSet):
     locked = filters.BooleanFilter()
     is_refund = filters.BooleanFilter()
     payment_reconciliation_present = DummyBooleanFilter()
+    created_by = filters.UUIDFilter(field_name="created_by__external_id")
 
 
 class AttachChargeItemToInvoiceRequest(BaseModel):

--- a/care/emr/api/viewsets/medication_request_prescription.py
+++ b/care/emr/api/viewsets/medication_request_prescription.py
@@ -33,7 +33,6 @@ from care.utils.shortcuts import get_object_or_404
 
 class MedicationRequestPrescriptionFilter(filters.FilterSet):
     encounter = filters.UUIDFilter(field_name="encounter__external_id")
-    patient = filters.UUIDFilter(field_name="patient__external_id")
     status = MultiSelectFilter(field_name="status")
     facility = filters.UUIDFilter(field_name="encounter__facility__external_id")
     created_date = filters.DateTimeFromToRangeFilter()


### PR DESCRIPTION
## Proposed Changes

- add created by filter for invoices
- add created by filter for dispense orders
- remove unnecessary patient filter in medication prescription viewset (viewset is already filtered by patient always)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dispense orders can now be filtered by creator
  * Invoices can now be filtered by creator

* **Refactor**
  * Removed patient filter from medication request prescription queries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->