### PR TITLE
fix dispense order created date filter; serialize audit users

### DIFF
--- a/care/emr/api/viewsets/inventory/dispense_order.py
+++ b/care/emr/api/viewsets/inventory/dispense_order.py
@@ -50,7 +50,7 @@ def cancel_dispense_order(instance):
 
 class DispenseOrderFilters(filters.FilterSet):
     status = MultiSelectFilter(field_name="status")
-    created_date = filters.DateRangeFilter()
+    created_date = filters.DateTimeFromToRangeFilter(field_name="created_date")
     patient = filters.UUIDFilter(field_name="patient__external_id")
     location = DummyUUIDFilter()
     include_children = DummyBooleanFilter()

--- a/care/emr/resources/medication/dispense/dispense_order.py
+++ b/care/emr/resources/medication/dispense/dispense_order.py
@@ -76,3 +76,4 @@ class MedicationDispenseOrderRetrieveSpec(MedicationDispenseOrderReadSpec):
         mapping["id"] = obj.external_id
         mapping["location"] = FacilityLocationListSpec.serialize(obj.location).to_json()
         mapping["patient"] = PatientRetrieveSpec.serialize(obj.patient).to_json()
+        cls.serialize_audit_users(mapping, obj)


### PR DESCRIPTION
## Proposed Changes

- serialize audit users in dispense order retrieve spec
- fixes created_date filter not being filtered by date time range



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dispense order filtering now supports date-time range queries, enabling more granular filtering by creation timestamp instead of date only.

* **Bug Fixes**
  * Enhanced audit trail recording for dispense orders to ensure complete and accurate tracking of audit-related data during serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->