### PR TITLE
refact:date time filter and added audit user for dispense order creation

### DIFF
--- a/care/emr/api/viewsets/inventory/dispense_order.py
+++ b/care/emr/api/viewsets/inventory/dispense_order.py
@@ -50,7 +50,7 @@ def cancel_dispense_order(instance):
 
 class DispenseOrderFilters(filters.FilterSet):
     status = MultiSelectFilter(field_name="status")
-    created_date = filters.DateRangeFilter()
+    created_date = filters.DateTimeFromToRangeFilter(field_name="created_date")
     patient = filters.UUIDFilter(field_name="patient__external_id")
     location = DummyUUIDFilter()
     include_children = DummyBooleanFilter()

--- a/care/emr/api/viewsets/medication_dispense.py
+++ b/care/emr/api/viewsets/medication_dispense.py
@@ -84,6 +84,9 @@ class MedicationDispenseViewSet(
     filter_backends = [filters.DjangoFilterBackend, OrderingFilter]
     ordering_fields = ["created_date", "modified_date"]
 
+    def get_serializer_create_context(self):
+        return {"user": self.request.user}
+
     def perform_create(self, instance):
         with transaction.atomic(), InventoryItemLock(instance.item):
             net_content = instance.item.net_content

--- a/care/emr/resources/medication/dispense/spec.py
+++ b/care/emr/resources/medication/dispense/spec.py
@@ -177,6 +177,7 @@ class MedicationDispenseWriteSpec(BaseMedicationDispenseSpec):
             ]:
                 raise ValidationError("Prescription is not active")
             if not dispense_order_obj:
+                user = self._context.get("user")
                 dispense_order_obj = DispenseOrder.objects.create(
                     status=self.create_dispense_order.status,
                     alternate_identifier=self.create_dispense_order.alternate_identifier,
@@ -185,6 +186,8 @@ class MedicationDispenseWriteSpec(BaseMedicationDispenseSpec):
                     facility=obj.encounter.facility,
                     name=self.create_dispense_order.name,
                     note=self.create_dispense_order.note,
+                    created_by=user,
+                    updated_by=user,
                 )
             obj.order = dispense_order_obj
 


### PR DESCRIPTION
## Proposed Changes

- Added audit user data on dispense order once created.
- updated the datetime filter

### Associated Issue

- No audit user data on dispense order creation on a medication dispense flow


## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dispense order date filters now support datetime precision for more granular date range searches.
  * Dispense orders now track creation and update attribution for improved audit trails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->