### PR TITLE
Fix: Facility PATCH endpoint behaving like PUT

### DIFF
--- a/care/emr/api/viewsets/base.py
+++ b/care/emr/api/viewsets/base.py
@@ -210,11 +210,11 @@ class EMRUpdateMixin:
 
     def update(self, request, *args, **kwargs):
         instance = self.get_object()
-        return Response(self.handle_update(instance, request.data))
+        partial = kwargs.pop("partial", False)
+        return Response(self.handle_update(instance, request.data, partial=partial))
 
     def partial_update(self, request, *args, **kwargs):
-        kwargs["partial"] = True
-        return self.update(request, *args, **kwargs)
+        return self.update(request, *args, partial=True, **kwargs)
 
     def get_serializer_update_context(self):
         return {}
@@ -222,7 +222,7 @@ class EMRUpdateMixin:
     def authorize_update(self, request_obj, model_instance):
         pass
 
-    def handle_update(self, instance, request_data):
+    def handle_update(self, instance, request_data, partial=False):
         clean_data = self.clean_update_data(request_data)  # From Create
         pydantic_model = self.get_update_pydantic_model()
         context = {
@@ -237,7 +237,6 @@ class EMRUpdateMixin:
         serializer_obj._context = context  # noqa: SLF001
         self.validate_data(serializer_obj, instance)
         self.authorize_update(serializer_obj, instance)
-        partial = getattr(self, "partial", False)
         model_instance = serializer_obj.de_serialize(obj=instance, partial=partial)
         self.perform_update(model_instance)
         return self.get_retrieve_pydantic_model().serialize(model_instance).to_json()

--- a/care/emr/api/viewsets/facility.py
+++ b/care/emr/api/viewsets/facility.py
@@ -21,6 +21,7 @@ from care.emr.resources.facility.spec import (
     FacilityMonetaryCodeSpec,
     FacilityReadSpec,
     FacilityRetrieveSpec,
+    FacilityUpdateSpec,
 )
 from care.emr.resources.user.spec import PublicUserReadSpec, UserRetrieveSpec, UserSpec
 from care.facility.models import Facility
@@ -80,6 +81,7 @@ class FacilityViewSet(EMRModelViewSet):
     pydantic_model = FacilityCreateSpec
     pydantic_read_model = FacilityReadSpec
     pydantic_retrieve_model = FacilityRetrieveSpec
+    pydantic_update_model = FacilityUpdateSpec
     filterset_class = FacilityFilters
     filter_backends = [DjangoFilterBackend]
 

--- a/care/emr/resources/facility/spec.py
+++ b/care/emr/resources/facility/spec.py
@@ -218,3 +218,47 @@ class FacilityMinimalReadSpec(FacilityBaseSpec):
             mapping["geo_organization"] = OrganizationReadSpec.serialize(
                 obj.geo_organization
             ).to_json()
+
+class FacilityUpdateSpec(FacilityCreateSpec):
+    name: str | None = None
+    description: str | None = None
+    longitude: Longitude | None = None
+    latitude: Latitude | None = None
+    pincode: int | None = None
+    address: str | None = None
+    phone_number: str | None = None
+    facility_type: str | None = None
+    is_public: bool | None = None
+    geo_organization: UUID4 | None = None
+    features: list[int] | None = None
+    @field_validator("name")
+    @classmethod
+    def validate_name_uniqueness(cls, v, info: ValidationInfo):
+        if not v:
+            return v
+
+        normalized_name = v.strip().lower()
+        context = info.context or {}
+        is_update = context.get("is_update", False)
+        obj = context.get("object")
+
+        qs = Facility.objects.annotate(normalized_name=Lower(Trim("name"))).filter(
+            normalized_name=normalized_name
+        )
+
+        if is_update and obj:
+            qs = qs.exclude(id=obj.id)
+
+        if qs.exists():
+            raise ValueError("A facility with this name already exists")
+
+        return v
+
+    def perform_extra_deserialization(self, is_update, obj):
+        if self.geo_organization:
+            obj.geo_organization = Organization.objects.filter(
+                external_id=self.geo_organization, org_type="govt"
+            ).first()
+
+        if self.facility_type:
+            obj.facility_type = REVERSE_REVERSE_FACILITY_TYPES[self.facility_type]

--- a/care/emr/tests/test_facility_api.py
+++ b/care/emr/tests/test_facility_api.py
@@ -1,6 +1,8 @@
 from django.urls import reverse
 from rest_framework import status
+
 from care.utils.tests.base import CareAPITestBase
+
 
 class TestFacilityPartialUpdate(CareAPITestBase):
     def setUp(self):

--- a/care/emr/tests/test_facility_api.py
+++ b/care/emr/tests/test_facility_api.py
@@ -1,0 +1,42 @@
+from django.urls import reverse
+from rest_framework import status
+from care.utils.tests.base import CareAPITestBase
+
+class TestFacilityPartialUpdate(CareAPITestBase):
+    def setUp(self):
+        super().setUp()
+        self.super_user = self.create_super_user(username="facility_admin")
+        self.client.force_authenticate(user=self.super_user)
+        self.facility = self.create_facility(
+            user=self.super_user,
+            name="Original Facility Name",
+        )
+
+        self.detail_url = reverse(
+            "facility-detail",
+            kwargs={"external_id": self.facility.external_id},
+        )
+
+    def test_patch_facility_with_partial_payload_updates_only_given_fields(self):
+        original_description = self.facility.description
+        original_address = self.facility.address
+        original_phone_number = self.facility.phone_number
+        original_pincode = self.facility.pincode
+        original_is_public = self.facility.is_public
+        original_facility_type = self.facility.facility_type
+
+        payload = {"name": "Patched Facility Name"}
+
+        response = self.client.patch(self.detail_url, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+
+        self.facility.refresh_from_db()
+
+        self.assertEqual(self.facility.name, payload["name"])
+        self.assertEqual(self.facility.description, original_description)
+        self.assertEqual(self.facility.address, original_address)
+        self.assertEqual(self.facility.phone_number, original_phone_number)
+        self.assertEqual(self.facility.pincode, original_pincode)
+        self.assertEqual(self.facility.is_public, original_is_public)
+        self.assertEqual(self.facility.facility_type, original_facility_type)


### PR DESCRIPTION
## Proposed Changes

- Fixed PATCH endpoint update flow in EMRUpdateMixin to correctly propagate partial update intent (partial=True) instead of defaulting to full update behavior. [BCP Guidelines](https://datatracker.ietf.org/doc/html/rfc5789).
- Added FacilityUpdateSpec with optional fields for update operations.
- Updated FacilityViewSet to use pydantic_update_model = FacilityUpdateSpec.
- Added regression test `care/emr/tests/test_facility_api.py` to ensure `PATCH /api/v1/facility/{id}/` works with partial payload.

#### Root Cause
- partial_update() was not passing partial semantics through shared update handling.
- Facility update path was using create and required field validation, causing PATCH to act like PUT.

#### Validation
- Manual API validation in Postman:

Before Fix
<img width="1498" height="371" alt="image" src="https://github.com/user-attachments/assets/cf7d9038-bb27-43e3-a8e7-228c00d1d79b" />

After Fix
<img width="1487" height="602" alt="image" src="https://github.com/user-attachments/assets/380c04aa-9157-460a-b0fd-3090583472b6" />


### Associated Issue
- Reproduced bug: `PATCH /api/v1/facility/{id}/ `with payload` { "name": "..." }` returned 400 with missing required fields.


## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Facility records can now be updated using partial updates (PATCH requests), allowing users to modify specific fields without affecting others.
  * Added validation to ensure facility names remain unique during updates.

* **Tests**
  * Added test coverage for facility partial update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->