### PR TITLE
Make code optional for timing

### DIFF
--- a/care/emr/resources/medication/request/spec.py
+++ b/care/emr/resources/medication/request/spec.py
@@ -140,7 +140,7 @@ class TimingRepeat(BaseModel):
 
 class Timing(BaseModel):
     repeat: TimingRepeat
-    code: Coding
+    code: Coding | None = None
 
 
 class DosageInstruction(BaseModel):


### PR DESCRIPTION
## Proposed Changes

It has become increasingly hard to document timing for a medication request as we have hard locked the timing code to the FHIR preferred valueset for Timing.code. In FHIR R5, Timing.code is 0..1 and bound as Preferred, not Required, also many valid timing instructions have no meaningful code. (eg 3–4 times a day)
<img width="726" height="231" alt="Screenshot 2026-02-12 at 4 08 58 AM" src="https://github.com/user-attachments/assets/ab46c406-acd2-4cc2-bddb-0371963dea43" />

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Medication timing information can now be submitted without specifying a code value, improving flexibility in data entry and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->