### PR TITLE
bug:updated cancel return invoice with sync_inventory_item

### DIFF
--- a/care/emr/resources/invoice/return_items_invoice.py
+++ b/care/emr/resources/invoice/return_items_invoice.py
@@ -101,9 +101,11 @@ def cancel_return_invoice(delivery_order: DeliveryOrder):
             paid_invoice=None,
             paid_on=None,
         )
-        sync_inventory_item(
-            location=delivery_order.destination,
-            product=SupplyDelivery.objects.get(order=delivery_order).supplied_item,
-        )
+        supply_deliveries = SupplyDelivery.objects.filter(order=delivery_order)
+        for supply_delivery in supply_deliveries:
+            sync_inventory_item(
+                location=delivery_order.destination,
+                product=supply_delivery.supplied_item,
+            )
 
     rebalance_account_task(delivery_order.patient_invoice.account.id)

--- a/care/emr/resources/invoice/return_items_invoice.py
+++ b/care/emr/resources/invoice/return_items_invoice.py
@@ -14,6 +14,9 @@ from care.emr.resources.charge_item.apply_charge_item_definition import (
     apply_charge_item_definition,
 )
 from care.emr.resources.charge_item.spec import ChargeItemStatusOptions
+from care.emr.resources.inventory.inventory_item.sync_inventory_item import (
+    sync_inventory_item,
+)
 from care.emr.resources.inventory.supply_delivery.spec import (
     SupplyDeliveryStatusOptions,
 )
@@ -98,4 +101,9 @@ def cancel_return_invoice(delivery_order: DeliveryOrder):
             paid_invoice=None,
             paid_on=None,
         )
+        sync_inventory_item(
+            location=delivery_order.destination,
+            product=SupplyDelivery.objects.get(order=delivery_order).supplied_item,
+        )
+
     rebalance_account_task(delivery_order.patient_invoice.account.id)


### PR DESCRIPTION
## Proposed Changes

- Updated cancel_return_invoice with sync_inventory_item

### Associated Issue

- Inventory Item was not updated when the delivery order is abandoned or entered in error

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inventory synchronization when return invoices are cancelled. Inventory items associated with cancelled returns are now automatically updated, ensuring accurate inventory levels are maintained across all delivery locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->