### PR TITLE
Add education activity type to AD category

### DIFF
--- a/care/emr/resources/activity_definition/spec.py
+++ b/care/emr/resources/activity_definition/spec.py
@@ -46,6 +46,7 @@ class ActivityDefinitionCategoryOptions(str, Enum):
     imaging = "imaging"
     counselling = "counselling"
     surgical_procedure = "surgical_procedure"
+    education = "education"
 
 
 class BaseActivityDefinitionSpec(EMRResource):


### PR DESCRIPTION

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "education" as a new category option for activity definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->