### PR TITLE
fix: Default filtering questionnaire response in Contex builder

### DIFF
--- a/care/emr/reports/context_builder/data_points/questionnaire.py
+++ b/care/emr/reports/context_builder/data_points/questionnaire.py
@@ -10,6 +10,9 @@ from care.emr.reports.context_builder.data_points.base import (
 from care.emr.reports.context_builder.data_points.user import (
     SingleUserRelatedContextBuilder,
 )
+from care.emr.resources.questionnaire_response.spec import (
+    QuestionnaireResponseStatusChoices,
+)
 
 
 class QuestionnaireResponsesContextBuilder(QuerysetContextBuilder):
@@ -80,7 +83,9 @@ class QuestionnaireContextBuilder(QuerysetContextBuilder):
 
     def get_context(self):
         return QuestionnaireResponse.objects.filter(
-            encounter=self.parent_context, questionnaire__isnull=False
+            encounter=self.parent_context,
+            questionnaire__isnull=False,
+            status=QuestionnaireResponseStatusChoices.completed.value,
         )
 
     def perform_extra_filters(self, qs, **kwargs):


### PR DESCRIPTION
## Proposed Changes

- Default filtering questionnaire response with completed status

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Questionnaire reports now correctly filter and display only completed responses, ensuring accurate reporting and data consistency across all questionnaire-related outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->