### PR TITLE
fix: add request and response schema to login endpoint for Swagger UI

### DIFF
--- a/config/auth_views.py
+++ b/config/auth_views.py
@@ -183,6 +183,10 @@ class TokenObtainPairView(TokenViewBase):
                 "properties": {
                     "access": {"type": "string"},
                     "refresh": {"type": "string"},
+                    "temp_token": {
+                        "type": "string",
+                        "description": "Returned instead of access/refresh when MFA is enabled. Use this token to complete MFA authentication.",
+                    },
                 },
             }
         },

--- a/config/auth_views.py
+++ b/config/auth_views.py
@@ -165,7 +165,28 @@ class TokenObtainPairView(TokenViewBase):
 
     serializer_class = TokenObtainPairSerializer
 
-    @extend_schema(tags=["auth"])
+    @extend_schema(
+        tags=["auth"],
+        request={
+            "application/json": {
+                "type": "object",
+                "properties": {
+                    "username": {"type": "string"},
+                    "password": {"type": "string", "format": "password"},
+                },
+                "required": ["username", "password"],
+            }
+        },
+        responses={
+            200: {
+                "type": "object",
+                "properties": {
+                    "access": {"type": "string"},
+                    "refresh": {"type": "string"},
+                },
+            }
+        },
+    )
     def post(self, request, *args, **kwargs):
         return super().post(request, *args, **kwargs)
 


### PR DESCRIPTION
The @extend_schema decorator on TokenObtainPairView was missing request 
and response annotations. Since TokenObtainPairSerializer adds its fields 
dynamically in __init__, drf-spectacular could not auto-detect them, 
causing Swagger UI to show "No parameters" for the login endpoint.

## Proposed Changes

- Added explicit `request` and `responses` schema to `@extend_schema` 
  decorator on `TokenObtainPairView.post` in `config/auth_views.py`
- Swagger UI now correctly shows username and password fields for 
  POST /api/v1/auth/login/

### Associated Issue

No existing issue — discovered while setting up local development environment.

### Architecture changes

None.

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced API docs for the authentication token endpoint: clearer request and response schemas, including explicit username/password fields and detailed response fields (access, refresh, and a temporary MFA-related token) for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->