### PR TITLE
Default to none for discount configuration

### DIFF
--- a/care/emr/resources/charge_item_definition/spec.py
+++ b/care/emr/resources/charge_item_definition/spec.py
@@ -35,7 +35,7 @@ class ChargeItemDefinitionSpec(EMRResource):
     purpose: str | None = None
     price_components: list[MonetaryComponent]
     can_edit_charge_item: bool
-    discount_configuration: DiscountConfiguration | None
+    discount_configuration: DiscountConfiguration | None = None
 
 
 class ChargeItemDefinitionWriteSpec(ChargeItemDefinitionSpec):


### PR DESCRIPTION
## Proposed Changes

- Set `None` as default value for discount configuration and fixes below error

<img width="545" height="142" alt="image" src="https://github.com/user-attachments/assets/f1f5f6df-387a-4dc3-892c-4bb857083d8b" />


### Associated Issue

- Link to issue here, explain how the proposed solution will solve the reported issue/ feature request.

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Discount configuration is now optional when creating charge items, allowing more flexible charge item setup without requiring discount settings to be specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->