### PR TITLE
feat:medications_only filter in medication request

### DIFF
--- a/care/emr/api/viewsets/medication_request.py
+++ b/care/emr/api/viewsets/medication_request.py
@@ -1,3 +1,4 @@
+from django.db import models
 from django_filters import rest_framework as filters
 from rest_framework import filters as rest_framework_filters
 from rest_framework.exceptions import PermissionDenied
@@ -22,6 +23,16 @@ from care.utils.filters.null_filter import NullFilter
 from care.utils.shortcuts import get_object_or_404
 
 
+class ProductTypeFilter(filters.CharFilter):
+    def filter(self, qs, value):
+        if not value:
+            return qs
+        return qs.filter(
+            models.Q(requested_product__isnull=True)
+            | models.Q(requested_product__product_type__iexact=value)
+        )
+
+
 class MedicationRequestFilter(filters.FilterSet):
     encounter = filters.UUIDFilter(field_name="encounter__external_id")
     status = MultiSelectFilter(field_name="status")
@@ -37,9 +48,7 @@ class MedicationRequestFilter(filters.FilterSet):
     dispense_status_isnull = NullFilter(field_name="dispense_status")
     facility = filters.UUIDFilter(field_name="encounter__facility__external_id")
     prescription = filters.UUIDFilter(field_name="prescription__external_id")
-    product_type = filters.CharFilter(
-        field_name="requested_product__product_type", lookup_expr="iexact"
-    )
+    product_type = ProductTypeFilter()
 
 
 class MedicationRequestViewSet(

--- a/care/emr/api/viewsets/medication_request.py
+++ b/care/emr/api/viewsets/medication_request.py
@@ -29,7 +29,7 @@ class ProductTypeFilter(filters.CharFilter):
         if not value:
             return qs
         query = models.Q(requested_product__product_type__iexact=value)
-        if value == ProductTypeOptions.medication.value:
+        if value.lower() == ProductTypeOptions.medication.value:
             query |= models.Q(requested_product__isnull=True)
         return qs.filter(query)
 

--- a/care/emr/api/viewsets/medication_request.py
+++ b/care/emr/api/viewsets/medication_request.py
@@ -54,9 +54,7 @@ class MedicationRequestFilter(filters.FilterSet):
     product_type = filters.CharFilter(
         field_name="requested_product__product_type", lookup_expr="iexact"
     )
-    medications_only = MedicationFilter(
-        field_name="requested_product__product_type", lookup_expr="iexact"
-    )
+    medications_only = MedicationFilter()
 
 
 class MedicationRequestViewSet(

--- a/care/emr/api/viewsets/medication_request.py
+++ b/care/emr/api/viewsets/medication_request.py
@@ -10,6 +10,7 @@ from care.emr.models.medication_request import MedicationRequest
 from care.emr.registries.system_questionnaire.system_questionnaire import (
     InternalQuestionnaireRegistry,
 )
+from care.emr.resources.inventory.product_knowledge.spec import ProductTypeOptions
 from care.emr.resources.medication.request.spec import (
     MedicationRequestReadSpec,
     MedicationRequestSpec,
@@ -27,10 +28,10 @@ class ProductTypeFilter(filters.CharFilter):
     def filter(self, qs, value):
         if not value:
             return qs
-        return qs.filter(
-            models.Q(requested_product__isnull=True)
-            | models.Q(requested_product__product_type__iexact=value)
-        )
+        query = models.Q(requested_product__product_type__iexact=value)
+        if value == ProductTypeOptions.medication.value:
+            query |= models.Q(requested_product__isnull=True)
+        return qs.filter(query)
 
 
 class MedicationRequestFilter(filters.FilterSet):

--- a/care/emr/api/viewsets/medication_request.py
+++ b/care/emr/api/viewsets/medication_request.py
@@ -24,14 +24,16 @@ from care.utils.filters.null_filter import NullFilter
 from care.utils.shortcuts import get_object_or_404
 
 
-class ProductTypeFilter(filters.CharFilter):
+class MedicationFilter(filters.BooleanFilter):
     def filter(self, qs, value):
-        if not value:
-            return qs
-        query = models.Q(requested_product__product_type__iexact=value)
-        if value.lower() == ProductTypeOptions.medication.value:
-            query |= models.Q(requested_product__isnull=True)
-        return qs.filter(query)
+        if value:
+            return qs.filter(
+                models.Q(
+                    requested_product__product_type__iexact=ProductTypeOptions.medication.value
+                )
+                | models.Q(requested_product__isnull=True)
+            )
+        return qs
 
 
 class MedicationRequestFilter(filters.FilterSet):
@@ -49,7 +51,12 @@ class MedicationRequestFilter(filters.FilterSet):
     dispense_status_isnull = NullFilter(field_name="dispense_status")
     facility = filters.UUIDFilter(field_name="encounter__facility__external_id")
     prescription = filters.UUIDFilter(field_name="prescription__external_id")
-    product_type = ProductTypeFilter()
+    product_type = filters.CharFilter(
+        field_name="requested_product__product_type", lookup_expr="iexact"
+    )
+    medications_only = MedicationFilter(
+        field_name="requested_product__product_type", lookup_expr="iexact"
+    )
 
 
 class MedicationRequestViewSet(


### PR DESCRIPTION
## Proposed Changes

-  Added filter support for SNOMED-based medications and medications as product type.

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional "medications only" filter on the medication request list to narrow results to medication-type items or unassigned products where relevant.

* **Bug Fixes**
  * Improved product-type filtering so searches return both requests with a matching product type and, when appropriate, requests without an assigned product for more complete results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->