### PR TITLE
Fix: enforce facility authorization in update_identifier endpoint

### DIFF
--- a/care/emr/api/viewsets/patient.py
+++ b/care/emr/api/viewsets/patient.py
@@ -400,9 +400,27 @@ class PatientViewSet(EMRModelViewSet):
         request_config = get_object_or_404(
             PatientIdentifierConfig, external_id=request_data.config
         )
+
+        facility = self.get_serializer_list_context().get("facility")
+
+        # Ensure identifier config belongs to the patient's facility context
+        if request_config.facility and facility and request_config.facility.id != facility.id:
+            raise PermissionDenied(
+                "Identifier configuration does not belong to the patient's facility"
+            )
+
+        # Check user permission for the config's facility
+        if request_config.facility and not AuthorizationController.call(
+            "can_write_facility_patient_identifier_config",
+            self.request.user,
+            request_config.facility,
+        ):
+            raise PermissionDenied(
+                "Cannot update identifier for this facility"
+            )
+
         if request_config.config.get("auto_maintained"):
             raise ValidationError("Cannot update auto maintained identifier")
-        # TODO: Check Facility Authz
         value = request_data.value
         if not value and request_config.config["required"]:
             raise ValidationError("Value is required")

--- a/care/emr/tests/test_patient_security_api.py
+++ b/care/emr/tests/test_patient_security_api.py
@@ -1,0 +1,61 @@
+from django.urls import reverse
+from rest_framework import status
+
+from care.emr.models.patient import PatientIdentifier, PatientIdentifierConfig
+from care.security.permissions.patient import PatientPermissions
+from care.utils.tests.base import CareAPITestBase
+
+
+class TestPatientSecurityAPI(CareAPITestBase):
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user()
+        self.facility_a = self.create_facility(self.user)
+        self.facility_b = self.create_facility(self.user)
+
+        self.org_a = self.create_organization(org_type="govt")
+        self.org_b = self.create_organization(org_type="govt")
+
+        # User has access to Facility A
+        self.role = self.create_role_with_permissions(
+            permissions=[
+                PatientPermissions.can_write_patient.name,
+                PatientPermissions.can_list_patients.name,
+            ]
+        )
+        self.attach_role_organization_user(self.org_a, self.user, self.role)
+
+        # Create a patient and link to Org A
+        self.patient = self.create_patient(geo_organization=self.org_a)
+
+    def test_update_identifier_bola_vulnerability(self):
+        """
+        Verify that a user can update an identifier using a config from another facility (BOLA).
+        """
+        # Create Identifier Config for Facility B
+        config_b = PatientIdentifierConfig.objects.create(
+            facility=self.facility_b,
+            status="active",
+            config={"required": True, "auto_maintained": False}
+        )
+
+        self.client.force_authenticate(user=self.user)
+        url = reverse("patient-update-identifier", kwargs={"external_id": self.patient.external_id})
+
+        payload = {
+            "config": str(config_b.external_id),
+            "value": "VULNERABLE_VALUE"
+        }
+
+        response = self.client.post(url, payload, format="json")
+
+        # Verify that access is now blocked (403 Forbidden)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        # Verify the identifier was NOT created in the database
+        exists = PatientIdentifier.objects.filter(
+            patient=self.patient,
+            config=config_b,
+            value="VULNERABLE_VALUE"
+        ).exists()
+        self.assertFalse(exists, "Identifier was created despite 403 Forbidden")

--- a/care/emr/tests/test_patient_security_api.py
+++ b/care/emr/tests/test_patient_security_api.py
@@ -18,9 +18,10 @@ class TestPatientSecurityAPI(CareAPITestBase):
         # User has access to Facility A
         self.role = self.create_role_with_permissions(
             permissions=[
-                PatientPermissions.can_write_facility_patient_identifier_config,
-                PatientPermissions.can_list_patients.name,
-            ]
+    PatientPermissions.can_write_facility_patient_identifier_config.name,
+    PatientPermissions.can_write_patient.name,
+    PatientPermissions.can_list_patients.name,
+    ]
         )
         self.attach_role_organization_user(self.org_a, self.user, self.role)
 

--- a/care/emr/tests/test_patient_security_api.py
+++ b/care/emr/tests/test_patient_security_api.py
@@ -14,12 +14,11 @@ class TestPatientSecurityAPI(CareAPITestBase):
         self.facility_b = self.create_facility(self.user)
 
         self.org_a = self.create_organization(org_type="govt")
-        self.org_b = self.create_organization(org_type="govt")
 
         # User has access to Facility A
         self.role = self.create_role_with_permissions(
             permissions=[
-                PatientPermissions.can_write_patient.name,
+                PatientPermissions.can_write_facility_patient_identifier_config,
                 PatientPermissions.can_list_patients.name,
             ]
         )
@@ -30,7 +29,7 @@ class TestPatientSecurityAPI(CareAPITestBase):
 
     def test_update_identifier_bola_vulnerability(self):
         """
-        Verify that a user can update an identifier using a config from another facility (BOLA).
+        Verify that a user cannot update an identifier using a config from another facility (BOLA).
         """
         # Create Identifier Config for Facility B
         config_b = PatientIdentifierConfig.objects.create(


### PR DESCRIPTION
## Summary

The `update_identifier` endpoint retrieved `PatientIdentifierConfig`
using only the `external_id` without validating the facility relationship.

This could allow cross-facility identifier updates if a valid UUID
was known.

## Fix

Added facility ownership validation before updating identifiers:

- Verify identifier configuration belongs to the same facility as the patient
- Enforce authorization using `AuthorizationController`

## Testing

- Ran Ruff lint checks
- Executed full test suite (1412 tests) – all passed
- Verified endpoint behaviour locally

This resolves the TODO comment in the original code:

`# TODO: Check Facility Authz`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened authorization for patient identifier updates to enforce facility-scoped checks; cross-facility update attempts without facility write permission are now rejected with Forbidden and blocked from creating identifiers.

* **Tests**
  * Added API tests that validate unauthorized identifier update attempts are denied and confirm no identifiers are created as a result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->