### PR TITLE
Fix: prevent 500 error when request body is not JSON object

### DIFF
--- a/care/emr/api/viewsets/facility.py
+++ b/care/emr/api/viewsets/facility.py
@@ -7,7 +7,7 @@ from drf_spectacular.utils import extend_schema
 from rest_framework import filters as drf_filters
 from rest_framework import serializers
 from rest_framework.decorators import action, parser_classes
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.parsers import MultiPartParser
 from rest_framework.response import Response
 
@@ -141,6 +141,8 @@ class FacilityViewSet(EMRModelViewSet):
     )
     @action(methods=["POST"], detail=True)
     def set_monetary_config(self, request, *args, **kwargs):
+        if not isinstance(request.data, dict):
+            raise ValidationError("Invalid request body")
         instance = self.get_object()
         self.authorize_update({}, instance)
         facility_monetory_config = FacilityMonetoryConfig.get_monetory_config(
@@ -167,6 +169,8 @@ class FacilityViewSet(EMRModelViewSet):
     )
     @action(methods=["POST"], detail=True)
     def set_invoice_expression(self, request, *args, **kwargs):
+        if not isinstance(request.data, dict):
+            raise ValidationError("Invalid request body")
         instance = self.get_object()
         self.authorize_update({}, instance)
         facility_monetory_config = FacilityMonetoryConfig.get_monetory_config(

--- a/care/emr/api/viewsets/patient.py
+++ b/care/emr/api/viewsets/patient.py
@@ -196,6 +196,8 @@ class PatientViewSet(EMRModelViewSet):
     )
     @action(detail=False, methods=["POST"])
     def search(self, request, *args, **kwargs):
+        if not isinstance(request.data, dict):
+            raise ValidationError("Invalid request body")
         request_data = self.SearchRequestSpec(**request.data)
         max_page_size = 100
         page_size = min(max_page_size, request_data.page_size)
@@ -270,6 +272,8 @@ class PatientViewSet(EMRModelViewSet):
     )
     @action(detail=False, methods=["POST"])
     def search_retrieve(self, request, *args, **kwargs):
+        if not isinstance(request.data, dict):
+            raise ValidationError("Invalid request body")
         request_data = self.SearchRetrieveRequestSpec(**request.data)
         queryset = Patient.objects.filter(phone_number=request_data.phone_number)
         queryset = queryset.filter(year_of_birth=request_data.year_of_birth)
@@ -300,7 +304,9 @@ class PatientViewSet(EMRModelViewSet):
     @extend_schema(request=PatientUserCreateSpec, responses={200: UserSpec})
     @action(detail=True, methods=["POST"])
     def add_user(self, request, *args, **kwargs):
-        request_data = self.PatientUserCreateSpec(**self.request.data)
+        if not isinstance(request.data, dict):
+            raise ValidationError("Invalid request body")
+        request_data = self.PatientUserCreateSpec(**request.data)
         user = get_object_or_404(User, external_id=request_data.user)
         role = get_object_or_404(RoleModel, external_id=request_data.role)
         patient = self.get_object()
@@ -316,7 +322,9 @@ class PatientViewSet(EMRModelViewSet):
     @extend_schema(request=PatientUserDeleteSpec, responses={200: {}})
     @action(detail=True, methods=["POST"])
     def delete_user(self, request, *args, **kwargs):
-        request_data = self.PatientUserDeleteSpec(**self.request.data)
+        if not isinstance(request.data, dict):
+            raise ValidationError("Invalid request body")
+        request_data = self.PatientUserDeleteSpec(**request.data)
         user = get_object_or_404(User, external_id=request_data.user)
         patient = self.get_object()
         self.authorize_update({}, patient)
@@ -394,15 +402,35 @@ class PatientViewSet(EMRModelViewSet):
     )
     @action(detail=True, methods=["POST"])
     def update_identifier(self, request, *args, **kwargs):
-        request_data = PatientIdentifierConfigRequest(**self.request.data)
+        if not isinstance(request.data, dict):
+            raise ValidationError("Invalid request body")
+        request_data = PatientIdentifierConfigRequest(**request.data)
         patient = self.get_object()
         self.authorize_update({}, patient)
         request_config = get_object_or_404(
             PatientIdentifierConfig, external_id=request_data.config
         )
+
+        facility = self.get_serializer_list_context().get("facility")
+
+        # Ensure identifier config belongs to the patient's facility context
+        if request_config.facility and facility and request_config.facility.id != facility.id:
+            raise PermissionDenied(
+                "Identifier configuration does not belong to the patient's facility"
+            )
+
+        # Check user permission for the config's facility
+        if request_config.facility and not AuthorizationController.call(
+            "can_write_facility_patient_identifier_config",
+            self.request.user,
+            request_config.facility,
+        ):
+            raise PermissionDenied(
+                "Cannot update identifier for this facility"
+            )
+
         if request_config.config.get("auto_maintained"):
             raise ValidationError("Cannot update auto maintained identifier")
-        # TODO: Check Facility Authz
         value = request_data.value
         if not value and request_config.config["required"]:
             raise ValidationError("Value is required")

--- a/care/emr/resources/facility/spec.py
+++ b/care/emr/resources/facility/spec.py
@@ -154,7 +154,7 @@ class FacilityCreateSpec(FacilityBaseSpec):
         obj.geo_organization = Organization.objects.filter(
             external_id=self.geo_organization, org_type="govt"
         ).first()
-        obj.facility_type = REVERSE_REVERSE_FACILITY_TYPES[self.facility_type]
+        obj.facility_type = REVERSE_REVERSE_FACILITY_TYPES.get(self.facility_type)
 
 
 class FacilityReadSpec(FacilityBaseSpec):
@@ -172,7 +172,7 @@ class FacilityReadSpec(FacilityBaseSpec):
         mapping["read_cover_image_url"] = obj.read_cover_image_url()
         if obj.created_by:
             mapping["created_by"] = model_from_cache(UserSpec, id=obj.created_by_id)
-        mapping["facility_type"] = REVERSE_FACILITY_TYPES[obj.facility_type]
+        mapping["facility_type"] = REVERSE_FACILITY_TYPES.get(obj.facility_type, "Unknown")
         if obj.geo_organization:
             mapping["geo_organization"] = OrganizationReadSpec.serialize(
                 obj.geo_organization
@@ -289,7 +289,7 @@ class FacilityMinimalReadSpec(FacilityBaseSpec):
     def perform_extra_serialization(cls, mapping, obj):
         mapping["id"] = obj.external_id
         mapping["read_cover_image_url"] = obj.read_cover_image_url()
-        mapping["facility_type"] = REVERSE_FACILITY_TYPES[obj.facility_type]
+        mapping["facility_type"] = REVERSE_FACILITY_TYPES.get(obj.facility_type, "Unknown")
         if obj.geo_organization:
             mapping["geo_organization"] = OrganizationReadSpec.serialize(
                 obj.geo_organization

--- a/care/emr/tests/test_patient_security_api.py
+++ b/care/emr/tests/test_patient_security_api.py
@@ -1,0 +1,61 @@
+from django.urls import reverse
+from rest_framework import status
+
+from care.emr.models.patient import PatientIdentifier, PatientIdentifierConfig
+from care.security.permissions.patient import PatientPermissions
+from care.utils.tests.base import CareAPITestBase
+
+
+class TestPatientSecurityAPI(CareAPITestBase):
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user()
+        self.facility_a = self.create_facility(self.user)
+        self.facility_b = self.create_facility(self.user)
+
+        self.org_a = self.create_organization(org_type="govt")
+        self.org_b = self.create_organization(org_type="govt")
+
+        # User has access to Facility A
+        self.role = self.create_role_with_permissions(
+            permissions=[
+                PatientPermissions.can_write_patient.name,
+                PatientPermissions.can_list_patients.name,
+            ]
+        )
+        self.attach_role_organization_user(self.org_a, self.user, self.role)
+
+        # Create a patient and link to Org A
+        self.patient = self.create_patient(geo_organization=self.org_a)
+
+    def test_update_identifier_bola_vulnerability(self):
+        """
+        Verify that a user can update an identifier using a config from another facility (BOLA).
+        """
+        # Create Identifier Config for Facility B
+        config_b = PatientIdentifierConfig.objects.create(
+            facility=self.facility_b,
+            status="active",
+            config={"required": True, "auto_maintained": False}
+        )
+
+        self.client.force_authenticate(user=self.user)
+        url = reverse("patient-update-identifier", kwargs={"external_id": self.patient.external_id})
+
+        payload = {
+            "config": str(config_b.external_id),
+            "value": "VULNERABLE_VALUE"
+        }
+
+        response = self.client.post(url, payload, format="json")
+
+        # Verify that access is now blocked (403 Forbidden)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        # Verify the identifier was NOT created in the database
+        exists = PatientIdentifier.objects.filter(
+            patient=self.patient,
+            config=config_b,
+            value="VULNERABLE_VALUE"
+        ).exists()
+        self.assertFalse(exists, "Identifier was created despite 403 Forbidden")


### PR DESCRIPTION
## Summary

Fixes a Broken Object Level Authorization (BOLA) vulnerability in
`PatientViewSet.update_identifier`.

Previously, a user could update a patient identifier using a
`PatientIdentifierConfig` belonging to another facility if they knew
the configuration UUID.

## Fix

Added facility-level validation before updating identifiers:

- Ensure the identifier configuration belongs to the correct facility context.
- Enforce authorization using
  `can_write_facility_patient_identifier_config`.

## Tests

Added a security test (`test_patient_security_api.py`) that verifies:

- Cross-facility identifier updates return **403 Forbidden**
- No identifier is created in the database

All existing tests pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced input validation across API endpoints to properly handle and reject malformed requests.
  * Added authorization checks for facility-specific configuration access and updates.
  * Improved robustness of facility data handling with safer fallback values.

* **Tests**
  * Added security validation tests for configuration access control scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->