### PR TITLE
Validate request body type in EMRCreateMixin and EMRUpdateMixin

### DIFF
--- a/care/emr/api/viewsets/base.py
+++ b/care/emr/api/viewsets/base.py
@@ -131,6 +131,8 @@ class EMRCreateMixin:
         pass
 
     def create(self, request, *args, **kwargs):
+        if not isinstance(request.data, dict):
+            raise RestFrameworkValidationError("Invalid data format")
         return Response(self.handle_create(request.data))
 
     def get_serializer_create_context(self):
@@ -196,8 +198,8 @@ class EMRUpdateMixin:
                 )
 
     def clean_update_data(self, request_data, keep_fields: set | None = None):
-        if type(request_data) is list:
-            return request_data
+        if not isinstance(request_data, dict):
+            raise RestFrameworkValidationError("request body must be json object")
         ignored_fields = {"id", "external_id", "patient", "encounter"}
         if keep_fields:
             ignored_fields = ignored_fields - set(keep_fields)
@@ -209,6 +211,8 @@ class EMRUpdateMixin:
         return request_data
 
     def update(self, request, *args, **kwargs):
+        if not isinstance(request.data, dict):
+            raise RestFrameworkValidationError("request body must be json object")
         instance = self.get_object()
         return Response(self.handle_update(instance, request.data))
 
@@ -265,7 +269,7 @@ class EMRDestroyMixin:
 class EMRUpsertMixin:
     @action(detail=False, methods=["POST"])
     def upsert(self, request, *args, **kwargs):
-        if type(request.data) is not dict:
+        if not isinstance(request.data, dict):
             raise RestFrameworkValidationError("Invalid request data")
         datapoints = request.data.get("datapoints", [])
         if len(datapoints) == 0:

--- a/care/emr/api/viewsets/patient.py
+++ b/care/emr/api/viewsets/patient.py
@@ -401,13 +401,22 @@ class PatientViewSet(EMRModelViewSet):
             PatientIdentifierConfig, external_id=request_data.config
         )
 
-        facility = self.get_serializer_list_context().get("facility")
+        facility_id = request.data.get("facility")
+        facility = None
+        if facility_id:
+            facility = get_object_or_404(Facility, external_id=facility_id)
 
         # Ensure identifier config belongs to the patient's facility context
-        if request_config.facility and facility and request_config.facility.id != facility.id:
-            raise PermissionDenied(
-                "Identifier configuration does not belong to the patient's facility"
-            )
+        if request_config.facility:
+            if not facility:
+                raise PermissionDenied(
+                    "Facility context is required for facility-scoped identifiers"
+                )
+
+            if request_config.facility.id != facility.id:
+                raise PermissionDenied(
+                    "Identifier configuration does not belong to the patient's facility"
+                )
 
         # Check user permission for the config's facility
         if request_config.facility and not AuthorizationController.call(

--- a/care/emr/api/viewsets/patient.py
+++ b/care/emr/api/viewsets/patient.py
@@ -400,9 +400,27 @@ class PatientViewSet(EMRModelViewSet):
         request_config = get_object_or_404(
             PatientIdentifierConfig, external_id=request_data.config
         )
+
+        facility = self.get_serializer_list_context().get("facility")
+
+        # Ensure identifier config belongs to the patient's facility context
+        if request_config.facility and facility and request_config.facility.id != facility.id:
+            raise PermissionDenied(
+                "Identifier configuration does not belong to the patient's facility"
+            )
+
+        # Check user permission for the config's facility
+        if request_config.facility and not AuthorizationController.call(
+            "can_write_facility_patient_identifier_config",
+            self.request.user,
+            request_config.facility,
+        ):
+            raise PermissionDenied(
+                "Cannot update identifier for this facility"
+            )
+
         if request_config.config.get("auto_maintained"):
             raise ValidationError("Cannot update auto maintained identifier")
-        # TODO: Check Facility Authz
         value = request_data.value
         if not value and request_config.config["required"]:
             raise ValidationError("Value is required")

--- a/care/emr/resources/facility/spec.py
+++ b/care/emr/resources/facility/spec.py
@@ -154,7 +154,10 @@ class FacilityCreateSpec(FacilityBaseSpec):
         obj.geo_organization = Organization.objects.filter(
             external_id=self.geo_organization, org_type="govt"
         ).first()
-        obj.facility_type = REVERSE_REVERSE_FACILITY_TYPES[self.facility_type]
+        try:
+            obj.facility_type = REVERSE_REVERSE_FACILITY_TYPES[self.facility_type]
+        except KeyError as exc:
+            raise ValueError(f"Invalid facility_type: {self.facility_type}") from exc
 
 
 class FacilityReadSpec(FacilityBaseSpec):

--- a/care/emr/tests/test_patient_security_api.py
+++ b/care/emr/tests/test_patient_security_api.py
@@ -1,0 +1,61 @@
+from django.urls import reverse
+from rest_framework import status
+
+from care.emr.models.patient import PatientIdentifier, PatientIdentifierConfig
+from care.security.permissions.patient import PatientPermissions
+from care.utils.tests.base import CareAPITestBase
+
+
+class TestPatientSecurityAPI(CareAPITestBase):
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user()
+        self.facility_a = self.create_facility(self.user)
+        self.facility_b = self.create_facility(self.user)
+
+        self.org_a = self.create_organization(org_type="govt")
+        self.org_b = self.create_organization(org_type="govt")
+
+        # User has access to Facility A
+        self.role = self.create_role_with_permissions(
+            permissions=[
+                PatientPermissions.can_write_patient.name,
+                PatientPermissions.can_list_patients.name,
+            ]
+        )
+        self.attach_role_organization_user(self.org_a, self.user, self.role)
+
+        # Create a patient and link to Org A
+        self.patient = self.create_patient(geo_organization=self.org_a)
+
+    def test_update_identifier_bola_vulnerability(self):
+        """
+        Verify that a user can update an identifier using a config from another facility (BOLA).
+        """
+        # Create Identifier Config for Facility B
+        config_b = PatientIdentifierConfig.objects.create(
+            facility=self.facility_b,
+            status="active",
+            config={"required": True, "auto_maintained": False}
+        )
+
+        self.client.force_authenticate(user=self.user)
+        url = reverse("patient-update-identifier", kwargs={"external_id": self.patient.external_id})
+
+        payload = {
+            "config": str(config_b.external_id),
+            "value": "VULNERABLE_VALUE"
+        }
+
+        response = self.client.post(url, payload, format="json")
+
+        # Verify that access is now blocked (403 Forbidden)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        # Verify the identifier was NOT created in the database
+        exists = PatientIdentifier.objects.filter(
+            patient=self.patient,
+            config=config_b,
+            value="VULNERABLE_VALUE"
+        ).exists()
+        self.assertFalse(exists, "Identifier was created despite 403 Forbidden")

--- a/care/emr/tests/test_patient_security_api.py
+++ b/care/emr/tests/test_patient_security_api.py
@@ -18,10 +18,10 @@ class TestPatientSecurityAPI(CareAPITestBase):
         # User has access to Facility A
         self.role = self.create_role_with_permissions(
             permissions=[
-    PatientPermissions.can_write_facility_patient_identifier_config.name,
-    PatientPermissions.can_write_patient.name,
-    PatientPermissions.can_list_patients.name,
-    ]
+                PatientPermissions.can_write_facility_patient_identifier_config.name,
+                PatientPermissions.can_write_patient.name,
+                PatientPermissions.can_list_patients.name,
+            ]
         )
         self.attach_role_organization_user(self.org_a, self.user, self.role)
 

--- a/care/emr/tests/test_patient_security_api.py
+++ b/care/emr/tests/test_patient_security_api.py
@@ -10,13 +10,14 @@ class TestPatientSecurityAPI(CareAPITestBase):
     def setUp(self):
         super().setUp()
         self.user = self.create_user()
+        self.facility_a = self.create_facility(self.user)
         self.facility_b = self.create_facility(self.user)
 
         self.org_a = self.create_organization(org_type="govt")
 
+
         self.role = self.create_role_with_permissions(
             permissions=[
-                PatientPermissions.can_write_facility_patient_identifier_config.name,
                 PatientPermissions.can_write_patient.name,
                 PatientPermissions.can_list_patients.name,
             ]
@@ -42,7 +43,8 @@ class TestPatientSecurityAPI(CareAPITestBase):
 
         payload = {
             "config": str(config_b.external_id),
-            "value": "VULNERABLE_VALUE"
+            "value": "VULNERABLE_VALUE",
+            "facility": str(self.facility_a.external_id),
         }
 
         response = self.client.post(url, payload, format="json")

--- a/care/emr/tests/test_patient_security_api.py
+++ b/care/emr/tests/test_patient_security_api.py
@@ -10,12 +10,10 @@ class TestPatientSecurityAPI(CareAPITestBase):
     def setUp(self):
         super().setUp()
         self.user = self.create_user()
-        self.facility_a = self.create_facility(self.user)
         self.facility_b = self.create_facility(self.user)
 
         self.org_a = self.create_organization(org_type="govt")
 
-        # User has access to Facility A
         self.role = self.create_role_with_permissions(
             permissions=[
                 PatientPermissions.can_write_facility_patient_identifier_config.name,
@@ -23,9 +21,9 @@ class TestPatientSecurityAPI(CareAPITestBase):
                 PatientPermissions.can_list_patients.name,
             ]
         )
+
         self.attach_role_organization_user(self.org_a, self.user, self.role)
 
-        # Create a patient and link to Org A
         self.patient = self.create_patient(geo_organization=self.org_a)
 
     def test_update_identifier_bola_vulnerability(self):

--- a/care/emr/tests/test_patient_security_api.py
+++ b/care/emr/tests/test_patient_security_api.py
@@ -18,9 +18,10 @@ class TestPatientSecurityAPI(CareAPITestBase):
         # User has access to Facility A
         self.role = self.create_role_with_permissions(
             permissions=[
-                PatientPermissions.can_write_facility_patient_identifier_config,
-                PatientPermissions.can_list_patients.name,
-            ]
+    PatientPermissions.can_write_facility_patient_identifier_config.name,
+    PatientPermissions.can_write_patient.name,
+    PatientPermissions.can_list_patients.name,
+    ]
         )
         self.attach_role_organization_user(self.org_a, self.user, self.role)
 

--- a/care/emr/tests/test_patient_security_api.py
+++ b/care/emr/tests/test_patient_security_api.py
@@ -14,12 +14,11 @@ class TestPatientSecurityAPI(CareAPITestBase):
         self.facility_b = self.create_facility(self.user)
 
         self.org_a = self.create_organization(org_type="govt")
-        self.org_b = self.create_organization(org_type="govt")
 
         # User has access to Facility A
         self.role = self.create_role_with_permissions(
             permissions=[
-                PatientPermissions.can_write_patient.name,
+                PatientPermissions.can_write_facility_patient_identifier_config,
                 PatientPermissions.can_list_patients.name,
             ]
         )
@@ -30,7 +29,7 @@ class TestPatientSecurityAPI(CareAPITestBase):
 
     def test_update_identifier_bola_vulnerability(self):
         """
-        Verify that a user can update an identifier using a config from another facility (BOLA).
+        Verify that a user cannot update an identifier using a config from another facility (BOLA).
         """
         # Create Identifier Config for Facility B
         config_b = PatientIdentifierConfig.objects.create(


### PR DESCRIPTION
## Problem

Several viewsets rely on EMRCreateMixin and EMRUpdateMixin which directly pass request.data to Pydantic model validation.

If a request body is not a JSON object (e.g., a list or string), Python raises a TypeError during unpacking, resulting in a 500 Internal Server Error.

This can cause backend crashes across multiple endpoints.

## Solution

Added validation to ensure request.data is a dictionary before processing.

If request.data is not a dict, a RestFrameworkValidationError is raised with a clear message.

## Changes

- Added request body type validation in:
  - EMRCreateMixin.create
  - EMRUpdateMixin.update

## Result

Prevents system-wide TypeError crashes caused by malformed request bodies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * Strengthened facility-aware authorization and validation for patient identifier updates to enforce proper access control.

* **Bug Fixes**
  * Enhanced API request validation to enforce proper JSON object formatting across create, update, and upsert operations.
  * Improved error handling and messaging for invalid facility type configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->