### PR TITLE
fix:changed the default value of extra details in Healthcare service

### DIFF
--- a/care/emr/resources/healthcare_service/spec.py
+++ b/care/emr/resources/healthcare_service/spec.py
@@ -34,7 +34,7 @@ class BaseHealthcareServiceSpec(EMRResource):
     internal_type: HealthcareServiceInternalType | None = None
     name: str
     styling_metadata: dict = {}
-    extra_details: str = ""
+    extra_details: str
 
 
 class HealthcareServiceWriteSpec(BaseHealthcareServiceSpec):


### PR DESCRIPTION
## Proposed Changes

- updated the default value to None.

### Associated Issue

- https://github.com/ohcnetwork/care_fe/issues/16015

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * The `extra_details` field in healthcare service records is now required during creation. Previously optional with an empty default value, you must now explicitly provide this field when initializing healthcare service records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->