### PR TITLE
fix parse_slug called with raw slug in charge item definition

### DIFF
--- a/care/emr/resources/charge_item_definition/spec.py
+++ b/care/emr/resources/charge_item_definition/spec.py
@@ -83,7 +83,7 @@ class ChargeItemDefinitionReadSpec(ChargeItemDefinitionSpec):
             mapping["category"] = ResourceCategoryReadSpec.serialize(
                 obj.category
             ).to_json()
-        mapping["slug_config"] = obj.parse_slug(obj.slug)
+        mapping["slug_config"] = obj.parse_slug(obj.calculate_slug())
         mapping["tags"] = SingleFacilityTagManager().render_tags(obj)
 
         cls.serialize_audit_users(mapping, obj)


### PR DESCRIPTION
## Proposed Changes

- Fixed a `ValueError: Invalid slug` that caused a 500 Internal Server Error on the `/charge_item/` API endpoint
- In `care/emr/resources/charge_item_definition/spec.py`, the `perform_extra_serialization` method was calling `obj.parse_slug(obj.slug)` where `obj.slug` is the raw stored value (e.g. `general-consultation`)
- `parse_slug()` expects the full prefixed format — either `f-{facility-uuid}-{slug}` for facility-scoped definitions or `i-{slug}` for instance-scoped ones
- Passing the raw slug directly causes `ValueError: Invalid slug` every time the charge items list is fetched for a billing account
- Fixed by changing to `obj.parse_slug(obj.calculate_slug())` — `calculate_slug()` already handles building the correct prefixed format based on whether the definition has a facility or not

### Associated Issue - Fixes #3571

### How to reproduce the bug

1. Create a billing account for a patient
2. Add some charge items to it
3. Open the account and click the **Charge Items** tab
4. The API call `/api/v1/facility/{id}/charge_item/?account={uuid}` returns 500

### Architecture changes

- No architecture changes — single line fix in serialization logic

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [x] Any other necessary step

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins
<img width="1204" height="858" alt="Screenshot 2026-03-12 at 05 16 49" src="https://github.com/user-attachments/assets/67e1bbe5-e343-4e38-a0fb-c921a45f698a" />

Now the Items are coming correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated slug derivation logic in charge item definition serialization to compute slugs through an alternative calculation method, affecting how slug configurations are generated during read operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->