### PR TITLE
Add support for default interpretations

### DIFF
--- a/care/emr/resources/observation_definition/spec.py
+++ b/care/emr/resources/observation_definition/spec.py
@@ -81,6 +81,7 @@ ABNORMAL_INTERPRETATION = {"display": "Abnormal"}
 class QualifiedRangeSpec(BaseModel):
     conditions: list[EvaluatorConditionSpec] = []
     ranges: list[NumericRangeSpec] = []
+    default_interpretation: InterpretationSpec | None = None
     normal_coded_value_set: str | None = ""
     critical_coded_value_set: str | None = ""
     abnormal_coded_value_set: str | None = ""

--- a/care/emr/resources/observation_definition/spec.py
+++ b/care/emr/resources/observation_definition/spec.py
@@ -5,6 +5,7 @@ from pydantic import UUID4, BaseModel, Field, field_validator, model_validator
 
 from care.emr.models.observation_definition import ObservationDefinition
 from care.emr.resources.base import EMRResource
+from care.emr.resources.common.coding import Coding
 from care.emr.resources.common.condition_evaluator import EvaluatorConditionSpec
 from care.emr.resources.facility.spec import FacilityBareMinimumSpec
 from care.emr.resources.observation.valueset import (
@@ -52,6 +53,8 @@ class InterpretationSpec(BaseModel):
     display: str
     icon: str | None = ""
     color: str | None = ""
+    highlight: bool | None = False
+    code: Coding | None = {}
 
 
 class NumericRangeSpec(BaseModel):
@@ -79,6 +82,7 @@ ABNORMAL_INTERPRETATION = {"display": "Abnormal"}
 
 
 class QualifiedRangeSpec(BaseModel):
+    title: str | None = None
     conditions: list[EvaluatorConditionSpec] = []
     ranges: list[NumericRangeSpec] = []
     default_interpretation: InterpretationSpec | None = None

--- a/care/utils/evaluators/interpretation_evaluator.py
+++ b/care/utils/evaluators/interpretation_evaluator.py
@@ -136,4 +136,6 @@ class InterpretationEvaluator:
             interpretation, ranges = self.get_interpretation(rule, value)
             if interpretation:
                 return interpretation, ranges
+            if rule.get("default_interpretation"):
+                return rule.get("default_interpretation"), rule.get("ranges", [])
         return None, []


### PR DESCRIPTION
Add support for default interpretations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for default interpretations in observation definitions, enabling fallback interpretations when evaluation rules don't produce explicit matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->