### PR TITLE
Fix component serialization during observation definition update

### DIFF
--- a/care/emr/resources/observation_definition/spec.py
+++ b/care/emr/resources/observation_definition/spec.py
@@ -217,6 +217,9 @@ class ObservationDefinitionUpdateSpec(BaseObservationDefinitionSpec):
 
     def perform_extra_deserialization(self, is_update, obj):
         obj.slug = self.slug_value
+        obj.component = [
+            c.model_dump(mode="json", exclude_defaults=True) for c in self.component
+        ]
 
 
 class ObservationDefinitionReadSpec(BaseObservationDefinitionSpec):

--- a/care/emr/resources/observation_definition/spec.py
+++ b/care/emr/resources/observation_definition/spec.py
@@ -166,7 +166,7 @@ class BaseObservationDefinitionSpec(EMRResource):
     category: ObservationCategoryChoices
     code: ValueSetBoundCoding[CARE_OBSERVATION_VALUSET.slug]
     permitted_data_type: QuestionType
-    component: list[ObservationDefinitionComponentSpec] = []
+    component: list[ObservationDefinitionComponentSpec] | None = None
     body_site: ValueSetBoundCoding[CARE_BODY_SITE_VALUESET.slug] | None = None
     method: ValueSetBoundCoding[CARE_OBSERVATION_COLLECTION_METHOD.slug] | None = None
     permitted_unit: ValueSetBoundCoding[CARE_UCUM_UNITS.slug] | None = None
@@ -217,9 +217,6 @@ class ObservationDefinitionUpdateSpec(BaseObservationDefinitionSpec):
 
     def perform_extra_deserialization(self, is_update, obj):
         obj.slug = self.slug_value
-        obj.component = [
-            c.model_dump(mode="json", exclude_defaults=True) for c in self.component
-        ]
 
 
 class ObservationDefinitionReadSpec(BaseObservationDefinitionSpec):

--- a/care/emr/tests/test_observation_definition_api.py
+++ b/care/emr/tests/test_observation_definition_api.py
@@ -1,0 +1,98 @@
+from django.urls import reverse
+
+from care.emr.resources.observation_definition.spec import (
+    ObservationCategoryChoices,
+    ObservationStatusChoices,
+)
+from care.emr.resources.questionnaire.spec import QuestionType
+from care.utils.tests.base import CareAPITestBase
+
+
+class TestObservationDefinitionViewSet(CareAPITestBase):
+    def setUp(self):
+        super().setUp()
+        self.superuser = self.create_super_user(username="superuser")
+        self.facility = self.create_facility(user=self.superuser)
+        self.base_url = reverse("observation_definition-list")
+        self.client.force_authenticate(user=self.superuser)
+
+    def _obs_def_data(self, slug_value, component=None, **kwargs):
+        data = {
+            "title": "Test Observation Definition",
+            "status": ObservationStatusChoices.active.value,
+            "description": "A test observation definition",
+            "category": ObservationCategoryChoices.vital_signs.value,
+            "code": {"system": "http://example.com", "code": "12345"},
+            "permitted_data_type": QuestionType.decimal.value,
+            "qualified_ranges": [
+                {
+                    "title": "Default",
+                    "ranges": [
+                        {
+                            "interpretation": {"display": "Normal"},
+                            "min": "0",
+                            "max": "100",
+                        }
+                    ],
+                }
+            ],
+            "facility": str(self.facility.external_id),
+            "slug_value": slug_value,
+            **kwargs,
+        }
+        if component is not None:
+            data["component"] = component
+        return data
+
+    def _component_payload(self):
+        return [
+            {
+                "code": {"system": "http://example.com", "code": "comp-1"},
+                "permitted_data_type": QuestionType.decimal.value,
+                "qualified_ranges": [
+                    {
+                        "title": "Component Range",
+                        "ranges": [
+                            {
+                                "interpretation": {"display": "Normal"},
+                                "min": "0",
+                                "max": "50",
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+
+    def _detail_url(self, slug):
+        return reverse("observation_definition-detail", kwargs={"slug": slug})
+
+    def test_update_component_to_empty_list_clears_components(self):
+        """
+        Creating an observation definition with components and then
+        updating with component=[] should clear the component list.
+        """
+        create_data = self._obs_def_data(
+            slug_value="clear-component-test",
+            component=self._component_payload(),
+        )
+        create_resp = self.client.post(self.base_url, create_data, format="json")
+        self.assertEqual(create_resp.status_code, 200)
+        slug = create_resp.data["slug"]
+
+        get_resp = self.client.get(self._detail_url(slug))
+        self.assertEqual(get_resp.status_code, 200)
+        self.assertEqual(len(get_resp.data["component"]), 1)
+
+        update_data = self._obs_def_data(
+            slug_value="clear-component-test",
+            component=[],
+        )
+        update_resp = self.client.put(
+            self._detail_url(slug), update_data, format="json"
+        )
+        self.assertEqual(update_resp.status_code, 200)
+
+        get_resp = self.client.get(self._detail_url(slug))
+        self.assertEqual(get_resp.status_code, 200)
+        self.assertEqual(get_resp.data["component"], [])


### PR DESCRIPTION
## Proposed Changes

- Fixes https://github.com/ohcnetwork/care_fe/issues/16188
- Fixes the component not being cleared during update when an empty `component: []` is sent in PUT request 
- Add test case for the fix


### Associated Issue

- Link to issue here, explain how the proposed solution will solve the reported issue/ feature request.

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve omitted vs explicitly empty observation components during create/update so components are not unintentionally removed or misrepresented.
* **Tests**
  * Added API tests verifying creating, updating (including setting components to an empty list), and retrieving observation definitions behave as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->