### PR TITLE
Add funding manifest URL for OHC network

### DIFF
--- a/.well-known/funding-manifest-urls
+++ b/.well-known/funding-manifest-urls
@@ -1,0 +1,1 @@
+https://ohc.network/funding.json


### PR DESCRIPTION
## Proposed Changes

This pull request introduces a small update to the repository's funding configuration by adding a new funding manifest URL to the `.well-known/funding-manifest-urls` file.

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added funding manifest endpoint configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->