### PR TITLE
updated slug validation regex to make it url safe

### DIFF
--- a/care/emr/tests/test_questionnaire_api.py
+++ b/care/emr/tests/test_questionnaire_api.py
@@ -2542,7 +2542,7 @@ class QuestionnaireRepeatableEnableWhenAllBehaviorTests(CareAPITestBase):
     def _create_questionnaire(self):
         data = {
             "title": "Appointment New",
-            "slug": "Appointment",
+            "slug": "appointment",
             "status": "active",
             "subject_type": "encounter",
             "organizations": [str(self.organization.external_id)],
@@ -2698,7 +2698,7 @@ class QuestionnaireRepeatableEnableWhenAnyBehaviorTests(CareAPITestBase):
     def _create_questionnaire(self):
         data = {
             "title": "Appointment New - Any",
-            "slug": "Appointment-any",
+            "slug": "appointment-any",
             "status": "active",
             "subject_type": "encounter",
             "organizations": [str(self.organization.external_id)],

--- a/care/emr/tests/test_slug_type.py
+++ b/care/emr/tests/test_slug_type.py
@@ -40,11 +40,8 @@ class TestSlugTypeValidation(TestCase):
                 TestModel(slug=slug)
 
     def test_uppercase_slug_handling(self):
-        try:
-            model = TestModel(slug="UPPERCASE")
-            self.assertEqual(model.slug, "UPPERCASE")
-        except ValidationError:
-            pass
+        with self.assertRaises(ValidationError):
+            TestModel(slug="UPPERCASE")
 
     def test_length_constraints(self):
         with self.assertRaises(ValidationError):

--- a/care/emr/tests/test_slug_type.py
+++ b/care/emr/tests/test_slug_type.py
@@ -40,8 +40,8 @@ class TestSlugTypeValidation(TestCase):
                 TestModel(slug=slug)
 
     def test_uppercase_slug_handling(self):
-        with self.assertRaises(ValidationError):
-            TestModel(slug="UPPERCASE")
+        model = TestModel(slug="UPPERCASE")
+        self.assertEqual(model.slug, "UPPERCASE")
 
     def test_length_constraints(self):
         with self.assertRaises(ValidationError):

--- a/care/emr/utils/slug_type.py
+++ b/care/emr/utils/slug_type.py
@@ -12,10 +12,10 @@ def slug_validator(value: str) -> str:
     if not value:
         raise ValueError("Slug cannot be empty")
 
-    pattern = r"^[a-z0-9][a-z0-9_-]*[a-z0-9]$"
+    pattern = r"^[a-zA-Z0-9][a-zA-Z0-9_-]*[a-zA-Z0-9]$"
     if not re.match(pattern, value):
         raise ValueError(
-            "Slug must contain only URL-safe characters (lowercase letters, numbers, hyphens, and underscores). "
+            "Slug must contain only URL-safe characters (letters, numbers, hyphens, and underscores). "
             "It must start and end with alphanumeric characters."
         )
 
@@ -30,10 +30,10 @@ def extended_slug_validator(value: str) -> str:
     if not value:
         raise ValueError("Slug cannot be empty")
 
-    pattern = r"^[a-z0-9][a-z0-9_-]*[a-z0-9]$"
+    pattern = r"^[a-zA-Z0-9][a-zA-Z0-9_-]*[a-zA-Z0-9]$"
     if not re.match(pattern, value):
         raise ValueError(
-            "Slug must contain only URL-safe characters (lowercase letters, numbers, hyphens, and underscores). "
+            "Slug must contain only URL-safe characters (letters, numbers, hyphens, and underscores). "
             "It must start and end with alphanumeric characters."
         )
 

--- a/care/emr/utils/slug_type.py
+++ b/care/emr/utils/slug_type.py
@@ -12,8 +12,8 @@ def slug_validator(value: str) -> str:
     if not value:
         raise ValueError("Slug cannot be empty")
 
-    pattern = r"^[-\w]+$"
-    if not re.match(pattern, value, re.ASCII):
+    pattern = r"^[a-z0-9][a-z0-9_-]*[a-z0-9]$"
+    if not re.match(pattern, value):
         raise ValueError(
             "Slug must contain only URL-safe characters (lowercase letters, numbers, hyphens, and underscores). "
             "It must start and end with alphanumeric characters."
@@ -30,8 +30,8 @@ def extended_slug_validator(value: str) -> str:
     if not value:
         raise ValueError("Slug cannot be empty")
 
-    pattern = r"^[-\w]+$"
-    if not re.match(pattern, value, re.ASCII):
+    pattern = r"^[a-z0-9][a-z0-9_-]*[a-z0-9]$"
+    if not re.match(pattern, value):
         raise ValueError(
             "Slug must contain only URL-safe characters (lowercase letters, numbers, hyphens, and underscores). "
             "It must start and end with alphanumeric characters."


### PR DESCRIPTION
## Proposed Changes

Regex used - `^[a-zA-Z0-9][a-zA-Z0-9_-]*[a-zA-Z0-9]$`

- ^ — start of string                                                                                                                                                                                                                      
- [a-zA-Z0-9] — first character must be a letter (upper or lower) or digit                                                                                                                                                                 
- [a-zA-Z0-9_-]* — middle characters (zero or more) can be letters, digits, hyphens, or underscores                                                                                                                                        
- [a-zA-Z0-9] — last character must be a letter (upper or lower) or digit                                                                                                                                                                  
- $ — end of string 
  
_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Slug validation tightened: slugs must start and end with an ASCII alphanumeric character; hyphens and underscores are allowed only in the middle. Validation message updated accordingly.

* **Tests**
  * Questionnaire and slug-related tests updated to align with the new slug validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->