### PR TITLE
docs: add missing help_text to Facility and Account models

### DIFF
--- a/care/emr/models/account.py
+++ b/care/emr/models/account.py
@@ -8,6 +8,7 @@ class Account(EMRBaseModel):
     facility = models.ForeignKey(
         "facility.Facility",
         on_delete=models.PROTECT,
+        help_text="The facility where this account was created.",
     )
     status = models.CharField(max_length=255)
     billing_status = models.CharField(max_length=255)
@@ -16,14 +17,30 @@ class Account(EMRBaseModel):
     description = models.TextField(null=True, blank=True)
     patient = models.ForeignKey("emr.Patient", on_delete=models.PROTECT)
     cached_items = models.JSONField(default=dict)
-    total_net = models.DecimalField(default=0, max_digits=20, decimal_places=6)
-    total_gross = models.DecimalField(default=0, max_digits=20, decimal_places=6)
-    total_paid = models.DecimalField(default=0, max_digits=20, decimal_places=6)
-    total_balance = models.DecimalField(default=0, max_digits=20, decimal_places=6)
+    total_net = models.DecimalField(
+        default=0, max_digits=20, decimal_places=6,
+        help_text="Total amount after discounts, before tax.",
+    )
+    total_gross = models.DecimalField(
+        default=0, max_digits=20, decimal_places=6,
+        help_text="Total amount before any discounts or adjustments.",
+    )
+    total_paid = models.DecimalField(
+        default=0, max_digits=20, decimal_places=6,
+        help_text="Total amount received from the patient so far.",
+    )
+    total_balance = models.DecimalField(
+        default=0, max_digits=20, decimal_places=6,
+        help_text="Outstanding amount owed."
+    )
     total_price_components = models.JSONField(default=dict)
-    calculated_at = models.DateTimeField(null=True, blank=True, default=None)
+    calculated_at = models.DateTimeField(
+        null=True, blank=True, default=None,
+        help_text="Timestamp of the last billing recalculation. Null if never calculated.",
+        )
     total_billable_charge_items = models.DecimalField(
-        default=0, max_digits=20, decimal_places=6
+        default=0, max_digits=20, decimal_places=6,
+        help_text="Sum of all individual charge items eligible for billing.",
     )
     tags = ArrayField(models.IntegerField(), default=list)
     extensions = models.JSONField(default=dict)

--- a/care/facility/models/facility.py
+++ b/care/facility/models/facility.py
@@ -153,7 +153,9 @@ DOCTOR_TYPES = [
 class Facility(BaseModel):
     name = models.CharField(max_length=1000, blank=False, null=False)
     description = models.TextField(blank=True, null=False)
-    is_active = models.BooleanField(default=True)
+    is_active = models.BooleanField(
+        default=True, help_text="Marks if the facility is admin-verified."
+    )
     verified = models.BooleanField(default=False)
     facility_type = models.IntegerField(choices=FACILITY_TYPES)
     features = ArrayField(
@@ -196,7 +198,10 @@ class Facility(BaseModel):
     )
     middleware_address = models.CharField(null=True, default=None, max_length=200)
 
-    is_public = models.BooleanField(default=False)
+    is_public = models.BooleanField(
+        default=False, 
+        help_text="Controls public visibility of the facility."
+    )
 
     print_templates = models.JSONField(default=list)
 

--- a/care/facility/models/facility.py
+++ b/care/facility/models/facility.py
@@ -199,7 +199,7 @@ class Facility(BaseModel):
     middleware_address = models.CharField(null=True, default=None, max_length=200)
 
     is_public = models.BooleanField(
-        default=False, 
+        default=False,
         help_text="Controls public visibility of the facility."
     )
 

--- a/care/facility/models/facility.py
+++ b/care/facility/models/facility.py
@@ -154,9 +154,11 @@ class Facility(BaseModel):
     name = models.CharField(max_length=1000, blank=False, null=False)
     description = models.TextField(blank=True, null=False)
     is_active = models.BooleanField(
-        default=True, help_text="Marks if the facility is admin-verified."
+        default=True, help_text="Marks if the facility is active/enabled."
     )
-    verified = models.BooleanField(default=False)
+    verified = models.BooleanField(
+        default=False, help_text="Marks if the facility is admin-verified."
+    )
     facility_type = models.IntegerField(choices=FACILITY_TYPES)
     features = ArrayField(
         models.SmallIntegerField(choices=FacilityFeature),


### PR DESCRIPTION
## Proposed Changes

- Added `help_text` to ambiguous and non-obvious fields in the `Facility` 
  model (`care/facility/models/facility.py`) and `Account` model 
  (`care/emr/models/account.py`)
- Focused only on fields where the name alone is insufficient 
- Self-documenting fields (`name`, `description`, `address`, `patient`) 
  were intentionally left unchanged

### Associated Issue

No associated issue. This is a proactive documentation improvement 
identified while onboarding to the codebase. The `help_text` additions 
improve Django admin readability and developer understanding of 
non-obvious fields

## Merge Checklist

- [ ] Tests added/fixed — not applicable, no functional changes
- [ ] Update docs in `/docs` — not applicable
- [x] Linting Complete
- [ ] Any other necessary step — ran `python manage.py check`, no issues

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added descriptive help text to billing account fields (facility/location, net/gross totals, paid amounts, outstanding balance, billing calculation timestamp, and billable charge item summary) to improve clarity and user guidance.
  * Enhanced facility management fields with descriptions for active/enabled status, administrative verification, and public visibility to provide better context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->