### PR TITLE
feat:added support and tests for medication return on supply delivery

### DIFF
--- a/care/emr/api/viewsets/inventory/supply_delivery.py
+++ b/care/emr/api/viewsets/inventory/supply_delivery.py
@@ -138,7 +138,10 @@ class SupplyDeliveryViewSet(
                     raise ValidationError(
                         "Supply delivery is abandoned or entered in error"
                     )
-                if old_instance.status == SupplyDeliveryStatusOptions.completed.value:
+                if (
+                    old_instance.status == SupplyDeliveryStatusOptions.completed.value
+                    and not (instance.order.origin is None and instance.order.patient)
+                ):
                     raise ValidationError("Supply delivery already completed")
                 if (
                     instance.status == SupplyDeliveryStatusOptions.completed.value

--- a/care/emr/tests/test_supply_delivery.py
+++ b/care/emr/tests/test_supply_delivery.py
@@ -770,6 +770,103 @@ class TestSupplyDeliveryViewSet(CareAPITestBase):
             status_code=400,
         )
 
+    def test_update_order_for_completed_supply_delivery_on_medication_return(self):
+        """
+        Test updating order for supply delivery with status as completed on medication return
+        """
+        self.client.force_authenticate(user=self.superuser)
+        supply_delivery = self.create_supply_delivery(
+            order=self.delivery_order_destination_external,
+            supplied_item_quantity=Decimal(500),
+            supplied_item=self.product,
+            status=SupplyDeliveryStatusOptions.completed.value,
+            supplied_inventory_item=self.inventory_item_destination,
+        )
+        medication_return_order = self.create_delivery_order(
+            destination=self.destination,
+            patient=self.patient,
+        )
+        update_response = self.client.put(
+            self.get_detail_url(supply_delivery.external_id),
+            {
+                "status": SupplyDeliveryStatusOptions.entered_in_error.value,
+                "order": medication_return_order.external_id,
+            },
+            format="json",
+        )
+        self.assertEqual(update_response.status_code, 200)
+        get_response = self.client.get(
+            self.get_detail_url(supply_delivery.external_id), format="json"
+        )
+        self.assertEqual(get_response.status_code, 200)
+        self.assertEqual(
+            get_response.data["status"],
+            SupplyDeliveryStatusOptions.entered_in_error.value,
+        )
+
+    def test_update_completed_supply_delivery_for_medication_return(self):
+        """
+        Test updating a completed supply delivery for medication return
+        """
+        self.client.force_authenticate(user=self.superuser)
+        medication_return_order = self.create_delivery_order(
+            destination=self.destination,
+            patient=self.patient,
+        )
+        supply_delivery = self.create_supply_delivery(
+            order=medication_return_order,
+            supplied_item_quantity=Decimal(10),
+            supplied_item=self.product,
+            status=SupplyDeliveryStatusOptions.completed.value,
+            supplied_inventory_item=self.inventory_item_destination,
+        )
+        update_response = self.client.put(
+            self.get_detail_url(supply_delivery.external_id),
+            {"status": SupplyDeliveryStatusOptions.entered_in_error.value},
+            format="json",
+        )
+        self.assertEqual(update_response.status_code, 200)
+        get_response = self.client.get(
+            self.get_detail_url(supply_delivery.external_id), format="json"
+        )
+        self.assertEqual(get_response.status_code, 200)
+        self.assertEqual(
+            get_response.data["status"],
+            SupplyDeliveryStatusOptions.entered_in_error.value,
+        )
+
+    def test_update_completed_supply_delivery_with_different_order(self):
+        """
+        Test updating a completed supply delivery with a different order
+        """
+        self.client.force_authenticate(user=self.superuser)
+        medication_return_order = self.create_delivery_order(
+            destination=self.destination,
+            patient=self.patient,
+        )
+        supply_delivery = self.create_supply_delivery(
+            order=medication_return_order,
+            supplied_item_quantity=Decimal(10),
+            supplied_item=self.product,
+            status=SupplyDeliveryStatusOptions.completed.value,
+            supplied_inventory_item=self.inventory_item_destination,
+        )
+
+        update_response = self.client.put(
+            self.get_detail_url(supply_delivery.external_id),
+            {
+                "status": SupplyDeliveryStatusOptions.entered_in_error.value,
+                "order": self.delivery_order_destination_external.external_id,
+            },
+            format="json",
+        )
+        self.assertEqual(update_response.status_code, 400)
+        self.assertContains(
+            update_response,
+            "Supply delivery already completed",
+            status_code=400,
+        )
+
     # Testcases for retrieve supply delivery
 
     def test_retrieve_supply_delivery_as_superuser(self):


### PR DESCRIPTION
## Proposed Changes

- Allow completed supply delivery to be modified for medication return flow.
- Added testcases 

### Associated Issue

- Updates to supply delivery related to medication returns upon cancellation cannot be processed due to the requirement of a complete status check during the update flow.

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Completed supply deliveries can now be updated and corrected for medication return scenarios, allowing status changes to "entered in error".
  * Validation continues to prevent updates to completed deliveries when reassigning to external orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->