### PR TITLE
feat:added username filter in available user endpoint in appointment api

### DIFF
--- a/care/emr/api/viewsets/scheduling/booking.py
+++ b/care/emr/api/viewsets/scheduling/booking.py
@@ -262,6 +262,10 @@ class TokenBookingViewSet(
             facility=facility,
             user__deleted=False,
         )
+        if request.query_params.get("username"):
+            user_resources = user_resources.filter(
+                user__username__icontains=request.query_params["username"]
+            )
         if request.query_params.get("organization_ids"):
             organization_ids = request.query_params.get("organization_ids").split(",")
             organizations = FacilityOrganization.objects.filter(

--- a/care/emr/tests/test_booking_api.py
+++ b/care/emr/tests/test_booking_api.py
@@ -511,6 +511,19 @@ class TestBookingViewSet(CareAPITestBase):
         self.assertContains(response, self.user.external_id)
         self.assertNotContains(response, deleted_user.external_id)
 
+    def test_list_available_users_filtered_by_username(self):
+        """Users can list available schedulable users filtered by username"""
+        another_user = self.create_user(username="john_doe")
+        self.create_resource(user=another_user)
+
+        available_users_url = reverse(
+            "appointments-available-users",
+            kwargs={"facility_external_id": self.facility.external_id},
+        )
+        response = self.client.get(available_users_url, {"username": "john"})
+        self.assertContains(response, another_user.external_id)
+        self.assertNotContains(response, self.user.external_id)
+
     def test_list_booking_for_user_with_schedules_in_multiple_facilities(self):
         """Appointments for a user with schedules in multiple facilities are filtered correctly."""
         permissions = [SchedulePermissions.can_list_booking.name]


### PR DESCRIPTION

## Proposed Changes

- Added username filter for practitioner filtering for available user endpoint in appointment api
- Added related testcase 

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional username filtering to the available users endpoint. Users can now search for specific resources by username using case-insensitive matching while maintaining all existing filtering capabilities.

* **Tests**
  * Added test coverage for the username filter functionality to verify correct filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->