### PR TITLE
[ENG-112] Add delivery order to supply delivery

### DIFF
--- a/care/emr/resources/inventory/supply_delivery/spec.py
+++ b/care/emr/resources/inventory/supply_delivery/spec.py
@@ -149,9 +149,14 @@ class SupplyDeliveryReadSpec(ExtensionListRenderer, BaseSupplyDeliverySpec):
     supplied_item_pack_quantity: int | None = None
     supplied_item_pack_size: int | None = None
     extensions: dict
+    order: dict | None = None
 
     @classmethod
     def perform_extra_serialization(cls, mapping, obj):
+        from care.emr.resources.inventory.supply_delivery.delivery_order import (
+            SupplyDeliveryOrderReadSpec,
+        )
+
         mapping["id"] = obj.external_id
         if obj.supplied_item:
             mapping["supplied_item"] = ProductReadSpec.serialize(
@@ -165,6 +170,8 @@ class SupplyDeliveryReadSpec(ExtensionListRenderer, BaseSupplyDeliverySpec):
             mapping["supply_request"] = SupplyRequestReadSpec.serialize(
                 obj.supply_request
             ).to_json()
+        if obj.order:
+            mapping["order"] = SupplyDeliveryOrderReadSpec.serialize(obj.order).to_json()
         return super().perform_extra_serialization(mapping, obj)
 
 

--- a/care/emr/resources/inventory/supply_delivery/spec.py
+++ b/care/emr/resources/inventory/supply_delivery/spec.py
@@ -171,7 +171,9 @@ class SupplyDeliveryReadSpec(ExtensionListRenderer, BaseSupplyDeliverySpec):
                 obj.supply_request
             ).to_json()
         if obj.order:
-            mapping["order"] = SupplyDeliveryOrderReadSpec.serialize(obj.order).to_json()
+            mapping["order"] = SupplyDeliveryOrderReadSpec.serialize(
+                obj.order
+            ).to_json()
         return super().perform_extra_serialization(mapping, obj)
 
 


### PR DESCRIPTION
Add Supply Order to Supply Delivery

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Supply delivery responses now include optional order information when available, providing additional context for delivery records.
  * The order payload is added only when present, preserving existing response shapes otherwise.
  * No other input fields or response properties were changed, ensuring backward compatibility for existing integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->