### PR TITLE
Ensure `get_slots_for_day` handler to generate slots across availabilities even if time range conflicts with other availabilities

### DIFF
--- a/care/emr/api/viewsets/scheduling/availability.py
+++ b/care/emr/api/viewsets/scheduling/availability.py
@@ -110,7 +110,7 @@ def convert_availability_and_exceptions_to_slots(availabilities, exceptions, day
 
             if not conflicting:
                 slots[
-                    f"{current_time.time()}-{(current_time + datetime.timedelta(minutes=slot_size_in_minutes)).time()}"
+                    f"{availability_id}-{current_time.time()}-{(current_time + datetime.timedelta(minutes=slot_size_in_minutes)).time()}"
                 ] = {
                     "start_time": current_time.time(),
                     "end_time": (
@@ -260,7 +260,7 @@ class SlotViewSet(EMRRetrieveMixin, EMRBaseViewSet):
         if is_public is True:
             created_slots = created_slots.filter(availability__schedule__is_public=True)
         for slot in created_slots:
-            slot_key = f"{timezone.make_naive(slot.start_datetime).time()}-{timezone.make_naive(slot.end_datetime).time()}"
+            slot_key = f"{slot.availability.id}-{timezone.make_naive(slot.start_datetime).time()}-{timezone.make_naive(slot.end_datetime).time()}"
             if (
                 slot_key in slots
                 and slots[slot_key]["availability_id"] == slot.availability.id

--- a/care/emr/tests/test_booking_api.py
+++ b/care/emr/tests/test_booking_api.py
@@ -1067,7 +1067,7 @@ class TestSlotViewSetSlotStatsApis(CareAPITestBase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data["results"]), 4)
 
-    def test_get_slots_for_day_with_multiple_schedules_having_same_availability_composition(
+    def test_get_slots_for_day_with_availabilities_having_same_availability_composition(
         self,
     ):
         """Slots having the same start and end time across availabilities should also show up."""

--- a/care/emr/tests/test_booking_api.py
+++ b/care/emr/tests/test_booking_api.py
@@ -1067,6 +1067,20 @@ class TestSlotViewSetSlotStatsApis(CareAPITestBase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data["results"]), 4)
 
+    def test_get_slots_for_day_with_multiple_schedules_having_same_availability_composition(
+        self,
+    ):
+        """Slots having the same start and end time across availabilities should also show up."""
+        self.create_availability()  # creates another availability for the resource that'd yield 8 more slots
+        data = {
+            "resource_type": SchedulableResourceTypeOptions.practitioner.value,
+            "resource_id": self.user.external_id,
+            "day": (datetime.now(UTC) + timedelta(days=1)).strftime("%Y-%m-%d"),
+        }
+        response = self.client.post(self._get_slot_for_day_url(), data, format="json")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data["results"]), 16)
+
     def test_availability_stats_with_permission(self):
         """Users can get availability statistics for a date range."""
         permissions = [SchedulePermissions.can_list_booking.name]


### PR DESCRIPTION
## Proposed Changes

- Ensure `get_slots_for_day` handler to generate slots across availabilities even if time range conflicts with other availabilities

### Associated Issue

- https://openhealthcarenetwork.atlassian.net/browse/ENG-234


## Merge Checklist

- [x] Tests added/fixed
- [x] Linting Complete

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disambiguation of overlapping availability slots so identical availability windows for the same resource are correctly distinguished and not duplicated or omitted.

* **Tests**
  * Added a test to verify slot generation when multiple availabilities share the same time composition, ensuring the expected combined slot count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->