### PR TITLE
[Eng-93] fix: Added start time in service_period on system generated accounts

### DIFF
--- a/care/emr/resources/account/default_account.py
+++ b/care/emr/resources/account/default_account.py
@@ -20,5 +20,6 @@ def get_default_account(patient, facility):
         facility=facility,
         status=AccountStatusOptions.active.value,
         billing_status=AccountBillingStatusOptions.open.value,
+        service_period={"start": care_now().strftime("%Y-%m-%dT%H:%M:%S.%fZ")},
         name=f"{patient.name} {care_now().strftime('%Y-%m-%d')}",
     )


### PR DESCRIPTION
## Proposed Changes

- Added start time in service_period for default generated accounts
- [ENG-93]

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Accounts now automatically receive a service period start timestamp upon creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[ENG-93]: https://openhealthcarenetwork.atlassian.net/browse/ENG-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ