### PR TITLE
[ENG-251] Update backend test fixtures to include facility org membership and location-org links

### DIFF
--- a/care/fixtures/base.py
+++ b/care/fixtures/base.py
@@ -183,6 +183,16 @@ class CareFixtureBase:
         }
         return self.post(url, data)
 
+    def add_organization_to_location(self, facility_id, location_id, organization_id):
+        url = reverse(
+            "location-organizations-add",
+            kwargs={
+                "facility_external_id": facility_id,
+                "external_id": location_id,
+            },
+        )
+        return self.post(url, {"organization": organization_id})
+
     def create_device(self, facility_id, **kwargs):
         url = reverse("device-list", kwargs={"facility_external_id": facility_id})
         data = {

--- a/care/fixtures/scripts/default_fixtures.py
+++ b/care/fixtures/scripts/default_fixtures.py
@@ -151,6 +151,14 @@ def load_fixtures(base):  # noqa: PLR0915, PLR0912
                 )
     log("Loading facility organization memberships completed")
 
+    base.create_facility(
+        geo_organization.id,
+        name="SECONDARY FACILITY",
+        facility_type="Private Hospital",
+        is_public=True,
+    )
+    log("Loading secondary facility completed")
+
     base.load_questionnaires_from_file([geo_organization.id])
     log("Loading questionnaires completed")
 

--- a/care/fixtures/scripts/default_fixtures.py
+++ b/care/fixtures/scripts/default_fixtures.py
@@ -140,6 +140,17 @@ def load_fixtures(base):  # noqa: PLR0915, PLR0912
         )
     log("Loading encounters completed")
 
+    admin_org = departments.get("Administration")
+    if admin_org:
+        for role_name in ("Facility Admin", "Nurse", "Staff"):
+            user = created_users.get(role_name)
+            role = roles.get(role_name)
+            if user and role:
+                base.add_user_to_facility_organization(
+                    facility_id, admin_org.id, user.id, role.id
+                )
+    log("Loading facility organization memberships completed")
+
     base.load_questionnaires_from_file([geo_organization.id])
     log("Loading questionnaires completed")
 
@@ -172,6 +183,7 @@ def load_fixtures(base):  # noqa: PLR0915, PLR0912
 
 def load_lab_definitions(base, facility_id, departments):
     laboratory = departments["Laboratory"]
+    administration = departments.get("Administration")
 
     lab_location = base.create_location(
         facility_id,
@@ -180,6 +192,11 @@ def load_lab_definitions(base, facility_id, departments):
         mode=FacilityLocationModeChoices.kind.value,
         organizations=[laboratory.id],
     )
+    base.add_organization_to_location(facility_id, lab_location.id, laboratory.id)
+    if administration:
+        base.add_organization_to_location(
+            facility_id, lab_location.id, administration.id
+        )
 
     lab_charge_category = base.create_resource_category(
         facility_id, "Lab Tests", "charge_item_definition"


### PR DESCRIPTION
## Proposed Changes

- Updated backend test fixtures to include facility org membership and location-org links

### Associated Issue
- https://openhealthcarenetwork.atlassian.net/browse/ENG-271
- https://openhealthcarenetwork.atlassian.net/browse/ENG-275

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for linking organizations to locations in fixture setup, improving location–organization associations.
  * Fixture loading now ensures facility Admin/Nurse/Staff users are assigned to the facility’s Administration organization when present, and lab locations are correctly linked to their organizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->