### PR TITLE
[ENG-117] refact: increase slug size to allow edits to older slugs

### DIFF
--- a/care/emr/tests/test_slug_type.py
+++ b/care/emr/tests/test_slug_type.py
@@ -28,7 +28,7 @@ class TestSlugTypeValidation(TestCase):
         invalid_slugs = [
             "",
             "ab",
-            "a" * 37,
+            "a" * 51,
             "invalid slug",
             "invalid@slug",
             "invalid.slug",
@@ -48,7 +48,7 @@ class TestSlugTypeValidation(TestCase):
             TestModel(slug="ab")
 
         with self.assertRaises(ValidationError):
-            TestModel(slug="a" * 37)
+            TestModel(slug="a" * 51)
 
     def test_optional_slug_handling(self):
         model = TestModel(slug="valid-slug", optional_slug=None)

--- a/care/emr/utils/slug_type.py
+++ b/care/emr/utils/slug_type.py
@@ -45,10 +45,10 @@ def extended_slug_validator(value: str) -> str:
 
 # Define reusable slug types with different lengths
 SlugType = Annotated[
-    str, Field(min_length=5, max_length=36), AfterValidator(slug_validator)
+    str, Field(min_length=5, max_length=50), AfterValidator(slug_validator)
 ]
 
 
 ExtendedSlugType = Annotated[
-    str, Field(min_length=7, max_length=75), AfterValidator(extended_slug_validator)
+    str, Field(min_length=7, max_length=88), AfterValidator(extended_slug_validator)
 ]


### PR DESCRIPTION
ENG-117
## Proposed Changes

- Updated the slug_type size to 50 and extended slug_type to 88.

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated length constraints for slug identifiers to accommodate longer values throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->