### PR TITLE
[ENG-132] feat :separate permissions for external and internal delivery

### DIFF
--- a/care/emr/api/viewsets/inventory/delivery_order.py
+++ b/care/emr/api/viewsets/inventory/delivery_order.py
@@ -114,13 +114,10 @@ class DeliveryOrderViewSet(
         return super().perform_create(instance)
 
     def authorize_order_write(self, order):
-        allowed = False
         if order.origin:
-            allowed = allowed or self.authorize_location_write(
-                order.origin, raise_error=False
-            )
+            allowed = self.authorize_location_write(order.origin, raise_error=False)
         else:
-            allowed = allowed or self.authorize_location_external_write(
+            allowed = self.authorize_location_external_write(
                 order.destination, raise_error=False
             )
         if not allowed:

--- a/care/emr/api/viewsets/inventory/delivery_order.py
+++ b/care/emr/api/viewsets/inventory/delivery_order.py
@@ -113,6 +113,22 @@ class DeliveryOrderViewSet(
             )
         return super().perform_create(instance)
 
+    def authorize_order_write(self, order):
+        allowed = False
+        if order.origin:
+            allowed = allowed or self.authorize_location_write(
+                order.origin, raise_error=False
+            )
+            allowed = allowed or self.authorize_location_write(
+                order.destination, raise_error=False
+            )
+        else:
+            allowed = allowed or self.authorize_location_external_write(
+                order.destination, raise_error=False
+            )
+        if not allowed:
+            raise PermissionDenied("Cannot write supply requests")
+
     def perform_update(self, instance):
         with transaction.atomic():
             old_instance = DeliveryOrder.objects.get(id=instance.id)
@@ -169,10 +185,7 @@ class DeliveryOrderViewSet(
         else the owner is the origin.
         """
         # TODO: Order Destination permission to be figured out
-        if model_instance.origin:
-            self.authorize_location_write(model_instance.origin)
-        else:
-            self.authorize_location_external_write(model_instance.destination)
+        self.authorize_order_write(model_instance)
 
     def authorize_retrieve(self, model_instance):
         allowed = False

--- a/care/emr/api/viewsets/inventory/delivery_order.py
+++ b/care/emr/api/viewsets/inventory/delivery_order.py
@@ -92,6 +92,17 @@ class DeliveryOrderViewSet(
             return False
         return True
 
+    def authorize_location_external_write(self, location_obj, raise_error=True):
+        if not AuthorizationController.call(
+            "can_write_facility_external_supply_delivery",
+            self.request.user,
+            location_obj,
+        ):
+            if raise_error:
+                raise PermissionDenied("Cannot write supply requests")
+            return False
+        return True
+
     def perform_create(self, instance):
         if (
             instance.origin
@@ -150,7 +161,7 @@ class DeliveryOrderViewSet(
             destination_location = get_object_or_404(
                 FacilityLocation, external_id=instance.destination
             )
-            self.authorize_location_write(destination_location)
+            self.authorize_location_external_write(destination_location)
 
     def authorize_update(self, request_obj, model_instance):
         """
@@ -161,7 +172,7 @@ class DeliveryOrderViewSet(
         if model_instance.origin:
             self.authorize_location_write(model_instance.origin)
         else:
-            self.authorize_location_write(model_instance.destination)
+            self.authorize_location_external_write(model_instance.destination)
 
     def authorize_retrieve(self, model_instance):
         allowed = False

--- a/care/emr/api/viewsets/inventory/delivery_order.py
+++ b/care/emr/api/viewsets/inventory/delivery_order.py
@@ -92,17 +92,6 @@ class DeliveryOrderViewSet(
             return False
         return True
 
-    def authorize_location_external_write(self, location_obj, raise_error=True):
-        if not AuthorizationController.call(
-            "can_write_facility_external_supply_delivery",
-            self.request.user,
-            location_obj,
-        ):
-            if raise_error:
-                raise PermissionDenied("Cannot write supply requests")
-            return False
-        return True
-
     def perform_create(self, instance):
         if (
             instance.origin
@@ -161,7 +150,7 @@ class DeliveryOrderViewSet(
             destination_location = get_object_or_404(
                 FacilityLocation, external_id=instance.destination
             )
-            self.authorize_location_external_write(destination_location)
+            self.authorize_location_write(destination_location)
 
     def authorize_update(self, request_obj, model_instance):
         """
@@ -172,7 +161,7 @@ class DeliveryOrderViewSet(
         if model_instance.origin:
             self.authorize_location_write(model_instance.origin)
         else:
-            self.authorize_location_external_write(model_instance.destination)
+            self.authorize_location_write(model_instance.destination)
 
     def authorize_retrieve(self, model_instance):
         allowed = False

--- a/care/emr/api/viewsets/inventory/delivery_order.py
+++ b/care/emr/api/viewsets/inventory/delivery_order.py
@@ -119,9 +119,6 @@ class DeliveryOrderViewSet(
             allowed = allowed or self.authorize_location_write(
                 order.origin, raise_error=False
             )
-            allowed = allowed or self.authorize_location_write(
-                order.destination, raise_error=False
-            )
         else:
             allowed = allowed or self.authorize_location_external_write(
                 order.destination, raise_error=False

--- a/care/emr/api/viewsets/inventory/supply_delivery.py
+++ b/care/emr/api/viewsets/inventory/supply_delivery.py
@@ -170,6 +170,17 @@ class SupplyDeliveryViewSet(
             return False
         return True
 
+    def authorize_location_external_write(self, location_obj, raise_error=True):
+        if not AuthorizationController.call(
+            "can_write_facility_external_supply_delivery",
+            self.request.user,
+            location_obj,
+        ):
+            if raise_error:
+                raise PermissionDenied("Cannot write supply requests")
+            return False
+        return True
+
     def authorize_order_read(self, order):
         allowed = False
         if order.origin:
@@ -188,7 +199,7 @@ class SupplyDeliveryViewSet(
             allowed = allowed or self.authorize_location_write(
                 order.origin, raise_error=False
             )
-        allowed = allowed or self.authorize_location_write(
+        allowed = allowed or self.authorize_location_external_write(
             order.destination, raise_error=False
         )
         if not allowed:

--- a/care/emr/api/viewsets/inventory/supply_delivery.py
+++ b/care/emr/api/viewsets/inventory/supply_delivery.py
@@ -199,9 +199,13 @@ class SupplyDeliveryViewSet(
             allowed = allowed or self.authorize_location_write(
                 order.origin, raise_error=False
             )
-        allowed = allowed or self.authorize_location_external_write(
-            order.destination, raise_error=False
-        )
+            allowed = allowed or self.authorize_location_write(
+                order.destination, raise_error=False
+            )
+        else:
+            allowed = allowed or self.authorize_location_external_write(
+                order.destination, raise_error=False
+            )
         if not allowed:
             raise PermissionDenied("Cannot write supply requests")
 

--- a/care/emr/tests/test_supply_delivery.py
+++ b/care/emr/tests/test_supply_delivery.py
@@ -78,6 +78,7 @@ class TestSupplyDeliveryViewSet(CareAPITestBase):
             permissions=[
                 SupplyDeliveryPermissions.can_read_supply_delivery.name,
                 SupplyDeliveryPermissions.can_write_supply_delivery.name,
+                SupplyDeliveryPermissions.can_write_external_supply_delivery.name,
             ]
         )
         self.base_url = reverse("supply_delivery-list")

--- a/care/emr/tests/test_supply_delivery.py
+++ b/care/emr/tests/test_supply_delivery.py
@@ -78,7 +78,6 @@ class TestSupplyDeliveryViewSet(CareAPITestBase):
             permissions=[
                 SupplyDeliveryPermissions.can_read_supply_delivery.name,
                 SupplyDeliveryPermissions.can_write_supply_delivery.name,
-                SupplyDeliveryPermissions.can_write_external_supply_delivery.name,
             ]
         )
         self.base_url = reverse("supply_delivery-list")
@@ -317,10 +316,16 @@ class TestSupplyDeliveryViewSet(CareAPITestBase):
         Test creating a external supply delivery as a user with permissions
         """
         self.client.force_authenticate(user=self.user)
+        role = self.create_role_with_permissions(
+            permissions=[
+                SupplyDeliveryPermissions.can_read_supply_delivery.name,
+                SupplyDeliveryPermissions.can_write_external_supply_delivery.name,
+            ]
+        )
         self.attach_role_facility_organization_user(
             facility_organization=self.facility_organization,
             user=self.user,
-            role=self.role,
+            role=role,
         )
         data = self.create_supply_delivery_data(
             supplied_item=self.product.external_id,
@@ -357,6 +362,16 @@ class TestSupplyDeliveryViewSet(CareAPITestBase):
         Test creating a external supply delivery as a user without permissions
         """
         self.client.force_authenticate(user=self.user)
+        role = self.create_role_with_permissions(
+            permissions=[
+                SupplyDeliveryPermissions.can_read_supply_delivery.name,
+            ]
+        )
+        self.attach_role_facility_organization_user(
+            facility_organization=self.facility_organization,
+            user=self.user,
+            role=role,
+        )
         data = self.create_supply_delivery_data(
             supplied_item=self.product.external_id,
             order=self.delivery_order_destination_external.external_id,
@@ -565,10 +580,16 @@ class TestSupplyDeliveryViewSet(CareAPITestBase):
         Test updating an external supply delivery as a user with permissions
         """
         self.client.force_authenticate(user=self.user)
+        role = self.create_role_with_permissions(
+            permissions=[
+                SupplyDeliveryPermissions.can_read_supply_delivery.name,
+                SupplyDeliveryPermissions.can_write_external_supply_delivery.name,
+            ]
+        )
         self.attach_role_facility_organization_user(
             facility_organization=self.facility_organization,
             user=self.user,
-            role=self.role,
+            role=role,
         )
         supply_delivery = self.create_supply_delivery(
             order=self.delivery_order_destination_external,
@@ -627,6 +648,16 @@ class TestSupplyDeliveryViewSet(CareAPITestBase):
         Test updating an external supply delivery as a user without permissions
         """
         self.client.force_authenticate(user=self.user)
+        role = self.create_role_with_permissions(
+            permissions=[
+                SupplyDeliveryPermissions.can_read_supply_delivery.name,
+            ]
+        )
+        self.attach_role_facility_organization_user(
+            facility_organization=self.facility_organization,
+            user=self.user,
+            role=role,
+        )
         supply_delivery = self.create_supply_delivery(
             order=self.delivery_order_destination_external,
             supplied_item_quantity=Decimal(500),

--- a/care/security/authorization/supply_delivery.py
+++ b/care/security/authorization/supply_delivery.py
@@ -24,5 +24,15 @@ class SupplyDeliveryAccess(AuthorizationHandler):
             orgs=location.facility_organization_cache,
         )
 
+    def can_write_facility_external_supply_delivery(self, user, location):
+        """
+        Check if the user has permission to view supply deliveries in the location
+        """
+        return self.check_permission_in_facility_organization(
+            [SupplyDeliveryPermissions.can_write_external_supply_delivery.name],
+            user,
+            orgs=location.facility_organization_cache,
+        )
+
 
 AuthorizationController.register_internal_controller(SupplyDeliveryAccess)

--- a/care/security/permissions/supply_delivery.py
+++ b/care/security/permissions/supply_delivery.py
@@ -35,3 +35,9 @@ class SupplyDeliveryPermissions(enum.Enum):
             PHARMACIST_ROLE,
         ],
     )
+    can_write_external_supply_delivery = Permission(
+        "Can Create External Supply Delivery on Facility",
+        "",
+        PermissionContext.FACILITY,
+        [FACILITY_ADMIN_ROLE, ADMIN_ROLE],
+    )


### PR DESCRIPTION

### Associated Issue ENG-132

- Split "Can Create Supply Delivery on Facility" into separate permissions for Supply Delivery and Internal Transfer

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a granular permission for external supply-delivery write access for facility/system admins.

* **Bug Fixes**
  * Centralized and clarified authorization so create/update operations correctly distinguish internal vs external locations and deny writes when neither permission applies.

* **Tests**
  * Updated authorization tests to cover external-write scenarios and explicit permission-denied cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->