### PR TITLE
[ENG-342] fix cancel dispense order

### DIFF
--- a/care/emr/api/viewsets/inventory/dispense_order.py
+++ b/care/emr/api/viewsets/inventory/dispense_order.py
@@ -38,8 +38,8 @@ def cancel_dispense_order(instance, user):
     for dispense in related_dispenses:
         if dispense.charge_item:
             handle_charge_item_cancel(dispense.charge_item)
-        dispense.charge_item.status = ChargeItemStatusOptions.aborted.value
-        dispense.charge_item.updated_by = user
+            dispense.charge_item.status = ChargeItemStatusOptions.aborted.value
+            dispense.charge_item.updated_by = user
         dispense.authorizing_request.dispense_status = (
             MedicationRequestDispenseStatus.incomplete.value
         )

--- a/care/emr/api/viewsets/inventory/dispense_order.py
+++ b/care/emr/api/viewsets/inventory/dispense_order.py
@@ -37,7 +37,7 @@ def cancel_dispense_order(instance, user):
     related_dispenses = MedicationDispense.objects.filter(order=instance)
     for dispense in related_dispenses:
         if dispense.charge_item:
-            handle_charge_item_cancel(instance.charge_item)
+            handle_charge_item_cancel(dispense.charge_item)
         dispense.charge_item.status = ChargeItemStatusOptions.aborted.value
         dispense.charge_item.updated_by = user
         dispense.authorizing_request.dispense_status = (

--- a/care/emr/tests/test_dispense_order_api.py
+++ b/care/emr/tests/test_dispense_order_api.py
@@ -2,11 +2,18 @@ from django.urls import reverse
 from model_bakery import baker
 
 from care.emr.models import FacilityLocation, FacilityLocationOrganization
-from care.emr.models.medication_dispense import DispenseOrder
+from care.emr.models.account import Account
+from care.emr.models.charge_item import ChargeItem
+from care.emr.models.inventory_item import InventoryItem
+from care.emr.models.medication_dispense import DispenseOrder, MedicationDispense
+from care.emr.models.medication_request import MedicationRequest
+from care.emr.models.product import Product
+from care.emr.resources.charge_item.spec import ChargeItemStatusOptions
 from care.emr.resources.location.spec import FacilityLocationModeChoices
 from care.emr.resources.medication.dispense.dispense_order import (
     MedicationDispenseOrderStatusOptions,
 )
+from care.emr.resources.medication.request.spec import MedicationRequestDispenseStatus
 from care.security.permissions.medication import MedicationPermissions
 from care.security.permissions.supply_delivery import SupplyDeliveryPermissions
 from care.utils.tests.base import CareAPITestBase
@@ -58,6 +65,43 @@ class DispenseOrderAPITestCase(CareAPITestBase):
 
     def create_dispense_order(self, **kwargs):
         return baker.make(DispenseOrder, **kwargs)
+
+    def create_medication_dispense_for_order(self, order, **overrides):
+        account = baker.make(Account, facility=order.facility, patient=order.patient)
+        charge_item = baker.make(
+            ChargeItem,
+            facility=order.facility,
+            patient=order.patient,
+            account=account,
+            status=ChargeItemStatusOptions.billable.value,
+            paid_invoice=None,
+        )
+        encounter = self.create_encounter(
+            patient=order.patient,
+            facility=order.facility,
+            organization=self.facility_organization,
+        )
+        authorizing_request = baker.make(
+            MedicationRequest,
+            patient=order.patient,
+            encounter=encounter,
+            dispense_status=MedicationRequestDispenseStatus.complete.value,
+        )
+        product = baker.make(Product, facility=order.facility)
+        inventory_item = baker.make(
+            InventoryItem, location=order.location, product=product
+        )
+        return baker.make(
+            MedicationDispense,
+            order=order,
+            patient=order.patient,
+            location=order.location,
+            encounter=encounter,
+            item=inventory_item,
+            charge_item=charge_item,
+            authorizing_request=authorizing_request,
+            **overrides,
+        )
 
     def generate_base_url(self, facility_external_id):
         return reverse(
@@ -633,3 +677,254 @@ class DispenseOrderAPITestCase(CareAPITestBase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data["results"]), 2)
+
+    # Testcases for status transitions / cancellation of dispense order
+
+    def _put_status(self, dispense_order, status):
+        return self.client.put(
+            self.get_detail_url(self.facility.external_id, dispense_order.external_id),
+            data={"name": dispense_order.name, "status": status},
+            format="json",
+        )
+
+    def test_update_dispense_order_completed_to_abandoned_allowed(self):
+        self.client.force_authenticate(user=self.superuser)
+        dispense_order = self.create_dispense_order(
+            location=self.location,
+            patient=self.patient,
+            name="Completed Order",
+            status=MedicationDispenseOrderStatusOptions.completed,
+            facility=self.facility,
+        )
+        response = self._put_status(
+            dispense_order, MedicationDispenseOrderStatusOptions.abandoned
+        )
+        self.assertEqual(response.status_code, 200)
+        dispense_order.refresh_from_db()
+        self.assertEqual(
+            dispense_order.status,
+            MedicationDispenseOrderStatusOptions.abandoned.value,
+        )
+
+    def test_update_dispense_order_completed_to_entered_in_error_allowed(self):
+        self.client.force_authenticate(user=self.superuser)
+        dispense_order = self.create_dispense_order(
+            location=self.location,
+            patient=self.patient,
+            name="Completed Order",
+            status=MedicationDispenseOrderStatusOptions.completed,
+            facility=self.facility,
+        )
+        response = self._put_status(
+            dispense_order, MedicationDispenseOrderStatusOptions.entered_in_error
+        )
+        self.assertEqual(response.status_code, 200)
+        dispense_order.refresh_from_db()
+        self.assertEqual(
+            dispense_order.status,
+            MedicationDispenseOrderStatusOptions.entered_in_error.value,
+        )
+
+    def test_update_dispense_order_completed_to_draft_rejected(self):
+        self.client.force_authenticate(user=self.superuser)
+        dispense_order = self.create_dispense_order(
+            location=self.location,
+            patient=self.patient,
+            name="Completed Order",
+            status=MedicationDispenseOrderStatusOptions.completed,
+            facility=self.facility,
+        )
+        response = self._put_status(
+            dispense_order, MedicationDispenseOrderStatusOptions.draft
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(
+            "Dispense order can only be cancelled",
+            response.data["errors"][0]["msg"],
+        )
+        dispense_order.refresh_from_db()
+        self.assertEqual(
+            dispense_order.status,
+            MedicationDispenseOrderStatusOptions.completed.value,
+        )
+
+    def test_update_dispense_order_completed_to_in_progress_rejected(self):
+        self.client.force_authenticate(user=self.superuser)
+        dispense_order = self.create_dispense_order(
+            location=self.location,
+            patient=self.patient,
+            name="Completed Order",
+            status=MedicationDispenseOrderStatusOptions.completed,
+            facility=self.facility,
+        )
+        response = self._put_status(
+            dispense_order, MedicationDispenseOrderStatusOptions.in_progress
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(
+            "Dispense order can only be cancelled",
+            response.data["errors"][0]["msg"],
+        )
+
+    def test_update_dispense_order_abandoned_cannot_change(self):
+        self.client.force_authenticate(user=self.superuser)
+        dispense_order = self.create_dispense_order(
+            location=self.location,
+            patient=self.patient,
+            name="Abandoned Order",
+            status=MedicationDispenseOrderStatusOptions.abandoned,
+            facility=self.facility,
+        )
+        response = self._put_status(
+            dispense_order, MedicationDispenseOrderStatusOptions.completed
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(
+            "already abandoned or entered in error",
+            response.data["errors"][0]["msg"],
+        )
+        dispense_order.refresh_from_db()
+        self.assertEqual(
+            dispense_order.status,
+            MedicationDispenseOrderStatusOptions.abandoned.value,
+        )
+
+    def test_update_dispense_order_entered_in_error_cannot_change(self):
+        self.client.force_authenticate(user=self.superuser)
+        dispense_order = self.create_dispense_order(
+            location=self.location,
+            patient=self.patient,
+            name="Errored Order",
+            status=MedicationDispenseOrderStatusOptions.entered_in_error,
+            facility=self.facility,
+        )
+        response = self._put_status(
+            dispense_order, MedicationDispenseOrderStatusOptions.draft
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(
+            "already abandoned or entered in error",
+            response.data["errors"][0]["msg"],
+        )
+
+    def test_update_dispense_order_same_status_no_op(self):
+        self.client.force_authenticate(user=self.superuser)
+        dispense_order = self.create_dispense_order(
+            location=self.location,
+            patient=self.patient,
+            name="Completed Order",
+            status=MedicationDispenseOrderStatusOptions.completed,
+            facility=self.facility,
+        )
+        response = self._put_status(
+            dispense_order, MedicationDispenseOrderStatusOptions.completed
+        )
+        self.assertEqual(response.status_code, 200)
+        dispense_order.refresh_from_db()
+        self.assertEqual(
+            dispense_order.status,
+            MedicationDispenseOrderStatusOptions.completed.value,
+        )
+
+    def test_update_dispense_order_draft_to_completed_allowed(self):
+        self.client.force_authenticate(user=self.superuser)
+        dispense_order = self.create_dispense_order(
+            location=self.location,
+            patient=self.patient,
+            name="Draft Order",
+            status=MedicationDispenseOrderStatusOptions.draft,
+            facility=self.facility,
+        )
+        # Attach a related dispense to confirm cancel logic is NOT triggered
+        # when transitioning out of a non-completed state.
+        related = self.create_medication_dispense_for_order(dispense_order)
+        response = self._put_status(
+            dispense_order, MedicationDispenseOrderStatusOptions.completed
+        )
+        self.assertEqual(response.status_code, 200)
+        related.refresh_from_db()
+        self.assertIsNotNone(related.authorizing_request_id)
+        related.charge_item.refresh_from_db()
+        self.assertEqual(
+            related.charge_item.status, ChargeItemStatusOptions.billable.value
+        )
+
+    def _assert_cancelled_side_effects(self, dispenses):
+        for dispense in dispenses:
+            original_request_id = dispense.authorizing_request_id
+            dispense.refresh_from_db()
+            self.assertIsNone(dispense.authorizing_request_id)
+            dispense.charge_item.refresh_from_db()
+            self.assertEqual(
+                dispense.charge_item.status,
+                ChargeItemStatusOptions.aborted.value,
+            )
+            request = MedicationRequest.objects.get(id=original_request_id)
+            self.assertEqual(
+                request.dispense_status,
+                MedicationRequestDispenseStatus.incomplete.value,
+            )
+
+    def test_cancel_completed_dispense_order_updates_related_records(self):
+        self.client.force_authenticate(user=self.superuser)
+        dispense_order = self.create_dispense_order(
+            location=self.location,
+            patient=self.patient,
+            name="Completed Order",
+            status=MedicationDispenseOrderStatusOptions.completed,
+            facility=self.facility,
+        )
+        dispenses = [
+            self.create_medication_dispense_for_order(dispense_order),
+            self.create_medication_dispense_for_order(dispense_order),
+        ]
+        response = self._put_status(
+            dispense_order, MedicationDispenseOrderStatusOptions.abandoned
+        )
+        self.assertEqual(response.status_code, 200)
+        dispense_order.refresh_from_db()
+        self.assertEqual(
+            dispense_order.status,
+            MedicationDispenseOrderStatusOptions.abandoned.value,
+        )
+        self._assert_cancelled_side_effects(dispenses)
+
+    def test_cancel_completed_dispense_order_via_entered_in_error(self):
+        self.client.force_authenticate(user=self.superuser)
+        dispense_order = self.create_dispense_order(
+            location=self.location,
+            patient=self.patient,
+            name="Completed Order",
+            status=MedicationDispenseOrderStatusOptions.completed,
+            facility=self.facility,
+        )
+        dispenses = [self.create_medication_dispense_for_order(dispense_order)]
+        response = self._put_status(
+            dispense_order, MedicationDispenseOrderStatusOptions.entered_in_error
+        )
+        self.assertEqual(response.status_code, 200)
+        dispense_order.refresh_from_db()
+        self.assertEqual(
+            dispense_order.status,
+            MedicationDispenseOrderStatusOptions.entered_in_error.value,
+        )
+        self._assert_cancelled_side_effects(dispenses)
+
+    def test_cancel_completed_dispense_order_with_no_related_dispenses(self):
+        self.client.force_authenticate(user=self.superuser)
+        dispense_order = self.create_dispense_order(
+            location=self.location,
+            patient=self.patient,
+            name="Completed Order",
+            status=MedicationDispenseOrderStatusOptions.completed,
+            facility=self.facility,
+        )
+        response = self._put_status(
+            dispense_order, MedicationDispenseOrderStatusOptions.abandoned
+        )
+        self.assertEqual(response.status_code, 200)
+        dispense_order.refresh_from_db()
+        self.assertEqual(
+            dispense_order.status,
+            MedicationDispenseOrderStatusOptions.abandoned.value,
+        )


### PR DESCRIPTION
## Proposed Changes

- pass charge item of each medication dispense instead of dispense order in dispense order cancel handler;

### Associated Issue

- [ENG-342]
- [CARE-152]

## Merge Checklist

- [x] Tests added/fixed
- [x] Linting Complete

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


[ENG-342]: https://openhealthcarenetwork.atlassian.net/browse/ENG-342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CARE-152]: https://openhealthcarenetwork.atlassian.net/browse/CARE-152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed charge item handling when cancelling dispense orders with multiple medication items.

* **Tests**
  * Expanded test coverage for dispense order status transitions and cancellation workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohcnetwork/care/pull/3656?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->