### PR TITLE
[ENG-348] Fix macOS support for Nix-based local development

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,19 @@
         pkgs = nixpkgs.legacyPackages.${system};
         python = pkgs.python313;
 
+        # procps on Linux provides pgrep/pkill; on Darwin nixpkgs procps is a stub
+        # without those binaries — use the system tools instead.
+        pgrep =
+          if pkgs.stdenv.isDarwin then
+            "/usr/bin/pgrep"
+          else
+            "${pgrep}";
+        pkill =
+          if pkgs.stdenv.isDarwin then
+            "/usr/bin/pkill"
+          else
+            "${pkill}";
+
         # Create a Python environment with pip-installable packages
         pythonEnv = python.withPackages (
           ps: with ps; [
@@ -59,9 +72,10 @@
           FACILITY_S3_BUCKET = "facility-bucket";
 
           # PostgreSQL configuration for compilation (using Nix store paths)
-          PG_CONFIG = "${pkgs.postgresql_15}/bin/pg_config";
-          LDFLAGS = "-L${pkgs.postgresql_15}/lib";
-          CPPFLAGS = "-I${pkgs.postgresql_15}/include";
+          # pg_config is now a separate derivation in nixpkgs (see NixOS/nixpkgs#408785)
+          PG_CONFIG = "${pkgs.postgresql_15.pg_config}/bin/pg_config";
+          LDFLAGS = "-L${pkgs.libpq}/lib";
+          CPPFLAGS = "-I${pkgs.libpq.dev}/include";
         };
 
         # Helper scripts
@@ -78,7 +92,7 @@
           mkdir -p ${postgresDir} ${redisDir} ${minioDir}
 
           echo "🐘 Starting PostgreSQL..."
-          if ! ${pkgs.procps}/bin/pgrep -x "postgres" > /dev/null; then
+          if ! ${pgrep} -x "postgres" > /dev/null; then
             # Check if database directory is corrupted or not properly initialized
             if [ -d ${postgresDir} ] && [ ! -f ${postgresDir}/PG_VERSION ]; then
               echo "Database directory exists but appears corrupted. Cleaning up..."
@@ -103,7 +117,7 @@
           fi
 
           echo "📮 Starting Redis..."
-          if ! ${pkgs.procps}/bin/pgrep -x "redis-server" > /dev/null; then
+          if ! ${pgrep} -x "redis-server" > /dev/null; then
             # Ensure Redis directory exists
             mkdir -p ${redisDir}
 
@@ -118,7 +132,7 @@
           fi
 
           echo "🗄️ Starting MinIO..."
-          if ! ${pkgs.procps}/bin/pgrep -x "minio" > /dev/null; then
+          if ! ${pgrep} -x "minio" > /dev/null; then
             MINIO_ROOT_USER="${envVars.BUCKET_KEY}" \
             MINIO_ROOT_PASSWORD="${envVars.BUCKET_SECRET}" \
             ${pkgs.minio}/bin/minio server ${minioDir} \
@@ -145,14 +159,14 @@
           if [ -f "$POSTGRES_DIR/postmaster.pid" ]; then
             ${pkgs.postgresql_15}/bin/pg_ctl -D "$POSTGRES_DIR" stop
           else
-            ${pkgs.procps}/bin/pkill postgres || true
+            ${pkill} postgres || true
           fi
 
           echo "Stopping Redis..."
-          ${pkgs.procps}/bin/pkill redis-server || true
+          ${pkill} redis-server || true
 
           echo "Stopping MinIO..."
-          ${pkgs.procps}/bin/pkill minio || true
+          ${pkill} minio || true
 
           echo "✅ Services stopped"
         '';
@@ -163,19 +177,19 @@
 
           # Stop Django development server
           echo "Stopping Django development server..."
-          ${pkgs.procps}/bin/pkill -f "runserver_plus" || true
-          ${pkgs.procps}/bin/pkill -f "manage.py runserver" || true
-          ${pkgs.procps}/bin/pkill -f "python.*manage.py" || true
+          ${pkill} -f "runserver_plus" || true
+          ${pkill} -f "manage.py runserver" || true
+          ${pkill} -f "python.*manage.py" || true
 
           # Stop Celery workers and beat
           echo "Stopping Celery workers..."
-          ${pkgs.procps}/bin/pkill -f "celery.*worker" || true
-          ${pkgs.procps}/bin/pkill -f "celery.*beat" || true
-          ${pkgs.procps}/bin/pkill -f "watchmedo.*celery" || true
+          ${pkill} -f "celery.*worker" || true
+          ${pkill} -f "celery.*beat" || true
+          ${pkill} -f "watchmedo.*celery" || true
 
           # Stop debugpy if running
           echo "Stopping debugger..."
-          ${pkgs.procps}/bin/pkill -f "debugpy" || true
+          ${pkill} -f "debugpy" || true
 
           # Stop background services
           echo "Stopping background services..."
@@ -183,16 +197,16 @@
 
           # Clean up any remaining Python processes that might be related
           echo "Cleaning up remaining processes..."
-          ${pkgs.procps}/bin/pkill -f "python.*config.celery_app" || true
+          ${pkill} -f "python.*config.celery_app" || true
 
           # Wait a moment for processes to terminate
           sleep 2
 
           # Force kill any stubborn processes
           echo "Force killing stubborn processes..."
-          ${pkgs.procps}/bin/pkill -9 -f "runserver_plus" 2>/dev/null || true
-          ${pkgs.procps}/bin/pkill -9 -f "celery.*worker" 2>/dev/null || true
-          ${pkgs.procps}/bin/pkill -9 -f "celery.*beat" 2>/dev/null || true
+          ${pkill} -9 -f "runserver_plus" 2>/dev/null || true
+          ${pkill} -9 -f "celery.*worker" 2>/dev/null || true
+          ${pkill} -9 -f "celery.*beat" 2>/dev/null || true
 
           echo "✅ All development processes stopped"
           echo ""
@@ -221,6 +235,11 @@
         # Development setup
         setupDev = makeScript "setup-dev" ''
           echo "🏗️  Setting up development environment..."
+
+          # Ensure pg_config is on PATH for building psycopg-c
+          # pg_config is now a separate derivation in nixpkgs (see NixOS/nixpkgs#408785)
+          export PATH="${pkgs.postgresql_15.pg_config}/bin:$PATH"
+          export PG_CONFIG="${pkgs.postgresql_15.pg_config}/bin/pg_config"
 
           # Install Python dependencies
           if [ ! -d ".venv" ]; then
@@ -426,6 +445,7 @@
 
             # Databases and services (from Nix store)
             postgresql_15
+            postgresql_15.pg_config
             libpq
             redis
             minio
@@ -441,8 +461,13 @@
             wget
             git
 
-            # Process management
-            procps
+            # WeasyPrint native dependencies (loaded via cffi dlopen at runtime)
+            glib
+            pango
+            harfbuzz
+            fontconfig
+            freetype
+            cairo
 
             # Development tools
             pre-commit
@@ -450,7 +475,11 @@
             # Build tools
             gcc
             gnumake
-
+          ]
+          ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+            pkgs.procps # pgrep/pkill (Darwin uses /usr/bin via processUtils above)
+          ]
+          ++ [
             # Development scripts
             setupDev
             startServices
@@ -480,6 +509,16 @@
             ${builtins.concatStringsSep "\n" (
               pkgs.lib.mapAttrsToList (name: value: "export ${name}='${value}'") envVars
             )}
+
+            # WeasyPrint needs to dlopen native libs (glib, pango, etc.) at runtime
+            export DYLD_FALLBACK_LIBRARY_PATH="${pkgs.lib.makeLibraryPath [
+              pkgs.glib
+              pkgs.pango
+              pkgs.harfbuzz
+              pkgs.fontconfig
+              pkgs.freetype
+              pkgs.cairo
+            ]}''${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 
             # Create project data directory
             mkdir -p ${projectDataDir}
@@ -558,6 +597,21 @@
             echo "Care development environment package"
             echo "Use 'nix develop' to enter the development shell"
           '';
+        };
+
+        # Production OCI image built with dockerTools.
+        #
+        # In CI the image is built via nix-build with --argstr overrides so
+        # that the pre-built .venv and checked-out source are injected.
+        #
+        # Locally you can test with:
+        #   nix build .#dockerImage
+        # (requires a .venv to exist at the repo root)
+        packages.dockerImage = import ./nix/docker-image.nix {
+          inherit pkgs;
+          appVersion = "dev";
+          venvPath = ./.venv;
+          appSrc = ./.;
         };
       }
     );


### PR DESCRIPTION
## Proposed Changes
- My Python installation failed, so I tried using flake.nix to run the server, but some commands failed to execute. Scripts use pgrep and pkill to manage Postgres, Redis, MinIO, Django, and Celery. On Mac, the Nix procps package does not provide those tools, so commands like start-services and stop-all fail

* The given changes were made by @tellmeY18  on my system

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Docker image build capability for development.

* **Chores**
  * Enhanced macOS compatibility for process management.
  * Updated development environment dependencies including native libraries for improved build support.
  * Updated PostgreSQL configuration for development builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohcnetwork/care/pull/3657?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->