### PR TITLE
[ENG-351] Update related dispense's status and fix unable to cancel dispense order having medication dispense without prescription

### DIFF
--- a/care/emr/api/viewsets/inventory/dispense_order.py
+++ b/care/emr/api/viewsets/inventory/dispense_order.py
@@ -36,6 +36,12 @@ from care.utils.filters.multiselect import MultiSelectFilter
 
 def cancel_dispense_order(instance, user):
     related_dispenses = MedicationDispense.objects.filter(order=instance)
+    if instance.status == MedicationDispenseOrderStatusOptions.abandoned.value:
+        dispense_status = MedicationDispenseStatus.cancelled.value
+    elif instance.status == MedicationDispenseOrderStatusOptions.entered_in_error.value:
+        dispense_status = MedicationDispenseStatus.entered_in_error.value
+    else:
+        raise ValidationError("Dispense order can only be cancelled")
     for dispense in related_dispenses:
         if dispense.charge_item:
             handle_charge_item_cancel(dispense.charge_item)
@@ -51,13 +57,7 @@ def cancel_dispense_order(instance, user):
                 update_fields=["dispense_status", "updated_by", "modified_date"]
             )
             dispense.authorizing_request = None
-        if instance.status == MedicationDispenseOrderStatusOptions.abandoned.value:
-            dispense.status = MedicationDispenseStatus.cancelled.value
-        if (
-            instance.status
-            == MedicationDispenseOrderStatusOptions.entered_in_error.value
-        ):
-            dispense.status = MedicationDispenseStatus.entered_in_error.value
+        dispense.status = dispense_status
         dispense.save()
 
 

--- a/care/emr/api/viewsets/inventory/dispense_order.py
+++ b/care/emr/api/viewsets/inventory/dispense_order.py
@@ -26,6 +26,7 @@ from care.emr.resources.medication.dispense.dispense_order import (
     MedicationDispenseOrderStatusOptions,
     MedicationDispenseOrderWriteSpec,
 )
+from care.emr.resources.medication.dispense.spec import MedicationDispenseStatus
 from care.emr.resources.medication.request.spec import MedicationRequestDispenseStatus
 from care.facility.models.facility import Facility
 from care.security.authorization.base import AuthorizationController
@@ -50,6 +51,13 @@ def cancel_dispense_order(instance, user):
                 update_fields=["dispense_status", "updated_by", "modified_date"]
             )
             dispense.authorizing_request = None
+        if instance.status == MedicationDispenseOrderStatusOptions.abandoned.value:
+            dispense.status = MedicationDispenseStatus.cancelled.value
+        if (
+            instance.status
+            == MedicationDispenseOrderStatusOptions.entered_in_error.value
+        ):
+            dispense.status = MedicationDispenseStatus.entered_in_error.value
         dispense.save()
 
 

--- a/care/emr/api/viewsets/inventory/dispense_order.py
+++ b/care/emr/api/viewsets/inventory/dispense_order.py
@@ -40,6 +40,7 @@ def cancel_dispense_order(instance, user):
             handle_charge_item_cancel(dispense.charge_item)
             dispense.charge_item.status = ChargeItemStatusOptions.aborted.value
             dispense.charge_item.updated_by = user
+            dispense.charge_item.save()
         if dispense.authorizing_request:
             dispense.authorizing_request.dispense_status = (
                 MedicationRequestDispenseStatus.incomplete.value
@@ -49,7 +50,6 @@ def cancel_dispense_order(instance, user):
                 update_fields=["dispense_status", "updated_by", "modified_date"]
             )
             dispense.authorizing_request = None
-        dispense.charge_item.save()
         dispense.save()
 
 

--- a/care/emr/api/viewsets/inventory/dispense_order.py
+++ b/care/emr/api/viewsets/inventory/dispense_order.py
@@ -40,14 +40,15 @@ def cancel_dispense_order(instance, user):
             handle_charge_item_cancel(dispense.charge_item)
             dispense.charge_item.status = ChargeItemStatusOptions.aborted.value
             dispense.charge_item.updated_by = user
-        dispense.authorizing_request.dispense_status = (
-            MedicationRequestDispenseStatus.incomplete.value
-        )
-        dispense.authorizing_request.updated_by = user
-        dispense.authorizing_request.save(
-            update_fields=["dispense_status", "updated_by", "modified_date"]
-        )
-        dispense.authorizing_request = None
+        if dispense.authorizing_request:
+            dispense.authorizing_request.dispense_status = (
+                MedicationRequestDispenseStatus.incomplete.value
+            )
+            dispense.authorizing_request.updated_by = user
+            dispense.authorizing_request.save(
+                update_fields=["dispense_status", "updated_by", "modified_date"]
+            )
+            dispense.authorizing_request = None
         dispense.charge_item.save()
         dispense.save()
 

--- a/care/emr/tests/test_dispense_order_api.py
+++ b/care/emr/tests/test_dispense_order_api.py
@@ -81,11 +81,14 @@ class DispenseOrderAPITestCase(CareAPITestBase):
             facility=order.facility,
             organization=self.facility_organization,
         )
-        authorizing_request = baker.make(
-            MedicationRequest,
-            patient=order.patient,
-            encounter=encounter,
-            dispense_status=MedicationRequestDispenseStatus.complete.value,
+        authorizing_request = overrides.pop(
+            "authorizing_request",
+            baker.make(
+                MedicationRequest,
+                patient=order.patient,
+                encounter=encounter,
+                dispense_status=MedicationRequestDispenseStatus.complete.value,
+            ),
         )
         product = baker.make(Product, facility=order.facility)
         inventory_item = baker.make(
@@ -928,3 +931,41 @@ class DispenseOrderAPITestCase(CareAPITestBase):
             dispense_order.status,
             MedicationDispenseOrderStatusOptions.abandoned.value,
         )
+
+    def test_cancel_completed_dispense_order_with_dispense_missing_authorizing_request(
+        self,
+    ):
+        self.client.force_authenticate(user=self.superuser)
+        dispense_order = self.create_dispense_order(
+            location=self.location,
+            patient=self.patient,
+            name="Completed Order",
+            status=MedicationDispenseOrderStatusOptions.completed,
+            facility=self.facility,
+        )
+        dispense_with_request = self.create_medication_dispense_for_order(
+            dispense_order
+        )
+        dispense_without_request = self.create_medication_dispense_for_order(
+            dispense_order, authorizing_request=None
+        )
+        response = self._put_status(
+            dispense_order, MedicationDispenseOrderStatusOptions.abandoned
+        )
+        self.assertEqual(response.status_code, 200)
+        dispense_order.refresh_from_db()
+        self.assertEqual(
+            dispense_order.status,
+            MedicationDispenseOrderStatusOptions.abandoned.value,
+        )
+        # Dispense without an authorizing_request should still have its charge_item
+        # cancelled and remain without an authorizing_request.
+        dispense_without_request.refresh_from_db()
+        self.assertIsNone(dispense_without_request.authorizing_request_id)
+        dispense_without_request.charge_item.refresh_from_db()
+        self.assertEqual(
+            dispense_without_request.charge_item.status,
+            ChargeItemStatusOptions.aborted.value,
+        )
+        # Dispense with an authorizing_request should have full cancel side effects.
+        self._assert_cancelled_side_effects([dispense_with_request])

--- a/care/emr/tests/test_dispense_order_api.py
+++ b/care/emr/tests/test_dispense_order_api.py
@@ -13,6 +13,7 @@ from care.emr.resources.location.spec import FacilityLocationModeChoices
 from care.emr.resources.medication.dispense.dispense_order import (
     MedicationDispenseOrderStatusOptions,
 )
+from care.emr.resources.medication.dispense.spec import MedicationDispenseStatus
 from care.emr.resources.medication.request.spec import MedicationRequestDispenseStatus
 from care.security.permissions.medication import MedicationPermissions
 from care.security.permissions.supply_delivery import SupplyDeliveryPermissions
@@ -852,11 +853,12 @@ class DispenseOrderAPITestCase(CareAPITestBase):
             related.charge_item.status, ChargeItemStatusOptions.billable.value
         )
 
-    def _assert_cancelled_side_effects(self, dispenses):
+    def _assert_cancelled_side_effects(self, dispenses, expected_dispense_status):
         for dispense in dispenses:
             original_request_id = dispense.authorizing_request_id
             dispense.refresh_from_db()
             self.assertIsNone(dispense.authorizing_request_id)
+            self.assertEqual(dispense.status, expected_dispense_status)
             dispense.charge_item.refresh_from_db()
             self.assertEqual(
                 dispense.charge_item.status,
@@ -890,7 +892,9 @@ class DispenseOrderAPITestCase(CareAPITestBase):
             dispense_order.status,
             MedicationDispenseOrderStatusOptions.abandoned.value,
         )
-        self._assert_cancelled_side_effects(dispenses)
+        self._assert_cancelled_side_effects(
+            dispenses, MedicationDispenseStatus.cancelled.value
+        )
 
     def test_cancel_completed_dispense_order_via_entered_in_error(self):
         self.client.force_authenticate(user=self.superuser)
@@ -911,7 +915,9 @@ class DispenseOrderAPITestCase(CareAPITestBase):
             dispense_order.status,
             MedicationDispenseOrderStatusOptions.entered_in_error.value,
         )
-        self._assert_cancelled_side_effects(dispenses)
+        self._assert_cancelled_side_effects(
+            dispenses, MedicationDispenseStatus.entered_in_error.value
+        )
 
     def test_cancel_completed_dispense_order_with_no_related_dispenses(self):
         self.client.force_authenticate(user=self.superuser)
@@ -959,13 +965,19 @@ class DispenseOrderAPITestCase(CareAPITestBase):
             MedicationDispenseOrderStatusOptions.abandoned.value,
         )
         # Dispense without an authorizing_request should still have its charge_item
-        # cancelled and remain without an authorizing_request.
+        # cancelled, status set to cancelled, and remain without an authorizing_request.
         dispense_without_request.refresh_from_db()
         self.assertIsNone(dispense_without_request.authorizing_request_id)
+        self.assertEqual(
+            dispense_without_request.status,
+            MedicationDispenseStatus.cancelled.value,
+        )
         dispense_without_request.charge_item.refresh_from_db()
         self.assertEqual(
             dispense_without_request.charge_item.status,
             ChargeItemStatusOptions.aborted.value,
         )
         # Dispense with an authorizing_request should have full cancel side effects.
-        self._assert_cancelled_side_effects([dispense_with_request])
+        self._assert_cancelled_side_effects(
+            [dispense_with_request], MedicationDispenseStatus.cancelled.value
+        )


### PR DESCRIPTION


## Proposed Changes

- Update related medication dispense's status as well to cancelled/entered-in-error when dispense order is cancelled/abandoned;
- Ensure related medication dispense's authorizing request is updated only if it has an authorizing_request;

### Associated Issue

- ENG-351

## Merge Checklist

- [x] Tests added/fixed
- [x] Linting Complete

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fix cancellation of dispense orders so it no longer fails when a related prescription reference is missing; affected charge items are properly marked aborted and dispense statuses are set to cancelled as expected.

* **Tests**
  * Added and updated tests to cover cancellation scenarios with missing prescription references and to allow overriding the prescription reference in test helpers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohcnetwork/care/pull/3660?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->