### PR TITLE
[ENG-495] Update related dispenses to cancelled when dispense order is cancelled from all statuses

### DIFF
--- a/care/emr/api/viewsets/inventory/dispense_order.py
+++ b/care/emr/api/viewsets/inventory/dispense_order.py
@@ -120,16 +120,18 @@ class DispenseOrderViewSet(
                     raise ValidationError(
                         "Dispense order already abandoned or entered in error"
                     )
-                if (
+                if instance.status in [
+                    MedicationDispenseOrderStatusOptions.abandoned.value,
+                    MedicationDispenseOrderStatusOptions.entered_in_error.value,
+                ]:
+                    cancel_dispense_order(instance, user)
+                elif (
                     old_object.status
                     == MedicationDispenseOrderStatusOptions.completed.value
                 ):
-                    if instance.status not in [
-                        MedicationDispenseOrderStatusOptions.abandoned.value,
-                        MedicationDispenseOrderStatusOptions.entered_in_error.value,
-                    ]:
-                        raise ValidationError("Dispense order can only be cancelled")
-                    cancel_dispense_order(instance, user)
+                    raise ValidationError(
+                        "Completed dispense order can only be cancelled"
+                    )
             return super().perform_update(instance)
 
     def perform_create(self, instance):

--- a/care/emr/tests/test_dispense_order_api.py
+++ b/care/emr/tests/test_dispense_order_api.py
@@ -743,7 +743,7 @@ class DispenseOrderAPITestCase(CareAPITestBase):
         )
         self.assertEqual(response.status_code, 400)
         self.assertIn(
-            "Dispense order can only be cancelled",
+            "Completed dispense order can only be cancelled",
             response.data["errors"][0]["msg"],
         )
         dispense_order.refresh_from_db()
@@ -766,7 +766,7 @@ class DispenseOrderAPITestCase(CareAPITestBase):
         )
         self.assertEqual(response.status_code, 400)
         self.assertIn(
-            "Dispense order can only be cancelled",
+            "Completed dispense order can only be cancelled",
             response.data["errors"][0]["msg"],
         )
 
@@ -936,6 +936,32 @@ class DispenseOrderAPITestCase(CareAPITestBase):
         self.assertEqual(
             dispense_order.status,
             MedicationDispenseOrderStatusOptions.abandoned.value,
+        )
+
+    def test_cancel_non_completed_dispense_order_updates_related_records(self):
+        self.client.force_authenticate(user=self.superuser)
+        dispense_order = self.create_dispense_order(
+            location=self.location,
+            patient=self.patient,
+            name="Draft Order",
+            status=MedicationDispenseOrderStatusOptions.draft,
+            facility=self.facility,
+        )
+        dispenses = [
+            self.create_medication_dispense_for_order(dispense_order),
+            self.create_medication_dispense_for_order(dispense_order),
+        ]
+        response = self._put_status(
+            dispense_order, MedicationDispenseOrderStatusOptions.abandoned
+        )
+        self.assertEqual(response.status_code, 200)
+        dispense_order.refresh_from_db()
+        self.assertEqual(
+            dispense_order.status,
+            MedicationDispenseOrderStatusOptions.abandoned.value,
+        )
+        self._assert_cancelled_side_effects(
+            dispenses, MedicationDispenseStatus.cancelled.value
         )
 
     def test_cancel_completed_dispense_order_with_dispense_missing_authorizing_request(


### PR DESCRIPTION

## Proposed Changes

- Update related dispenses to cancelled when dispense order is cancelled from all statuses
- ENG-495



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved dispense order cancellation logic to properly update related dispenses and associated items when orders are marked as abandoned or entered in error.
  * Enhanced validation to provide clearer error messages when attempting invalid status transitions on completed dispense orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->