### PR TITLE
[ENG-497] Action for validating JIRA ID in PR Titles

### DIFF
--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -4,15 +4,10 @@ on:
   pull_request:
     types: [opened, reopened, edited]
 
-permissions:
-  pull-requests: write
-
 jobs:
   validate-jira-ticket:
     runs-on: ubuntu-24.04-arm
-    if: >
-      github.event.pull_request.user.type != 'Bot' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.user.type != 'Bot'
 
     steps:
       - name: Validate JIRA Ticket in PR Title

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -1,0 +1,38 @@
+name: PR Title JIRA Validation
+
+on:
+  pull_request:
+    types: [opened, reopened, edited]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  validate-jira-ticket:
+    runs-on: ubuntu-24.04-arm
+    if: >
+      github.event.pull_request.user.type != 'Bot' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Validate JIRA Ticket in PR Title
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // Configure JIRA project keys here
+            const jiraProjectKeys = ['ENG'];
+
+            const prTitle = context.payload.pull_request.title;
+
+            // Check that title starts with [ENG-456] format
+            const pattern = new RegExp(`^\\[(${jiraProjectKeys.join('|')})-\\d+\\]`, 'i');
+
+            if (!pattern.test(prTitle)) {
+              const examples = jiraProjectKeys.map(k => `[${k}-123]`).join(', ');
+              core.setFailed(
+                `PR title must start with a JIRA ticket in brackets.\n` +
+                `Expected format: [PROJECT-NUMBER] title\n` +
+                `Examples: ${examples}`
+              );
+            }


### PR DESCRIPTION
## Proposed Changes

- Adds a workflow to Validates that Pull Request titles contain a valid JIRA ticket e.g [ENG-456]

### Associated Issue

- [ENG-497]


## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


[ENG-456]: https://openhealthcarenetwork.atlassian.net/browse/ENG-456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-497]: https://openhealthcarenetwork.atlassian.net/browse/ENG-497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated validation for pull request titles to enforce a JIRA-style ticket prefix (e.g., [ENG-123]), ensuring consistent PR naming; PRs that don’t match the required format will be marked as failed. This check runs on PR creation/editing and ignores bot authors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ohcnetwork/care/pull/3672?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[ENG-123]: https://openhealthcarenetwork.atlassian.net/browse/ENG-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ