### PR TITLE
Use icontains as fallback for AD search

### DIFF
--- a/care/emr/api/viewsets/activity_definition.py
+++ b/care/emr/api/viewsets/activity_definition.py
@@ -1,4 +1,5 @@
 from django.contrib.postgres.search import TrigramSimilarity
+from django.db.models import Q
 from django_filters import rest_framework as filters
 from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.filters import OrderingFilter
@@ -42,7 +43,9 @@ class TrigramFilter(filters.CharFilter):
             queryset.annotate(
                 similarity=TrigramSimilarity(self.field_name, value),
             )
-            .filter(similarity__gt=0.1)
+            .filter(
+                Q(similarity__gt=0.1) | Q(**{f"{self.field_name}__icontains": value})
+            )
             .order_by("-similarity")
         )
 

--- a/care/emr/tests/test_activity_definition_api.py
+++ b/care/emr/tests/test_activity_definition_api.py
@@ -1133,6 +1133,30 @@ class ActivityDefinitionAPITestBase(CareAPITestBase):
             ActivityDefinitionStatusOptions.active.value,
         )
 
+    def test_list_activity_definition_with_title_acronym_filter(self):
+        """Test listing activity definitions with an acronym in the title."""
+        self.client.force_authenticate(user=self.superuser)
+        activity_definition = self.create_activity_definition(
+            facility=self.facility,
+            slug="c-reactive-protein",
+            title="C-reactive protein (CRP including new born)",
+            category=self.resource_category,
+        )
+        self.create_activity_definition(
+            facility=self.facility,
+            slug="complete-blood-count",
+            title="Complete blood count",
+            category=self.resource_category,
+        )
+
+        response = self.client.get(self.base_url, {"title": "CRP"}, format="json")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertEqual(
+            response.data["results"][0]["slug"], str(activity_definition.slug)
+        )
+
     def test_list_activity_definition_with_category_filter(self):
         """Test filtering activity definitions by dummy category filter."""
 


### PR DESCRIPTION
## Proposed Changes

- Brief of changes made.

## Merge Checklist

- [x] Tests added/fixed
- [x] Linting Complete

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced activity definition search filtering to support both similarity-based matching and case-insensitive substring searches, allowing users to find definitions more easily using acronyms or partial text matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->