### PR TITLE
[ENG-553] fix:helper datetime function updated with return localtime

### DIFF
--- a/care/emr/reports/renderer/template_engine.py
+++ b/care/emr/reports/renderer/template_engine.py
@@ -37,9 +37,7 @@ class TemplateEngine:
         env.filters["currency"] = self._filter_currency
         env.filters["phone"] = self._filter_phone
 
-        env.globals["current_date"] = self._current_date
         env.globals["current_datetime"] = self._current_datetime
-        env.globals["current_time"] = self._current_time
 
         return env
 
@@ -147,16 +145,8 @@ class TemplateEngine:
         return phone
 
     @staticmethod
-    def _current_date(format_str: str = "%d/%m/%Y") -> str:
-        return care_now().strftime(format_str)
-
-    @staticmethod
-    def _current_datetime(format_str: str = "%d/%m/%Y %I:%M %p") -> str:
-        return care_now().strftime(format_str)
-
-    @staticmethod
-    def _current_time(format_str: str = "%I:%M %p") -> str:
-        return care_now().strftime(format_str)
+    def _current_datetime() -> datetime:
+        return localtime(care_now())
 
     def validate_syntax(self, template_string: str) -> tuple[bool, str]:
         try:

--- a/care/emr/reports/renderer/template_engine.py
+++ b/care/emr/reports/renderer/template_engine.py
@@ -37,7 +37,9 @@ class TemplateEngine:
         env.filters["currency"] = self._filter_currency
         env.filters["phone"] = self._filter_phone
 
+        env.globals["current_date"] = self._current_date
         env.globals["current_datetime"] = self._current_datetime
+        env.globals["current_time"] = self._current_time
 
         return env
 
@@ -145,8 +147,16 @@ class TemplateEngine:
         return phone
 
     @staticmethod
+    def _current_date() -> date:
+        return TemplateEngine._filter_date(care_now())
+
+    @staticmethod
     def _current_datetime() -> datetime:
-        return localtime(care_now())
+        return TemplateEngine._filter_datetime(care_now())
+
+    @staticmethod
+    def _current_time() -> str:
+        return TemplateEngine._filter_time(care_now())
 
     def validate_syntax(self, template_string: str) -> tuple[bool, str]:
         try:


### PR DESCRIPTION
## Proposed Changes

- Updated the return value of datetime helper function in template to local time

### Associated Issue

- ENG-553

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated report template “current date/time” helpers to rely on the existing date, datetime, and time formatting rules, improving consistent localization across generated reports.
  * Removed support for passing custom format strings to these helpers; they now take no arguments while the underlying formatting is handled by the standard filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->