### PR TITLE
[ENG-572] Fixes user create ignoring geo organization

### DIFF
--- a/care/emr/resources/user/spec.py
+++ b/care/emr/resources/user/spec.py
@@ -99,6 +99,7 @@ class UserCreateSpec(UserUpdateSpec):
         return password
 
     def perform_extra_deserialization(self, is_update, obj):
+        super().perform_extra_deserialization(is_update, obj)
         obj._role_orgs = self.role_orgs  # noqa SLF001
         obj.set_password(self.password)
 

--- a/care/emr/tests/test_user_api.py
+++ b/care/emr/tests/test_user_api.py
@@ -8,6 +8,7 @@ from PIL import Image
 
 from care.emr.resources.patient.spec import GenderChoices
 from care.security.permissions.user import UserPermissions
+from care.users.models import User
 from care.utils.tests.base import CareAPITestBase
 
 
@@ -81,6 +82,12 @@ class UserviewTestCase(CareAPITestBase):
         get_response = self.client.get(self.get_user_detail_url("newuser"))
         self.assertEqual(get_response.status_code, 200)
         self.assertEqual(get_response.data["id"], response.data["id"])
+        self.assertEqual(
+            get_response.data["geo_organization"]["id"],
+            str(self.organization.external_id),
+        )
+        created_user = User.objects.get(username="newuser")
+        self.assertEqual(created_user.geo_organization_id, self.organization.id)
 
     def test_create_user_as_user_with_permission(self):
         self.attach_role_organization_user(
@@ -93,6 +100,12 @@ class UserviewTestCase(CareAPITestBase):
         get_response = self.client.get(self.get_user_detail_url("newuser"))
         self.assertEqual(get_response.status_code, 200)
         self.assertEqual(get_response.data["id"], response.data["id"])
+        self.assertEqual(
+            get_response.data["geo_organization"]["id"],
+            str(self.organization.external_id),
+        )
+        created_user = User.objects.get(username="newuser")
+        self.assertEqual(created_user.geo_organization_id, self.organization.id)
 
     def test_create_user_as_user_without_permission(self):
         self.client.force_authenticate(user=self.user)


### PR DESCRIPTION
## Proposed Changes

- Invoke update spec's perform extra deserialization as well so that geo org is retrieved.

### Associated Issue

- [ENG-572]



[ENG-572]: https://openhealthcarenetwork.atlassian.net/browse/ENG-572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user update handling to ensure geographic organization data is correctly processed during user updates.

* **Tests**
  * Strengthened test coverage for user creation to verify geographic organization assignment is correctly stored and returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->