### PR TITLE
[ENG-587] Add period and range in medication request spec

### DIFF
--- a/care/emr/resources/medication/request/spec.py
+++ b/care/emr/resources/medication/request/spec.py
@@ -11,7 +11,7 @@ from care.emr.models.medication_request import (
     MedicationRequestPrescription,
 )
 from care.emr.models.product_knowledge import ProductKnowledge
-from care.emr.resources.base import EMRResource, model_from_cache
+from care.emr.resources.base import EMRResource, PeriodSpec, model_from_cache
 from care.emr.resources.common.coding import Coding
 from care.emr.resources.inventory.product_knowledge.spec import ProductKnowledgeReadSpec
 from care.emr.resources.medication.request_prescription.spec import (
@@ -120,6 +120,11 @@ class TimingQuantity(BaseModel):
     unit: TimingUnit
 
 
+class TimingRange(BaseModel):
+    low: TimingQuantity
+    high: TimingQuantity
+
+
 class DoseRange(BaseModel):
     low: DosageQuantity
     high: DosageQuantity
@@ -135,7 +140,21 @@ class TimingRepeat(BaseModel):
     frequency: int
     period: Decimal = Field(max_digits=20, decimal_places=0)
     period_unit: TimingUnit
-    bounds_duration: TimingQuantity
+    bounds_duration: TimingQuantity | None = None
+    bounds_range: TimingRange | None = None
+    bounds_period: PeriodSpec | None = None
+
+    @model_validator(mode="after")
+    def validate_bounds(self):
+        if (
+            not self.bounds_duration
+            and not self.bounds_range
+            and not self.bounds_period
+        ):
+            raise ValueError(
+                "At least one of bounds_duration, bounds_range, or bounds_period is required"
+            )
+        return self
 
 
 class Timing(BaseModel):


### PR DESCRIPTION
## Proposed Changes

Add period and range in medication request spec

### Associated Issue

ENG-587

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Medication timing entries now support multiple ways to define bounds, including range and period options in addition to duration.
  * Added support for low/high timing quantities to describe timing ranges more precisely.

* **Bug Fixes**
  * Improved validation so medication timing entries must include at least one bounds value, helping prevent incomplete records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->