### PR TITLE
fix: zero amount/factor on monetary components incorrectly rejected as missing

### DIFF
--- a/care/emr/resources/charge_item/sync_charge_item_costs.py
+++ b/care/emr/resources/charge_item/sync_charge_item_costs.py
@@ -9,11 +9,11 @@ from care.utils.rounding.rounding import care_round
 
 
 def calculate_amount(component, quantity, base):
-    if component.amount:
+    if component.amount is not None:
         component.amount = convert_to_decimal(component.amount)
         component.amount = care_round(component.amount * quantity)
         return component
-    if component.factor:
+    if component.factor is not None:
         component.factor = convert_to_decimal(component.factor)
         component.amount = care_round(base * component.factor / 100)
         return component

--- a/care/emr/resources/common/monetary_component.py
+++ b/care/emr/resources/common/monetary_component.py
@@ -55,7 +55,7 @@ class MonetaryComponent(BaseModel):
 
     @model_validator(mode="after")
     def check_amount_and_factor(self):
-        if self.factor and (self.amount is not None):
+        if (self.factor is not None) and (self.amount is not None):
             raise ValueError(
                 "Only one of 'amount' or 'factor' can be present, not both."
             )
@@ -65,7 +65,7 @@ class MonetaryComponent(BaseModel):
     def check_amount_or_factor(self):
         if self.global_component and self.code:
             return self
-        if not ((self.amount is not None) or self.factor):
+        if not ((self.amount is not None) or (self.factor is not None)):
             raise ValueError("Either 'amount' or 'factor' must be present.")
         return self
 

--- a/care/emr/tests/test_charge_item_api.py
+++ b/care/emr/tests/test_charge_item_api.py
@@ -26,6 +26,9 @@ from care.emr.resources.charge_item.spec import (
     ChargeItemStatusOptions,
     ChargeItemWriteSpec,
 )
+from care.emr.resources.charge_item.sync_charge_item_costs import (
+    sync_charge_item_costs,
+)
 from care.emr.resources.charge_item_definition.spec import (
     ChargeItemDefinitionStatusOptions,
 )
@@ -1896,3 +1899,112 @@ class TestChargeItemPydanticValidation(CareAPITestBase):
         self.assertIsNone(request.patient)
         self.assertIsNone(request.service_resource)
         self.assertIsNone(request.service_resource_id)
+
+
+class TestSyncChargeItemCostsZeroAmountComponents(CareAPITestBase):
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user()
+        self.facility = self.create_facility(user=self.user)
+        self.organization = self.create_facility_organization(facility=self.facility)
+        self.patient = self.create_patient()
+        self.encounter = self.create_encounter(
+            patient=self.patient, facility=self.facility, organization=self.organization
+        )
+        self.account = Account.objects.create(
+            facility=self.facility,
+            patient=self.patient,
+            name=f"Account for {self.patient.name}",
+            status=AccountStatusOptions.active.value,
+            billing_status=AccountBillingStatusOptions.open.value,
+        )
+
+    def _build_charge_item(self, unit_price_components, quantity=Decimal("1.00")):
+        return ChargeItem(
+            facility=self.facility,
+            title="Test Item",
+            patient=self.patient,
+            account=self.account,
+            status="billable",
+            quantity=quantity,
+            unit_price_components=unit_price_components,
+        )
+
+    def test_zero_amount_tax_component_does_not_raise(self):
+        """
+        Verify that a tax component with amount=0 does not raise and contributes 0.
+        """
+        charge_item = self._build_charge_item(
+            [
+                {"monetary_component_type": "base", "amount": "100.00"},
+                {"monetary_component_type": "tax", "amount": "0.00"},
+            ]
+        )
+        sync_charge_item_costs(charge_item)
+        self.assertEqual(charge_item.total_price, Decimal("100.00"))
+
+    def test_zero_amount_surcharge_component_does_not_raise(self):
+        """
+        Verify that a surcharge component with amount=0 does not raise and contributes 0.
+        """
+        charge_item = self._build_charge_item(
+            [
+                {"monetary_component_type": "base", "amount": "100.00"},
+                {"monetary_component_type": "surcharge", "amount": "0.00"},
+            ]
+        )
+        sync_charge_item_costs(charge_item)
+        self.assertEqual(charge_item.total_price, Decimal("100.00"))
+
+    def test_zero_amount_discount_component_does_not_raise(self):
+        """
+        Verify that a discount component with amount=0 does not raise and contributes 0.
+        """
+        charge_item = self._build_charge_item(
+            [
+                {"monetary_component_type": "base", "amount": "100.00"},
+                {"monetary_component_type": "discount", "amount": "0.00"},
+            ]
+        )
+        sync_charge_item_costs(charge_item)
+        self.assertEqual(charge_item.total_price, Decimal("100.00"))
+
+    def test_nonzero_amount_components_still_work(self):
+        """
+        Verify that non-zero discount and tax amounts are correctly calculated.
+        """
+        charge_item = self._build_charge_item(
+            [
+                {"monetary_component_type": "base", "amount": "100.00"},
+                {"monetary_component_type": "tax", "amount": "10.00"},
+                {"monetary_component_type": "discount", "amount": "5.00"},
+            ]
+        )
+        sync_charge_item_costs(charge_item)
+        self.assertEqual(charge_item.total_price, Decimal("105.00"))
+
+    def test_factor_based_components_still_work(self):
+        """
+        Verify that factor-based tax components are calculated correctly.
+        """
+        charge_item = self._build_charge_item(
+            [
+                {"monetary_component_type": "base", "amount": "100.00"},
+                {"monetary_component_type": "tax", "factor": "10.00"},
+            ]
+        )
+        sync_charge_item_costs(charge_item)
+        self.assertEqual(charge_item.total_price, Decimal("110.00"))
+
+    def test_missing_amount_and_factor_still_raises(self):
+        """
+        Verify that a component missing both amount and factor raises Pydantic ValidationError.
+        """
+        charge_item = self._build_charge_item(
+            [
+                {"monetary_component_type": "base", "amount": "100.00"},
+                {"monetary_component_type": "tax"},
+            ]
+        )
+        with self.assertRaises(PydanticValidationError):
+            sync_charge_item_costs(charge_item)

--- a/care/emr/tests/test_charge_item_api.py
+++ b/care/emr/tests/test_charge_item_api.py
@@ -1985,7 +1985,7 @@ class TestSyncChargeItemCostsZeroAmountComponents(CareAPITestBase):
 
     def test_factor_based_components_still_work(self):
         """
-        Verify that factor-based tax components are calculated correctly.
+        Sanity check that non-zero factor-based (percentage) components, which were already handled correctly.
         """
         charge_item = self._build_charge_item(
             [
@@ -1995,6 +1995,26 @@ class TestSyncChargeItemCostsZeroAmountComponents(CareAPITestBase):
         )
         sync_charge_item_costs(charge_item)
         self.assertEqual(charge_item.total_price, Decimal("110.00"))
+
+    def test_zero_factor_component_does_not_raise(self):
+        """
+        A tax component with factor=0 (e.g. a 0% tax bracket) should
+        compute to a zero contribution, not raise "Amount or factor is
+        required". This mirrors the amount=0 cases above but exercises
+        the `factor` branch of `calculate_amount` specifically, since
+        `factor=0` was just as broken as `amount=0` by the original
+        truthy check.
+        """
+        charge_item = self._build_charge_item(
+            [
+                {"monetary_component_type": "base", "amount": "100.00"},
+                {"monetary_component_type": "tax", "factor": "0"},
+            ]
+        )
+
+        sync_charge_item_costs(charge_item)
+
+        self.assertEqual(charge_item.total_price, Decimal("100.00"))
 
     def test_missing_amount_and_factor_still_raises(self):
         """


### PR DESCRIPTION
## Proposed Changes

- Fixes a bug where monetary components (tax, surcharge, or discount) on a charge item with an explicitly-set `amount` or `factor` of exactly `0` were incorrectly rejected as if neither value were present.
- Root cause: `calculate_amount()` in `care/emr/resources/charge_item/sync_charge_item_costs.py`, and the `check_amount_and_factor` / `check_amount_or_factor` validators on `MonetaryComponent` in `care/emr/resources/common/monetary_component.py`, used truthy checks (`if component.amount:`, `if component.factor:`) on `Decimal` fields. `Decimal("0")` is falsy in Python, so a zero-value component was treated as missing, incorrectly raising `"Either 'amount' or 'factor' must be present."` / `"Amount or factor is required"` even though zero is a valid, schema-allowed value (no `gt=0` constraint exists on either field).
- This meant a perfectly ordinary case — e.g. a tax-exempt line item recorded as `amount: 0` rather than omitted, or a `0%`/`0`-value surcharge kept for auditability — would crash charge item creation entirely.
- Fix: switched all three checks to explicit `is not None` checks, consistent with how `amount` was already checked correctly elsewhere in the same file (e.g. `check_tax_included_amount_and_amount`).
- Added regression tests covering: zero-amount tax/surcharge/discount components (each should compute correctly instead of raising), a non-zero sanity check, factor-based components, and confirmation that a component missing both `amount` and `factor` still correctly raises.

### Associated Issue

- No existing GitHub issue. Found via manual code audit and confirmed via a Django shell session reproducing the failure before any fix was applied.

## Merge Checklist

- [x] Tests added
- [x] Linting Complete

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed charge item cost calculations to correctly handle zero-valued tax, surcharge, and discount amounts.
  * Updated monetary component validation to treat `0` amounts/factors as valid (instead of interpreting them as missing).
  * Ensured total price calculation remains correct for both amount-based and factor-based components.

* **Tests**
  * Added coverage for zero `amount` and zero `factor` scenarios, and for validation errors when both are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->