### PR TITLE
fix: attach_account_to_invoice assigns queryset instead of list to ArrayField

### DIFF
--- a/care/emr/api/viewsets/invoice.py
+++ b/care/emr/api/viewsets/invoice.py
@@ -298,7 +298,7 @@ class InvoiceViewSet(
                     account=invoice.account,
                     status=ChargeItemStatusOptions.billable.value,
                 )
-                invoice.charge_items = charge_items.values_list("id", flat=True)
+                invoice.charge_items = list(charge_items.values_list("id", flat=True))
                 sync_invoice_items(invoice)
                 invoice.updated_by = self.request.user
                 invoice.save()

--- a/care/emr/tests/test_invoice_api.py
+++ b/care/emr/tests/test_invoice_api.py
@@ -1,0 +1,147 @@
+from decimal import Decimal
+
+from django.urls import reverse
+from model_bakery import baker
+from rest_framework import status
+
+from care.emr.models import Account
+from care.emr.resources.account.spec import (
+    AccountBillingStatusOptions,
+    AccountStatusOptions,
+)
+from care.emr.resources.charge_item.spec import ChargeItemStatusOptions
+from care.emr.resources.invoice.spec import InvoiceStatusOptions
+from care.security.permissions.invoice import InvoicePermissions
+from care.utils.tests.base import CareAPITestBase
+
+
+class TestAttachAccountToInvoice(CareAPITestBase):
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user()
+        self.facility = self.create_facility(user=self.user)
+        self.organization = self.create_facility_organization(facility=self.facility)
+        self.patient = self.create_patient()
+        self.encounter = self.create_encounter(
+            patient=self.patient, facility=self.facility, organization=self.organization
+        )
+
+        self.account = Account.objects.create(
+            facility=self.facility,
+            patient=self.patient,
+            name=f"Account for {self.patient.name}",
+            status=AccountStatusOptions.active.value,
+            billing_status=AccountBillingStatusOptions.open.value,
+        )
+
+        self.charge_item_1 = baker.make(
+            "emr.ChargeItem",
+            facility=self.facility,
+            patient=self.patient,
+            encounter=self.encounter,
+            account=self.account,
+            status=ChargeItemStatusOptions.billable.value,
+            quantity=Decimal("1.00"),
+            unit_price_components=[{"amount": 100, "monetary_component_type": "base"}],
+            total_price_components=[{"amount": 100, "monetary_component_type": "base"}],
+            total_price=Decimal("100.00"),
+        )
+        self.charge_item_2 = baker.make(
+            "emr.ChargeItem",
+            facility=self.facility,
+            patient=self.patient,
+            encounter=self.encounter,
+            account=self.account,
+            status=ChargeItemStatusOptions.billable.value,
+            quantity=Decimal("1.00"),
+            unit_price_components=[{"amount": 200, "monetary_component_type": "base"}],
+            total_price_components=[{"amount": 200, "monetary_component_type": "base"}],
+            total_price=Decimal("200.00"),
+        )
+
+    def _get_url(self, invoice_external_id):
+        return reverse(
+            "invoice-attach-account-to-invoice",
+            kwargs={
+                "facility_external_id": self.facility.external_id,
+                "external_id": invoice_external_id,
+            },
+        )
+
+    def test_attach_account_to_invoice_attaches_all_billable_charge_items(self):
+        role = self.create_role_with_permissions(
+            [
+                InvoicePermissions.can_read_invoice.name,
+                InvoicePermissions.can_write_invoice.name,
+            ]
+        )
+        self.attach_role_facility_organization_user(self.organization, self.user, role)
+        self.client.force_authenticate(user=self.user)
+
+        invoice = baker.make(
+            "emr.Invoice",
+            facility=self.facility,
+            account=self.account,
+            patient=self.patient,
+            status=InvoiceStatusOptions.draft.value,
+            total_net=Decimal("0.00"),
+            total_gross=Decimal("0.00"),
+        )
+
+        response = self.client.post(self._get_url(invoice.external_id))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        invoice.refresh_from_db()
+        # Assert invoice.charge_items is a proper Python list, not a queryset
+        self.assertIsInstance(invoice.charge_items, list)
+        self.assertEqual(len(invoice.charge_items), 2)
+        self.assertIn(self.charge_item_1.id, invoice.charge_items)
+        self.assertIn(self.charge_item_2.id, invoice.charge_items)
+
+        # Assert charge items status updated to billed and paid_invoice set
+        self.charge_item_1.refresh_from_db()
+        self.charge_item_2.refresh_from_db()
+        self.assertEqual(
+            self.charge_item_1.status, ChargeItemStatusOptions.billed.value
+        )
+        self.assertEqual(
+            self.charge_item_2.status, ChargeItemStatusOptions.billed.value
+        )
+        self.assertEqual(self.charge_item_1.paid_invoice, invoice)
+        self.assertEqual(self.charge_item_2.paid_invoice, invoice)
+
+    def test_attach_account_to_invoice_requires_draft_status(self):
+        role = self.create_role_with_permissions(
+            [
+                InvoicePermissions.can_read_invoice.name,
+                InvoicePermissions.can_write_invoice.name,
+            ]
+        )
+        self.attach_role_facility_organization_user(self.organization, self.user, role)
+        self.client.force_authenticate(user=self.user)
+
+        invoice = baker.make(
+            "emr.Invoice",
+            facility=self.facility,
+            account=self.account,
+            patient=self.patient,
+            status=InvoiceStatusOptions.issued.value,
+        )
+
+        response = self.client.post(self._get_url(invoice.external_id))
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_attach_account_to_invoice_without_permission(self):
+        # Authenticate without attaching the role with permissions to the user
+        self.client.force_authenticate(user=self.user)
+
+        invoice = baker.make(
+            "emr.Invoice",
+            facility=self.facility,
+            account=self.account,
+            patient=self.patient,
+            status=InvoiceStatusOptions.draft.value,
+        )
+
+        response = self.client.post(self._get_url(invoice.external_id))
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)


### PR DESCRIPTION
## Proposed Changes

- Fixes a bug in `attach_account_to_invoice` where `invoice.charge_items`
  was assigned a lazy `ValuesListQuerySet` instead of a `list`, causing
  incorrect behaviour when saving to the `ArrayField(IntegerField)` backing
  this field.
- Root cause: `charge_items.values_list("id", flat=True)` returns a
  `ValuesListQuerySet`, not a list. Django's `ArrayField.get_db_prep_value`
  only handles `list` or `tuple` — anything else is passed through raw to
  psycopg, which either crashes or silently misbehaves, meaning charge
  items are not correctly attached to the invoice.
- The identical operation appears correctly in two other places in the same
  file (lines ~143 and ~248) using `list(charge_items.values_list(...))` —
  this is a copy-paste omission where the `list()` call was dropped.
- Fix: wrap the assignment in `list()`, consistent with the two correct
  call sites already in the same file.
- Added regression tests covering: successful attachment of all billable
  charge items, rejection on non-draft invoice, and permission enforcement.

### Associated Issue

No existing GitHub issue. Found via manual code audit — the missing
`list()` call was identified by comparing the three `values_list` call
sites in the same file, two of which correctly wrap with `list()`.

## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved invoice account attachment so charge items are handled reliably during invoice updates.
  * Prevented invalid account attachment when an invoice is not in draft status.
* **Tests**
  * Added API coverage for attaching an account to an invoice.
  * Verified successful charge item attachment, draft-only behavior, and permission checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->