### PR TITLE
fix: confirm OTP raises ValidationError when no user linked to phone number

### DIFF
--- a/care/emr/tests/test_otp_reset_password_api.py
+++ b/care/emr/tests/test_otp_reset_password_api.py
@@ -169,3 +169,19 @@ class OTPResetPasswordAPITestCase(CareAPITestBase):
             "No User with this username linked to this phone number",
             response.data["errors"][0]["msg"]["error"],
         )
+
+    def test_confirm_otp_with_no_user_linked_to_phone_number(self):
+        """
+        If a valid OTP exists for a phone number but no user account is
+        linked to that number (e.g. the account was deleted after the OTP
+        was generated), confirm should return 400 with a validation error
+        instead of crashing with AttributeError on user.set_password().
+        """
+        phone_number = "+919876543211"
+        MobileOTP.objects.create(phone_number=phone_number, otp=self.otp)
+        response = self._confirm(otp=self.otp, phone_number=phone_number)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data["errors"][0]["msg"]["error"],
+            "No user linked to this phone number",
+        )

--- a/care/users/api/otp_viewset/reset_password.py
+++ b/care/users/api/otp_viewset/reset_password.py
@@ -74,6 +74,8 @@ class OTPResetPasswordView(EMRBaseViewSet):
 
         users = User.objects.filter(phone_number=data.phone_number)
         user_count = users.count()
+        if user_count == 0:
+            raise ValidationError({"error": "No user linked to this phone number"})
         if user_count > 1:
             if data.username:
                 users = users.filter(username=data.username)


### PR DESCRIPTION
## Proposed Changes

- Fixes a bug in the OTP password reset flow where the `confirm` action
  crashes with an unhandled `AttributeError` when no user account is
  linked to the submitted phone number.
- Root cause: `confirm` correctly handles `user_count > 1` (multiple
  users on one phone) but has no guard for `user_count == 0`. When
  `users.first()` returns `None`, the very next call
  `user.set_password(data.password)` raises
  `AttributeError: 'NoneType' object has no attribute 'set_password'`,
  surfacing as an unhandled 500 to the caller.
- This is reachable in practice: a valid OTP can exist for a phone
  number whose user account was deleted or had its phone number removed
  after the OTP was generated. The OTP validation passes (it only checks
  the OTP against the phone number, not against any user), then the code
  tries to reset a password for a user that no longer exists and crashes.
- Fix: add a `user_count == 0` guard before `users.first()`, raising a
  clean `ValidationError` with a descriptive message — consistent with
  how the `user_count > 1` case is already handled in the same block.
- Added a regression test covering the zero-user case. The existing test
  suite already covered `generate` with a non-existent user
  (`test_send_otp_request_by_non_exisiting_user`) but had no
  corresponding test for `confirm` with a phone number that has no linked
  user — which is the exact crash path this fix addresses.

### Associated Issue

No existing GitHub issue. Found via manual code audit — the missing
`user_count == 0` guard was identified by comparing the `> 1` handling
already present in the same block.

### Architecture changes

Remove this section if not used

## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OTP password reset handling when a phone number is not linked to an existing account.
  * The reset request now returns a clear validation error instead of failing unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->