### PR TITLE
test: add coverage for created_by filter and tag config org clearing

### DIFF
--- a/care/emr/tests/test_questionnaire_response_api.py
+++ b/care/emr/tests/test_questionnaire_response_api.py
@@ -479,6 +479,7 @@ class QuestionnaireTestBase(CareAPITestBase):
         )
         self.assertEqual(response.status_code, 200)
         results = response.json()["results"]
+        self.assertEqual(len(results), 1)
         result_ids = [res["id"] for res in results]
         self.assertIn(response_a["id"], result_ids)
         self.assertNotIn(response_b["id"], result_ids)
@@ -489,6 +490,7 @@ class QuestionnaireTestBase(CareAPITestBase):
         )
         self.assertEqual(response.status_code, 200)
         results = response.json()["results"]
+        self.assertEqual(len(results), 1)
         result_ids = [res["id"] for res in results]
         self.assertIn(response_b["id"], result_ids)
         self.assertNotIn(response_a["id"], result_ids)

--- a/care/emr/tests/test_questionnaire_response_api.py
+++ b/care/emr/tests/test_questionnaire_response_api.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 from care.emr.models.questionnaire import QuestionnaireResponse
 from care.security.permissions.encounter import EncounterPermissions
 from care.security.permissions.patient import PatientPermissions
+from care.security.permissions.questionnaire import QuestionnairePermissions
 from care.utils.tests.base import CareAPITestBase
 
 
@@ -424,6 +425,73 @@ class QuestionnaireTestBase(CareAPITestBase):
         self.assertEqual(
             response_data["results"][0]["id"], self.questionnaire_response["id"]
         )
+
+    def test_list_questionnaire_responses_with_created_by_filter(self):
+        """
+        Verify the created_by filter returns only responses created by the
+        specified user, identified by their external_id UUID.
+        """
+        user_a = self.create_user(username="usera")
+        user_b = self.create_user(username="userb")
+
+        permissions = [
+            *self.permissions,
+            QuestionnairePermissions.can_read_questionnaire.name,
+        ]
+        role = self.create_role_with_permissions(permissions=permissions)
+
+        self.attach_role_facility_organization_user(
+            self.facility_organization,
+            user_a,
+            role,
+        )
+        self.attach_role_organization_user(
+            self.organization,
+            user_a,
+            role,
+        )
+
+        self.attach_role_facility_organization_user(
+            self.facility_organization,
+            user_b,
+            role,
+        )
+        self.attach_role_organization_user(
+            self.organization,
+            user_b,
+            role,
+        )
+
+        # Force-authenticate as user_a and submit
+        self.client.force_authenticate(user=user_a)
+        response_a = self._submit(self.responses)
+
+        # Force-authenticate as user_b and submit
+        self.client.force_authenticate(user=user_b)
+        response_b = self._submit(self.responses)
+
+        # Force-authenticate back as self.user (superuser) to call list endpoint
+        self.client.force_authenticate(user=self.user)
+
+        # Filter by user_a
+        response = self.client.get(
+            self.get_url(), {"created_by": str(user_a.external_id)}
+        )
+        self.assertEqual(response.status_code, 200)
+        results = response.json()["results"]
+        result_ids = [res["id"] for res in results]
+        self.assertIn(response_a["id"], result_ids)
+        self.assertNotIn(response_b["id"], result_ids)
+
+        # Filter by user_b
+        response = self.client.get(
+            self.get_url(), {"created_by": str(user_b.external_id)}
+        )
+        self.assertEqual(response.status_code, 200)
+        results = response.json()["results"]
+        result_ids = [res["id"] for res in results]
+        self.assertIn(response_b["id"], result_ids)
+        self.assertNotIn(response_a["id"], result_ids)
 
     def test_list_questionnaire_responses_without_encounter_permission(self):
         """

--- a/care/emr/tests/test_tag_config_api.py
+++ b/care/emr/tests/test_tag_config_api.py
@@ -397,6 +397,55 @@ class TestTagConfigAPI(CareAPITestBase):
         self.assertEqual(get_response.data["status"], TagStatus.archived.value)
         self.assertEqual(get_response.data["description"], "")
 
+    def test_update_tag_config_clears_organization_when_omitted(self):
+        """
+        Verify that updating a tag config without supplying `organization`
+        clears the existing organization to None (the [ENG-580] behavior).
+        Previously, omitting the field would leave it unchanged; now it
+        explicitly nullifies it.
+        """
+        self.client.force_authenticate(user=self.superuser)
+        tag_config = self.create_tag_config(
+            resource=TagResource.encounter,
+            organization=self.organization,
+        )
+        self.assertEqual(tag_config.organization, self.organization)
+
+        response = self.client.put(
+            self.get_detail_url(tag_config.external_id),
+            self.generate_tag_config_data(
+                resource=TagResource.encounter.value,
+            ),
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        tag_config.refresh_from_db()
+        self.assertIsNone(tag_config.organization)
+
+    def test_update_tag_config_clears_facility_organization_when_omitted(self):
+        """
+        Verify that updating a tag config without supplying
+        `facility_organization` clears the existing value to None.
+        """
+        self.client.force_authenticate(user=self.superuser)
+        tag_config = self.create_tag_config(
+            resource=TagResource.encounter,
+            facility=self.facility,
+            facility_organization=self.facility_organization,
+        )
+        self.assertEqual(tag_config.facility_organization, self.facility_organization)
+
+        response = self.client.put(
+            self.get_detail_url(tag_config.external_id),
+            self.generate_tag_config_data(
+                resource=TagResource.encounter.value,
+            ),
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        tag_config.refresh_from_db()
+        self.assertIsNone(tag_config.facility_organization)
+
     def test_update_tag_config_as_with_facility_as_superuser(self):
         """Test updating a tag config with facility as superuser"""
         self.client.force_authenticate(user=self.superuser)

--- a/care/emr/tests/test_tag_config_api.py
+++ b/care/emr/tests/test_tag_config_api.py
@@ -439,6 +439,7 @@ class TestTagConfigAPI(CareAPITestBase):
             self.get_detail_url(tag_config.external_id),
             self.generate_tag_config_data(
                 resource=TagResource.encounter.value,
+                facility=self.facility.external_id,
             ),
             format="json",
         )


### PR DESCRIPTION
## Proposed Changes

- Adds test coverage for two recently merged features that shipped
  without tests.

**`created_by` filter on questionnaire responses ([ENG-558], #3695):**
A `created_by` UUID filter was added to the questionnaire response list
endpoint but no tests were written for it. The new tests verify that
filtering by a user's `external_id` returns only that user's responses
and excludes responses created by other users.

**Clearing `organization`/`facility_organization` on tag config update
([ENG-580], #3690):**
The tag config update spec (`TagConfigUpdateSpec.perform_extra_deserialization`)
was updated to explicitly set `organization` and `facility_organization`
to `None` when those fields are omitted from a PUT request — previously
they would be left unchanged. The new tests verify that omitting either
field in an update actually clears the existing value to `None` in the
database.

## Merge Checklist

- [x] Tests added
- [x] Linting Complete

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


[ENG-558]: https://openhealthcarenetwork.atlassian.net/browse/ENG-558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-580]: https://openhealthcarenetwork.atlassian.net/browse/ENG-580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Questionnaire response listings now support filtering by the user who created each response.
  * Tag configuration updates now correctly clear organization and facility organization settings when those fields are omitted.
  * Improved consistency when updating tag configurations and reviewing questionnaire responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->