### PR TITLE
Improve phone number validator type validation

### DIFF
--- a/care/utils/models/validators.py
+++ b/care/utils/models/validators.py
@@ -1,5 +1,5 @@
 import re
-from collections.abc import Iterable
+from collections.abc import Collection, Iterable
 from fractions import Fraction
 from pathlib import Path
 
@@ -103,19 +103,23 @@ class PhoneNumberValidator(RegexValidator):
         "support": support_number_regex,
     }
 
-    def __init__(self, types: Iterable[str], *args, **kwargs):
-        if not isinstance(types, Iterable) or isinstance(types, str):
-            msg = "The `types` argument must be a non-empty iterable."
+    def __init__(self, types: Collection[str], *args, **kwargs):
+        if not isinstance(types, Collection) or isinstance(types, str):
+            msg = "The `types` argument must be a non-empty collection."
             raise ValueError(msg)
 
         types = tuple(types)
         if not types:
-            msg = "The `types` argument must be a non-empty iterable."
+            msg = "The `types` argument must be a non-empty collection."
             raise ValueError(msg)
 
-        unsupported_types = [type_ for type_ in types if type_ not in self.regex_map]
+        unsupported_types = [
+            type_
+            for type_ in types
+            if not isinstance(type_, str) or type_ not in self.regex_map
+        ]
         if unsupported_types:
-            msg = f"Unsupported phone number type(s): {', '.join(unsupported_types)}."
+            msg = f"Unsupported phone number type(s): {', '.join(str(type_) for type_ in unsupported_types)}."
             raise ValueError(msg)
 
         self.types = types

--- a/care/utils/models/validators.py
+++ b/care/utils/models/validators.py
@@ -104,8 +104,18 @@ class PhoneNumberValidator(RegexValidator):
     }
 
     def __init__(self, types: Iterable[str], *args, **kwargs):
-        if not isinstance(types, Iterable) or isinstance(types, str) or len(types) == 0:
+        if not isinstance(types, Iterable) or isinstance(types, str):
             msg = "The `types` argument must be a non-empty iterable."
+            raise ValueError(msg)
+
+        types = tuple(types)
+        if not types:
+            msg = "The `types` argument must be a non-empty iterable."
+            raise ValueError(msg)
+
+        unsupported_types = [type_ for type_ in types if type_ not in self.regex_map]
+        if unsupported_types:
+            msg = f"Unsupported phone number type(s): {', '.join(unsupported_types)}."
             raise ValueError(msg)
 
         self.types = types

--- a/care/utils/tests/test_phone_number_validator.py
+++ b/care/utils/tests/test_phone_number_validator.py
@@ -130,3 +130,27 @@ class PhoneNumberValidatorTests(TestCase):
         for number in self.invalid_support_numbers:
             with self.assertRaises(ValidationError, msg=f"Failed for {number}"):
                 self.support_validator(number)
+
+    def test_types_must_be_non_empty_iterable(self):
+        invalid_types = ["mobile", ()]
+
+        for types in invalid_types:
+            with self.assertRaisesMessage(
+                ValueError,
+                "The `types` argument must be a non-empty iterable.",
+            ):
+                PhoneNumberValidator(types=types)
+
+    def test_unsupported_types_raise_value_error(self):
+        with self.assertRaisesMessage(
+            ValueError,
+            "Unsupported phone number type(s): pager.",
+        ):
+            PhoneNumberValidator(types=("mobile", "pager"))
+
+    def test_types_accepts_generator(self):
+        types = (type_ for type_ in ("mobile", "landline"))
+        validator = PhoneNumberValidator(types=types)
+
+        self.assertIsNone(validator("+919876543210"))
+        self.assertIsNone(validator("+914902626488"))

--- a/care/utils/tests/test_phone_number_validator.py
+++ b/care/utils/tests/test_phone_number_validator.py
@@ -131,13 +131,13 @@ class PhoneNumberValidatorTests(TestCase):
             with self.assertRaises(ValidationError, msg=f"Failed for {number}"):
                 self.support_validator(number)
 
-    def test_types_must_be_non_empty_iterable(self):
-        invalid_types = ["mobile", ()]
+    def test_types_must_be_non_empty_collection(self):
+        invalid_types = ["mobile", (), (type_ for type_ in ("mobile",))]
 
         for types in invalid_types:
             with self.assertRaisesMessage(
                 ValueError,
-                "The `types` argument must be a non-empty iterable.",
+                "The `types` argument must be a non-empty collection.",
             ):
                 PhoneNumberValidator(types=types)
 
@@ -148,9 +148,22 @@ class PhoneNumberValidatorTests(TestCase):
         ):
             PhoneNumberValidator(types=("mobile", "pager"))
 
-    def test_types_accepts_generator(self):
-        types = (type_ for type_ in ("mobile", "landline"))
-        validator = PhoneNumberValidator(types=types)
+    def test_unhashable_types_raise_value_error(self):
+        with self.assertRaisesMessage(
+            ValueError,
+            "Unsupported phone number type(s): [].",
+        ):
+            PhoneNumberValidator(types=([],))
+
+    def test_non_string_types_raise_value_error(self):
+        with self.assertRaisesMessage(
+            ValueError,
+            "Unsupported phone number type(s): 1.",
+        ):
+            PhoneNumberValidator(types=(1,))
+
+    def test_types_accepts_reiterable_collection(self):
+        validator = PhoneNumberValidator(types=["mobile", "landline"])
 
         self.assertIsNone(validator("+919876543210"))
         self.assertIsNone(validator("+914902626488"))


### PR DESCRIPTION
## Proposed Changes

- Added explicit validation for unsupported `PhoneNumberValidator` types.
- Changed unsupported validator type handling from raw `KeyError`/`TypeError` failures to clear `ValueError` messages.
- Require `types` to be a non-empty collection so one-shot iterators/generators are rejected for safer Django validator deconstruction.
- Preserved existing behavior for supported phone number types.
- Added tests for invalid `types`, unsupported types, non-string values, unhashable values, and iterator input.

### Associated Issue

- No linked issue. This is a small validation hardening change for shared phone number validator behavior.


## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [x] Verified no migration changes are generated

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved phone-number validation configuration handling.
  * Empty, unsupported, unhashable, or non-string phone-number types now produce clear validation errors.
  * Phone-number type configurations must now use a non-string collection, with supported mobile and landline types validated correctly.

* **Tests**
  * Added coverage for invalid, empty, unsupported, unhashable, and non-string configuration inputs.
  * Added validation coverage for supported mobile and landline types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->