### PR TITLE
fix: remove duplicate date field in TokenQueueReadSpec

### DIFF
--- a/care/emr/resources/scheduling/token_queue/spec.py
+++ b/care/emr/resources/scheduling/token_queue/spec.py
@@ -33,7 +33,6 @@ class TokenQueueReadSpec(TokenQueueBaseSpec):
     date: datetime.date
     is_primary: bool
     system_generated: bool
-    date: datetime.date
 
     @classmethod
     def perform_extra_serialization(cls, mapping, obj):


### PR DESCRIPTION
## Proposed Changes

- Fixes a linting error in `care/emr/resources/scheduling/token_queue/spec.py` where `date` was defined twice within the `TokenQueueReadSpec` class.
- Removing this duplicate field definition resolves the Ruff linter check warning and ensures the build/lint checks pass successfully.

### Error Caused

This issue was causing `ruff check` to fail locally and in CI with the following error:

```
  --> care/emr/resources/scheduling/token_queue/spec.py:
   |
34 |     is_primary: bool
35 |     system_generated: bool
36 |     date: datetime.date
   |     ^^^^^^^^^^^^^^^^^^^
```

## Merge Checklist

- [x] Tests added/fixed
- [x] Linting Complete
