### PR TITLE
[ENG-870] Remove `criticality` field from Condition Read Spec

### DIFF
--- a/care/emr/resources/condition/spec.py
+++ b/care/emr/resources/condition/spec.py
@@ -112,7 +112,6 @@ class ConditionReadSpec(BaseConditionSpec):
     clinical_status: str
     verification_status: str
     category: str
-    criticality: str
     severity: str
     code: Coding
     encounter: UUID4


### PR DESCRIPTION
## Proposed Changes

- Remove `criticality` field from Condition Read Spec

### Associated Issue

- ENG-870


## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [x] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the `criticality` field from condition data returned by the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->